### PR TITLE
Add much better error handling

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -6,9 +6,6 @@ import android.util.Log
 import android.widget.Toast
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.api.ApolloResponse
-import com.apollographql.apollo3.api.CompiledType
-import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.exception.ApolloException
@@ -17,12 +14,7 @@ import com.apollographql.apollo3.network.http.HttpInterceptor
 import com.apollographql.apollo3.network.http.HttpInterceptorChain
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.LazyHeaders
-import com.github.damontecres.stashapp.api.FindScenesQuery
 import com.github.damontecres.stashapp.api.ServerInfoQuery
-import com.github.damontecres.stashapp.api.fragment.SlimSceneData
-import com.github.damontecres.stashapp.api.type.CriterionModifier
-import com.github.damontecres.stashapp.api.type.HierarchicalMultiCriterionInput
-import com.github.damontecres.stashapp.api.type.SceneFilterType
 import com.github.damontecres.stashapp.data.Scene
 
 object Constants {

--- a/app/src/main/java/com/github/damontecres/stashapp/ErrorFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ErrorFragment.kt
@@ -18,7 +18,10 @@ class ErrorFragment : ErrorSupportFragment() {
 
     internal fun setErrorContent() {
         imageDrawable =
-            ContextCompat.getDrawable(requireActivity(), androidx.leanback.R.drawable.lb_ic_sad_cloud)
+            ContextCompat.getDrawable(
+                requireActivity(),
+                androidx.leanback.R.drawable.lb_ic_sad_cloud
+            )
         message = resources.getString(R.string.error_fragment_message)
         setDefaultBackground(TRANSLUCENT)
 

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -230,7 +230,6 @@ class MainFragment : BrowseSupportFragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             if (testStashConnection(requireContext(), false)) {
                 addRowsIfNeeded()
-                val apolloClient = createApolloClient(requireContext())
                 try {
                     val queryEngine = QueryEngine(requireContext(), showToasts = true)
 

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -39,6 +39,7 @@ import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
 import com.github.damontecres.stashapp.presenters.StudioPresenter
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import java.util.Timer
 import java.util.TimerTask
@@ -233,7 +234,7 @@ class MainFragment : BrowseSupportFragment() {
                 try {
                     val queryEngine = QueryEngine(requireContext(), showToasts = true)
 
-                    viewLifecycleOwner.lifecycleScope.launch {
+                    viewLifecycleOwner.lifecycleScope.async {
                         sceneAdapter.addAll(
                             0, queryEngine.findScenes(
                                 FindFilterType(
@@ -245,7 +246,7 @@ class MainFragment : BrowseSupportFragment() {
                         )
                     }
 
-                    viewLifecycleOwner.lifecycleScope.launch {
+                    viewLifecycleOwner.lifecycleScope.async {
                         performerAdapter.addAll(
                             0, queryEngine.findPerformers(
                                 FindFilterType(
@@ -257,7 +258,7 @@ class MainFragment : BrowseSupportFragment() {
                         )
                     }
 
-                    viewLifecycleOwner.lifecycleScope.launch {
+                    viewLifecycleOwner.lifecycleScope.async {
                         studioAdapter.addAll(
                             0, queryEngine.findStudios(
                                 FindFilterType(

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -31,9 +31,6 @@ import com.apollographql.apollo3.api.Optional
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
-import com.github.damontecres.stashapp.api.FindPerformersQuery
-import com.github.damontecres.stashapp.api.FindScenesQuery
-import com.github.damontecres.stashapp.api.FindStudiosQuery
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.presenters.PerformerPresenter

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
@@ -9,14 +9,10 @@ import androidx.fragment.app.Fragment
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.ListRowView
 import androidx.lifecycle.lifecycleScope
-import androidx.preference.PreferenceManager
-import com.apollographql.apollo3.api.Optional
 import com.bumptech.glide.Glide
-import com.github.damontecres.stashapp.api.FindPerformersQuery
 import com.github.damontecres.stashapp.data.Performer
 import com.github.damontecres.stashapp.presenters.ScenePresenter
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
 
 class PerformerFragment : Fragment(R.layout.performer_view) {
 

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
@@ -37,32 +37,20 @@ class PerformerFragment : Fragment(R.layout.performer_view) {
             mPerformerName.text = performer.name
             mPerformerDisambiguation.text = performer.disambiguation
 
-            val apolloClient = createApolloClient(requireContext())
-            if (apolloClient != null) {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    val performers = apolloClient.query(
-                        FindPerformersQuery(
-                            performer_ids = Optional.present(
-                                listOf(
-                                    performer.id.toInt()
-                                )
-                            )
-                        )
-                    ).execute().data?.findPerformers?.performers;
-                    if (performers != null && !performers.isEmpty()) {
-                        val performer = performers.first().performerData
-                        val apiKey = PreferenceManager.getDefaultSharedPreferences(requireContext())
-                            .getString("stashApiKey", "")
-                        if (performer.image_path != null) {
-                            val url = createGlideUrl(performer.image_path, apiKey)
-                            Glide.with(requireActivity())
-                                .load(url)
-                                .centerCrop()
-                                .error(R.drawable.default_background)
-                                .into(mPerformerImage)
-                        }
+            val queryEngine = QueryEngine(requireContext(), true)
+            viewLifecycleOwner.lifecycleScope.launch {
+                val performers =
+                    queryEngine.findPerformers(performerIds = listOf(performer.id.toInt()))
+                if (performers.isNotEmpty()) {
+                    val performerData = performers.first()
+                    if (performerData.image_path != null) {
+                        val url = createGlideUrl(performerData.image_path, requireContext())
+                        Glide.with(requireActivity())
+                            .load(url)
+                            .centerCrop()
+                            .error(R.drawable.default_background)
+                            .into(mPerformerImage)
                     }
-
                 }
             }
         } else {

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
@@ -15,6 +15,7 @@ import com.bumptech.glide.Glide
 import com.github.damontecres.stashapp.api.FindPerformersQuery
 import com.github.damontecres.stashapp.data.Performer
 import com.github.damontecres.stashapp.presenters.ScenePresenter
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 
 class PerformerFragment : Fragment(R.layout.performer_view) {
@@ -38,7 +39,7 @@ class PerformerFragment : Fragment(R.layout.performer_view) {
             mPerformerDisambiguation.text = performer.disambiguation
 
             val queryEngine = QueryEngine(requireContext(), true)
-            viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.async {
                 val performers =
                     queryEngine.findPerformers(performerIds = listOf(performer.id.toInt()))
                 if (performers.isNotEmpty()) {

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerListActivity.kt
@@ -3,7 +3,6 @@ package com.github.damontecres.stashapp
 import android.os.Bundle
 import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
-import com.github.damontecres.stashapp.data.Performer
 import com.github.damontecres.stashapp.suppliers.PerformerDataSupplier
 
 class PerformerListActivity : FragmentActivity() {

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.stashapp
 
 import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.ApolloClient
@@ -46,6 +47,7 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
                         Toast.LENGTH_LONG
                     ).show()
                 }
+                Log.e(TAG, "Errors in $queryName:\n$errorMsgs")
                 throw QueryException("($queryName), ${response.errors!!.size} errors in graphql response")
             }
         } catch (ex: ApolloNetworkException) {
@@ -56,6 +58,7 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
                     Toast.LENGTH_LONG
                 ).show()
             }
+            Log.e(TAG, "Network error in $queryName", ex)
             throw QueryException("Network error ($queryName)", ex)
         } catch (ex: ApolloHttpException) {
             if (showToasts) {
@@ -65,6 +68,7 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
                     Toast.LENGTH_LONG
                 ).show()
             }
+            Log.e(TAG, "HTTP ${ex.statusCode} error in $queryName", ex)
             throw QueryException("HTTP ${ex.statusCode} ($queryName)", ex)
         } catch (ex: ApolloException) {
             if (showToasts) {
@@ -74,6 +78,7 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
                     Toast.LENGTH_LONG
                 ).show()
             }
+            Log.e(TAG, "ApolloException in $queryName", ex)
             throw QueryException("Apollo exception ($queryName)", ex)
         }
     }
@@ -148,6 +153,10 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
         val tags =
             executeQuery(query).data?.findTags?.tags?.map { fromFindTag(it) }
         return tags.orEmpty()
+    }
+
+    companion object {
+        const val TAG = "QueryEngine"
     }
 
     open class QueryException(msg: String? = null, cause: ApolloException? = null) :

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -1,0 +1,136 @@
+package com.github.damontecres.stashapp
+
+import android.content.Context
+import android.widget.Toast
+import com.apollographql.apollo3.ApolloCall
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.Optional
+import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.exception.ApolloHttpException
+import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.github.damontecres.stashapp.api.FindPerformersQuery
+import com.github.damontecres.stashapp.api.FindScenesQuery
+import com.github.damontecres.stashapp.api.FindStudiosQuery
+import com.github.damontecres.stashapp.api.fragment.PerformerData
+import com.github.damontecres.stashapp.api.fragment.SlimSceneData
+import com.github.damontecres.stashapp.api.fragment.StudioData
+import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.api.type.PerformerFilterType
+import com.github.damontecres.stashapp.api.type.SceneFilterType
+import com.github.damontecres.stashapp.api.type.SortDirectionEnum
+import com.github.damontecres.stashapp.api.type.StudioFilterType
+
+class QueryEngine(private val context: Context, private val showToasts: Boolean = false) {
+
+    private val client = createApolloClient(context) ?: throw StashNotConfiguredException()
+
+    private suspend fun <D : Operation.Data> executeQuery(query: ApolloCall<D>): ApolloResponse<D> {
+        val queryName = query.operation.name()
+        try {
+            val response = query.execute()
+            if (response.errors.isNullOrEmpty()) {
+                return response
+            } else {
+                val errorMsgs = response.errors!!.map { it.message }.joinToString("\n")
+                if (showToasts) {
+                    Toast.makeText(
+                        context,
+                        "${response.errors!!.size} errors in response ($queryName)\n$errorMsgs",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+                throw QueryException("($queryName), ${response.errors!!.size} errors in graphql response")
+            }
+        } catch (ex: ApolloNetworkException) {
+            if (showToasts) {
+                Toast.makeText(
+                    context,
+                    "Network error ($queryName). Message: ${ex.message}, ${ex.cause?.message}",
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            throw QueryException("Network error ($queryName)", ex)
+        } catch (ex: ApolloHttpException) {
+            if (showToasts) {
+                Toast.makeText(
+                    context,
+                    "HTTP error ($queryName). Status=${ex.statusCode}, Msg=${ex.message}",
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            throw QueryException("HTTP ${ex.statusCode} ($queryName)", ex)
+        } catch (ex: ApolloException) {
+            if (showToasts) {
+                Toast.makeText(
+                    context,
+                    "Server query error ($queryName). Msg=${ex.message}, ${ex.cause?.message}",
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            throw QueryException("Apollo exception ($queryName)", ex)
+        }
+    }
+
+    suspend fun findScenes(
+        findFilter: FindFilterType? = null,
+        sceneFilter: SceneFilterType? = null,
+        sceneIds: List<Int>? = null
+    ): List<SlimSceneData> {
+        val query = client.query(
+            FindScenesQuery(
+                filter = Optional.presentIfNotNull(findFilter),
+                scene_filter = Optional.presentIfNotNull(sceneFilter),
+                scene_ids = Optional.presentIfNotNull(sceneIds)
+            )
+        )
+        val scenes = executeQuery(query).data?.findScenes?.scenes?.map {
+            it.slimSceneData
+        }
+        return scenes.orEmpty()
+    }
+
+    suspend fun findPerformers(
+        findFilter: FindFilterType? = null,
+        performerFilter: PerformerFilterType? = null,
+        performerIds: List<Int>? = null
+    ): List<PerformerData> {
+        val query = client.query(
+            FindPerformersQuery(
+                filter = Optional.presentIfNotNull(findFilter),
+                performer_filter = Optional.presentIfNotNull(performerFilter),
+                performer_ids = Optional.presentIfNotNull(performerIds)
+            )
+        )
+        val performers = executeQuery(query).data?.findPerformers?.performers?.map {
+            it.performerData
+        }
+        return performers.orEmpty()
+    }
+
+    // TODO Add studioIds?
+    suspend fun findStudios(
+        findFilter: FindFilterType? = null,
+        studioFilter: StudioFilterType? = null
+    ): List<StudioData> {
+        val query = client.query(
+            FindStudiosQuery(
+                filter = Optional.present(findFilter),
+                studio_filter = Optional.presentIfNotNull(studioFilter),
+            )
+        )
+        val studios = executeQuery(query).data?.findStudios?.studios?.map {
+            it.studioData
+        }
+        return studios.orEmpty()
+    }
+
+
+    open class QueryException(msg: String? = null, cause: ApolloException? = null) :
+        RuntimeException(msg, cause) {
+    }
+
+    class StashNotConfiguredException : QueryException() {
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.Log
 import android.widget.Toast
 import com.apollographql.apollo3.ApolloCall
-import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Optional
@@ -22,7 +21,6 @@ import com.github.damontecres.stashapp.api.fragment.StudioData
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.PerformerFilterType
 import com.github.damontecres.stashapp.api.type.SceneFilterType
-import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.data.Tag

--- a/app/src/main/java/com/github/damontecres/stashapp/StashSearchFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashSearchFragment.kt
@@ -22,6 +22,7 @@ import com.github.damontecres.stashapp.presenters.ScenePresenter
 import com.github.damontecres.stashapp.presenters.StudioPresenter
 import com.github.damontecres.stashapp.presenters.TagPresenter
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -84,16 +85,16 @@ class StashSearchFragment : SearchSupportFragment(), SearchSupportFragment.Searc
                 per_page = Optional.present(perPage)
             )
             val queryEngine = QueryEngine(requireContext(), true)
-            viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.async {
                 sceneAdapter.addAll(0, queryEngine.findScenes(filter))
             }
-            viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.async {
                 studioAdapter.addAll(0, queryEngine.findStudios(filter))
             }
-            viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.async {
                 performerAdapter.addAll(0, queryEngine.findPerformers(filter))
             }
-            viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.async {
                 tagAdapter.addAll(0, queryEngine.findTags(filter))
             }
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/StashSearchFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashSearchFragment.kt
@@ -79,41 +79,22 @@ class StashSearchFragment : SearchSupportFragment(), SearchSupportFragment.Searc
         if (!TextUtils.isEmpty(query)) {
             val perPage = PreferenceManager.getDefaultSharedPreferences(requireContext())
                 .getInt("maxSearchResults", 25)
-            val filter = Optional.present(
-                FindFilterType(
-                    q = Optional.present(query), per_page = Optional.present(perPage)
-                )
+            val filter = FindFilterType(
+                q = Optional.present(query),
+                per_page = Optional.present(perPage)
             )
-            val apolloClient = createApolloClient(requireContext())
-            if (apolloClient != null) {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    val results = apolloClient.query(FindScenesQuery(filter = filter)).execute()
-                    val mapped =
-                        results.data?.findScenes?.scenes?.map { it.slimSceneData }.orEmpty()
-                    sceneAdapter.addAll(0, mapped)
-
-                }
-                viewLifecycleOwner.lifecycleScope.launch {
-                    val results =
-                        apolloClient.query(FindStudiosQuery(filter = filter)).execute()
-                    val mapped =
-                        results.data?.findStudios?.studios?.map { it.studioData }.orEmpty()
-                    studioAdapter.addAll(0, mapped)
-                }
-                viewLifecycleOwner.lifecycleScope.launch {
-                    val results =
-                        apolloClient.query(FindPerformersQuery(filter = filter)).execute()
-                    val mapped =
-                        results.data?.findPerformers?.performers?.map { it.performerData }
-                            .orEmpty()
-                    performerAdapter.addAll(0, mapped)
-                }
-                viewLifecycleOwner.lifecycleScope.launch {
-                    val results = apolloClient.query(FindTagsQuery(filter = filter)).execute()
-                    val mapped =
-                        results.data?.findTags?.tags?.map { fromFindTag(it) }.orEmpty()
-                    tagAdapter.addAll(0, mapped)
-                }
+            val queryEngine = QueryEngine(requireContext(), true)
+            viewLifecycleOwner.lifecycleScope.launch {
+                sceneAdapter.addAll(0, queryEngine.findScenes(filter))
+            }
+            viewLifecycleOwner.lifecycleScope.launch {
+                studioAdapter.addAll(0, queryEngine.findStudios(filter))
+            }
+            viewLifecycleOwner.lifecycleScope.launch {
+                performerAdapter.addAll(0, queryEngine.findPerformers(filter))
+            }
+            viewLifecycleOwner.lifecycleScope.launch {
+                tagAdapter.addAll(0, queryEngine.findTags(filter))
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/StashSearchFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashSearchFragment.kt
@@ -11,12 +11,7 @@ import androidx.leanback.widget.ObjectAdapter
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo3.api.Optional
-import com.github.damontecres.stashapp.api.FindPerformersQuery
-import com.github.damontecres.stashapp.api.FindScenesQuery
-import com.github.damontecres.stashapp.api.FindStudiosQuery
-import com.github.damontecres.stashapp.api.FindTagsQuery
 import com.github.damontecres.stashapp.api.type.FindFilterType
-import com.github.damontecres.stashapp.data.fromFindTag
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
 import com.github.damontecres.stashapp.presenters.StudioPresenter

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -24,11 +24,9 @@ import androidx.leanback.widget.ListRowPresenter
 import androidx.leanback.widget.OnActionClickedListener
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
-import com.apollographql.apollo3.api.Optional
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
-import com.github.damontecres.stashapp.api.FindPerformersQuery
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.data.fromSlimSceneDataTag
 import com.github.damontecres.stashapp.presenters.PerformerPresenter

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPagingSource.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPagingSource.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingState
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.exception.ApolloException
+import com.github.damontecres.stashapp.QueryEngine
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.createApolloClient
@@ -21,9 +22,12 @@ import com.github.damontecres.stashapp.data.CountAndList
 class StashPagingSource<T : Query.Data, D : Any>(
     private val context: Context,
     private val pageSize: Int,
-    private val dataSupplier: DataSupplier<T, D>
+    private val dataSupplier: DataSupplier<T, D>,
+    showToasts: Boolean = false
 ) :
     PagingSource<Int, D>() {
+
+    private val queryEngine = QueryEngine(context, showToasts)
 
     interface DataSupplier<T : Query.Data, D : Any> {
         /**
@@ -55,17 +59,14 @@ class StashPagingSource<T : Query.Data, D : Any>(
     }
 
     private suspend fun fetchPage(page: Int): CountAndList<D> {
-        val apolloClient = createApolloClient(context)
-        if (apolloClient != null) {
-            val filter = dataSupplier.getDefaultFilter().copy(
-                per_page = Optional.present(pageSize),
-                page = Optional.present(page),
-            )
-            val query = dataSupplier.createQuery(filter)
-            val results = apolloClient.query(query).execute()
-            return dataSupplier.parseQuery(results.data)
-        }
-        return CountAndList(-1, listOf())
+
+        val filter = dataSupplier.getDefaultFilter().copy(
+            per_page = Optional.present(pageSize),
+            page = Optional.present(page),
+        )
+        val query = dataSupplier.createQuery(filter)
+        val results = queryEngine.executeQuery(query)
+        return dataSupplier.parseQuery(results.data)
     }
 
     override suspend fun load(
@@ -86,7 +87,7 @@ class StashPagingSource<T : Query.Data, D : Any>(
                 prevKey = if (pageNum > 1) pageNum - 1 else null, // Only a previous page if current page is 2+
                 nextKey = nextPageNum
             )
-        } catch (e: ApolloException) {
+        } catch (e: QueryEngine.QueryException) {
             return LoadResult.Error(e)
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPagingSource.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPagingSource.kt
@@ -5,11 +5,9 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Query
-import com.apollographql.apollo3.exception.ApolloException
 import com.github.damontecres.stashapp.QueryEngine
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
-import com.github.damontecres.stashapp.createApolloClient
 import com.github.damontecres.stashapp.data.CountAndList
 
 /**


### PR DESCRIPTION
Queries (except for the connection test) are migrated to `QueryEngine` which incorporates extra error handling for network, HTTP, and syntax errors.

Additionally, activities that performer multiple queries use `async` to prevent propagating exceptions. This means on the main page, an error during the performers query won't crash the app nor prevent the scenes/studio queries from completing.

Errors are logged as toasts including the name for easier debugging.

This PR might help figure out what's happening in #12