### PR TITLE
Add (temporary) resume to video playback

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
@@ -1,17 +1,44 @@
 package com.github.damontecres.stashapp
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 
+
 /** Loads [PlaybackVideoFragment]. */
 class PlaybackActivity : FragmentActivity() {
+
+    private val fragment: PlaybackVideoFragment = PlaybackVideoFragment()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
-                .replace(android.R.id.content, PlaybackVideoFragment())
+                .replace(android.R.id.content, fragment)
                 .commit()
         }
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onBackPressed() {
+        // TODO: deprecated, so use https://stackoverflow.com/a/72634975/608317 eventually
+        returnPosition()
+        super.onBackPressed()
+    }
+
+    override fun onStop() {
+        returnPosition() // Not sure if it's actually needed here, but doesn't hurt
+        super.onStop()
+    }
+
+    /**
+     * Return the video's current position to the previous Activity
+     */
+    private fun returnPosition() {
+        val intent = Intent()
+        intent.putExtra("position", fragment.currentVideoPosition)
+        setResult(Activity.RESULT_OK, intent)
+        finish()
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -7,7 +7,6 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.util.Log
-import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -35,7 +34,6 @@ import com.github.damontecres.stashapp.data.fromSlimSceneDataTag
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.TagPresenter
 import kotlinx.coroutines.launch
-import java.lang.IllegalArgumentException
 
 /**
  * A wrapper fragment for leanback details screens.
@@ -85,7 +83,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     position = data!!.getLongExtra(POSITION_ARG, -1)
                     if (position > 0) {
                         // If some of the video played, reset the available actions
-                        // This only causes the focused action to be resume
+                        // This also causes the focused action to default to resume which is an added bonus
                         actionAdapter.clear()
                         actionAdapter.add(Action(ACTION_RESUME_SCENE, "Resume"))
                         actionAdapter.add(Action(ACTION_PLAY_SCENE, "Restart"))
@@ -158,7 +156,8 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     private fun setupDetailsOverviewRow() {
         Log.d(TAG, "doInBackground: " + mSelectedMovie?.toString())
         val row = DetailsOverviewRow(mSelectedMovie!!)
-        row.imageDrawable = ContextCompat.getDrawable(requireActivity(), R.drawable.default_background)
+        row.imageDrawable =
+            ContextCompat.getDrawable(requireActivity(), R.drawable.default_background)
         val width = convertDpToPixel(requireActivity(), DETAIL_THUMB_WIDTH)
         val height = convertDpToPixel(requireActivity(), DETAIL_THUMB_HEIGHT)
 

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -1,5 +1,6 @@
 package com.github.damontecres.stashapp
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -7,6 +8,8 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.leanback.app.DetailsSupportFragment
 import androidx.leanback.app.DetailsSupportFragmentBackgroundController
@@ -32,6 +35,7 @@ import com.github.damontecres.stashapp.data.fromSlimSceneDataTag
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.TagPresenter
 import kotlinx.coroutines.launch
+import java.lang.IllegalArgumentException
 
 /**
  * A wrapper fragment for leanback details screens.
@@ -47,6 +51,10 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     private lateinit var mDetailsBackground: DetailsSupportFragmentBackgroundController
     private lateinit var mPresenterSelector: ClassPresenterSelector
     private lateinit var mAdapter: ArrayObjectAdapter
+    private lateinit var resultLauncher: ActivityResultLauncher<Intent>
+
+    private val actionAdapter = ArrayObjectAdapter()
+    private var position = -1L // The position in the video
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d(TAG, "onCreate DetailsFragment")
@@ -69,6 +77,22 @@ class VideoDetailsFragment : DetailsSupportFragment() {
             val intent = Intent(activity!!, MainActivity::class.java)
             startActivity(intent)
         }
+
+        resultLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == Activity.RESULT_OK) {
+                    val data: Intent? = result.data
+                    position = data!!.getLongExtra(POSITION_ARG, -1)
+                    if (position > 0) {
+                        // If some of the video played, reset the available actions
+                        // This only causes the focused action to be resume
+                        actionAdapter.clear()
+                        actionAdapter.add(Action(ACTION_RESUME_SCENE, "Resume"))
+                        actionAdapter.add(Action(ACTION_PLAY_SCENE, "Restart"))
+                    }
+                }
+
+            }
     }
 
     override fun onStart() {
@@ -159,8 +183,6 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 })
         }
 
-        val actionAdapter = ArrayObjectAdapter()
-
         actionAdapter.add(
             Action(
                 ACTION_PLAY_SCENE,
@@ -187,12 +209,17 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         detailsPresenter.isParticipatingEntranceTransition = true
 
         detailsPresenter.onActionClickedListener = OnActionClickedListener { action ->
-            if (action.id == ACTION_PLAY_SCENE && mSelectedMovie != null) {
-                val intent = Intent(activity!!, PlaybackActivity::class.java)
-                intent.putExtra(DetailsActivity.MOVIE, mSelectedMovie)
-                startActivity(intent)
-            } else {
-                Toast.makeText(activity!!, action.toString(), Toast.LENGTH_SHORT).show()
+            if (mSelectedMovie != null) {
+                if (action.id in longArrayOf(ACTION_PLAY_SCENE, ACTION_RESUME_SCENE)) {
+                    val intent = Intent(requireActivity(), PlaybackActivity::class.java)
+                    intent.putExtra(DetailsActivity.MOVIE, mSelectedMovie)
+                    if (action.id == ACTION_RESUME_SCENE) {
+                        intent.putExtra(POSITION_ARG, position)
+                    }
+                    resultLauncher.launch(intent)
+                } else {
+                    throw IllegalArgumentException("Action $action (id=${action.id} is not supported!")
+                }
             }
         }
         mPresenterSelector.addClassPresenter(DetailsOverviewRow::class.java, detailsPresenter)
@@ -214,12 +241,13 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         private val TAG = "VideoDetailsFragment"
 
         private val ACTION_PLAY_SCENE = 1L
-        private val ACTION_RENT = 2L
-        private val ACTION_BUY = 3L
+        private val ACTION_RESUME_SCENE = 2L
 
         private val DETAIL_THUMB_WIDTH = 274
         private val DETAIL_THUMB_HEIGHT = 274
 
         private val NUM_COLS = 10
+
+        const val POSITION_ARG = "position"
     }
 }


### PR DESCRIPTION
This is a quality-of-life improvement. When exiting a playing video, pass the current position back to the `VideoDetailsFragment`, so the user can optionally resume the playback.

This helps when seeking in a video if you accidentally press `back` too many times (trying to get rid of the controls), you can resume the video playback. This even seems to work despite #6.

The position is *not* persisted and is lost when the `VideoDetailsFragment` is removed (e.g. pressing back on the details page).

Some apps remember playback positions persistently, which might be a good future enhancement?