### PR TITLE
If scene has no performers, don't try to query for any

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -106,19 +106,21 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                             tagsAdapter.addAll(0, scene.tags.map { fromSlimSceneDataTag(it) })
                         }
 
-                        val performerIds = scene?.performers?.map {
+                        val performerIds = scene.performers.map {
                             it.id.toInt()
                         }
-                        val performers = apolloClient.query(
-                            FindPerformersQuery(
-                                performer_ids = Optional.present(performerIds)
-                            )
-                        ).execute()
-                        val perfs = performers.data?.findPerformers?.performers?.map {
-                            it.performerData
-                        }
-                        if (perfs != null) {
-                            performersAdapter.addAll(0, perfs)
+                        if (performerIds.isNotEmpty()) {
+                            val performers = apolloClient.query(
+                                FindPerformersQuery(
+                                    performer_ids = Optional.present(performerIds)
+                                )
+                            ).execute()
+                            val perfs = performers.data?.findPerformers?.performers?.map {
+                                it.performerData
+                            }
+                            if (perfs != null) {
+                                performersAdapter.addAll(0, perfs)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Since querying Stash for a empty list of performer IDs will actually return 25 "random" performers, the video details page should only query for performers if there are actually performers to query for.

Without this change, scenes without any performers set will list the "random" performers in the `VideoDetailsFragment` page.