### PR TITLE
Use rows & filters from server

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ apollo {
     service("app") {
         packageName.set("com.github.damontecres.stashapp.api")
         schemaFiles.setFrom(fileTree("../stash-server/graphql/schema/").filter { it.extension == "graphql" }.files.map { it.path })
+        generateOptionalOperationVariables.set(false)
     }
 }
 

--- a/app/src/main/graphql/Configuration.graphql
+++ b/app/src/main/graphql/Configuration.graphql
@@ -1,0 +1,5 @@
+query Configuration {
+  configuration {
+    ui
+  }
+}

--- a/app/src/main/graphql/FindSavedFilter.graphql
+++ b/app/src/main/graphql/FindSavedFilter.graphql
@@ -1,18 +1,30 @@
 query FindSavedFilter($id: ID!) {
   findSavedFilter(id: $id) {
-    id
-    mode
-    name
-    find_filter {
-      q
-      page
-      per_page
-      sort
-      direction
-      __typename
-    }
-    object_filter
-    ui_options
+    ...SavedFilterData
     __typename
   }
+}
+
+query FindDefaultFilter($mode: FilterMode!) {
+  findDefaultFilter(mode: $mode) {
+    ...SavedFilterData
+    __typename
+  }
+}
+
+fragment SavedFilterData on SavedFilter {
+  id
+  mode
+  name
+  find_filter {
+    q
+    page
+    per_page
+    sort
+    direction
+    __typename
+  }
+  object_filter
+  ui_options
+  __typename
 }

--- a/app/src/main/graphql/FindSavedFilter.graphql
+++ b/app/src/main/graphql/FindSavedFilter.graphql
@@ -1,0 +1,18 @@
+query FindSavedFilter($id: ID!) {
+  findSavedFilter(id: $id) {
+    id
+    mode
+    name
+    find_filter {
+      q
+      page
+      per_page
+      sort
+      direction
+      __typename
+    }
+    object_filter
+    ui_options
+    __typename
+  }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -17,8 +17,15 @@ import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.LazyHeaders
 import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.ServerInfoQuery
+import com.github.damontecres.stashapp.api.type.CriterionModifier
 import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.api.type.FloatCriterionInput
+import com.github.damontecres.stashapp.api.type.HierarchicalMultiCriterionInput
+import com.github.damontecres.stashapp.api.type.IntCriterionInput
+import com.github.damontecres.stashapp.api.type.MultiCriterionInput
+import com.github.damontecres.stashapp.api.type.PerformerFilterType
+import com.github.damontecres.stashapp.api.type.StringCriterionInput
 import com.github.damontecres.stashapp.data.Scene
 
 object Constants {
@@ -207,3 +214,135 @@ fun convertFilter(filter: FindSavedFilterQuery.Find_filter?): FindFilterType? {
 
 val supportedFilterModes =
     setOf(FilterMode.SCENES, FilterMode.STUDIOS, FilterMode.PERFORMERS, FilterMode.TAGS)
+
+
+fun convertIntCriterionInput(it: Map<String, *>?): IntCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, Int?>
+        IntCriterionInput(
+            values["value"]!!,
+            Optional.presentIfNotNull(values["value2"]),
+            CriterionModifier.valueOf(it["modifier"]!! as String)
+        )
+    } else {
+        null
+    }
+}
+
+fun convertFloatCriterionInput(it: Map<String, *>?): FloatCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, Double?>
+        FloatCriterionInput(
+            values["value"]!!,
+            Optional.presentIfNotNull(values["value2"]),
+            CriterionModifier.valueOf(it["modifier"]!! as String)
+        )
+    } else {
+        null
+    }
+}
+
+fun convertStringCriterionInput(it: Map<String, *>?): StringCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, String?>
+        StringCriterionInput(
+            values["value"]!!,
+            CriterionModifier.valueOf(it["modifier"]!!.toString())
+        )
+    } else {
+        null
+    }
+}
+
+fun mapToIds(list: Any?): List<String>? {
+    return (list as List<*>?)?.map { (it as Map<String, String>)["id"].orEmpty() }?.toList()
+}
+
+fun convertHierarchicalMultiCriterionInput(it: Map<String, *>?): HierarchicalMultiCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, *>
+        val items = mapToIds(values["items"])
+        val excludes = mapToIds(values["excludes"])
+        HierarchicalMultiCriterionInput(
+            Optional.presentIfNotNull(items),
+            CriterionModifier.valueOf(it["modifier"]!!.toString()),
+            Optional.presentIfNotNull(it["depth"] as Int?),
+            Optional.presentIfNotNull(excludes)
+        )
+    } else {
+        null
+    }
+}
+
+fun convertMultiCriterionInput(it: Map<String, *>?): MultiCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, *>
+        val items = mapToIds(values["items"])
+        val excludes = mapToIds(values["excludes"])
+        MultiCriterionInput(
+            Optional.presentIfNotNull(items),
+            CriterionModifier.valueOf(it["modifier"]!!.toString()),
+            Optional.presentIfNotNull(excludes)
+        )
+    } else {
+        null
+    }
+}
+
+fun convertBoolean(it: Map<String, *>?): Boolean? {
+    return if (it != null) {
+        val value = (it["value"] as String?).toBoolean()
+        when (CriterionModifier.valueOf(it["modifier"] as String)) {
+            CriterionModifier.EQUALS -> value
+            CriterionModifier.NOT_EQUALS -> !value
+            else -> null
+        }
+    } else {
+        null
+    }
+}
+
+fun convertPerformerObjectFilter(filter: Map<String, Map<String, *>>?): PerformerFilterType? {
+    // TODO AND, OR, & NOT
+    return PerformerFilterType(
+        name = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("name"))),
+        disambiguation = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("disambiguation"))),
+        details = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("details"))),
+        filter_favorites = Optional.presentIfNotNull(convertBoolean(filter?.get("filter_favorites"))),
+        birth_year = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("birth_year"))),
+        age = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("age"))),
+        ethnicity = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("ethnicity"))),
+        country = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("country"))),
+        eye_color = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("eye_color"))),
+        height_cm = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("height_cm"))),
+        measurements = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("measurements"))),
+        fake_tits = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("fake_tits"))),
+        penis_length = Optional.presentIfNotNull(convertFloatCriterionInput(filter?.get("penis_length"))),
+//        circumcised = Optional.presentIfNotNull(convertCircumcisionCriterionInput(filter?.get("circumcised"))),
+        career_length = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("career_length"))),
+        tattoos = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("tattoos"))),
+        piercings = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("piercings"))),
+        aliases = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("aliases"))),
+//        gender = Optional.presentIfNotNull(convertGenderCriterionInput(filter?.get("gender"))),
+        // is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+        tags = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("tags"))),
+        tag_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("tag_count"))),
+        scene_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("scene_count"))),
+        image_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("image_count"))),
+        gallery_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("gallery_count"))),
+        o_counter = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("o_counter"))),
+        //stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
+        rating100 = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("rating100"))),
+        url = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("url"))),
+        hair_color = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("hair_color"))),
+        weight = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("weight"))),
+        death_year = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("death_year"))),
+        studios = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("studios"))),
+        performers = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("performers"))),
+        ignore_auto_tag = Optional.presentIfNotNull(convertBoolean(filter?.get("ignore_auto_tag"))),
+//        birthdate = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("birthdate"))),
+//        death_date = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("death_date"))),
+//        created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
+//        updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at")))
+    )
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.exception.ApolloException
@@ -14,7 +15,9 @@ import com.apollographql.apollo3.network.http.HttpInterceptor
 import com.apollographql.apollo3.network.http.HttpInterceptorChain
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.LazyHeaders
+import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.ServerInfoQuery
+import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.data.Scene
 
 object Constants {
@@ -185,4 +188,18 @@ fun selectStream(scene: Scene?): String? {
         stream = scene.streamUrl
     }
     return stream
+}
+
+fun convertFilter(filter: FindSavedFilterQuery.Find_filter?): FindFilterType? {
+    return if (filter != null) {
+        FindFilterType(
+            q = Optional.presentIfNotNull(filter.q),
+            page = Optional.presentIfNotNull(filter.page),
+            per_page = Optional.presentIfNotNull(filter.per_page),
+            sort = Optional.presentIfNotNull(filter.sort),
+            direction = Optional.presentIfNotNull(filter.direction)
+        )
+    } else {
+        null
+    }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -17,6 +17,7 @@ import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.LazyHeaders
 import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.ServerInfoQuery
+import com.github.damontecres.stashapp.api.fragment.SavedFilterData
 import com.github.damontecres.stashapp.api.type.CircumcisionCriterionInput
 import com.github.damontecres.stashapp.api.type.CircumisedEnum
 import com.github.damontecres.stashapp.api.type.CriterionModifier
@@ -212,7 +213,7 @@ fun selectStream(scene: Scene?): String? {
     return stream
 }
 
-fun convertFilter(filter: FindSavedFilterQuery.Find_filter?): FindFilterType? {
+fun convertFilter(filter: SavedFilterData.Find_filter?): FindFilterType? {
     return if (filter != null) {
         FindFilterType(
             q = Optional.presentIfNotNull(filter.q),

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -17,6 +17,7 @@ import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.LazyHeaders
 import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.ServerInfoQuery
+import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.data.Scene
 
@@ -203,3 +204,6 @@ fun convertFilter(filter: FindSavedFilterQuery.Find_filter?): FindFilterType? {
         null
     }
 }
+
+val supportedFilterModes =
+    setOf(FilterMode.SCENES, FilterMode.STUDIOS, FilterMode.STUDIOS, FilterMode.TAGS)

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -206,4 +206,4 @@ fun convertFilter(filter: FindSavedFilterQuery.Find_filter?): FindFilterType? {
 }
 
 val supportedFilterModes =
-    setOf(FilterMode.SCENES, FilterMode.STUDIOS, FilterMode.STUDIOS, FilterMode.TAGS)
+    setOf(FilterMode.SCENES, FilterMode.STUDIOS, FilterMode.PERFORMERS, FilterMode.TAGS)

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -41,6 +41,7 @@ import com.github.damontecres.stashapp.api.type.StringCriterionInput
 import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.api.type.TimestampCriterionInput
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 
 object Constants {
@@ -427,9 +428,9 @@ fun convertResolutionCriterionInput(it: Map<String, *>?): ResolutionCriterionInp
     }
 }
 
-fun convertPerformerObjectFilter(filter: Map<String, Map<String, *>>?): PerformerFilterType? {
-    // TODO AND, OR, & NOT
-    return if (filter != null) {
+fun convertPerformerObjectFilter(f: Any?): PerformerFilterType? {
+    return if (f != null) {
+        val filter = f as Map<String, Map<String, *>>
         PerformerFilterType(
             AND = Optional.presentIfNotNull(convertPerformerObjectFilter(filter?.get("AND") as Map<String, Map<String, *>>?)),
             OR = Optional.presentIfNotNull(convertPerformerObjectFilter(filter?.get("OR") as Map<String, Map<String, *>>?)),
@@ -479,8 +480,9 @@ fun convertPerformerObjectFilter(filter: Map<String, Map<String, *>>?): Performe
     }
 }
 
-fun convertSceneObjectFilter(filter: Map<String, Map<String, *>>?): SceneFilterType? {
-    return if (filter != null) {
+fun convertSceneObjectFilter(f: Any?): SceneFilterType? {
+    return if (f != null) {
+        val filter = f as Map<String, Map<String, *>>
         SceneFilterType(
             AND = Optional.presentIfNotNull(convertSceneObjectFilter(filter?.get("AND") as Map<String, Map<String, *>>?)),
             OR = Optional.presentIfNotNull(convertSceneObjectFilter(filter?.get("OR") as Map<String, Map<String, *>>?)),
@@ -552,8 +554,9 @@ fun convertSceneObjectFilter(filter: Map<String, Map<String, *>>?): SceneFilterT
 
 }
 
-fun convertStudioObjectFilter(filter: Map<String, Map<String, *>>?): StudioFilterType? {
-    return if (filter != null) {
+fun convertStudioObjectFilter(f: Any?): StudioFilterType? {
+    return if (f != null) {
+        val filter = f as Map<String, Map<String, *>>
         StudioFilterType(
             AND = Optional.presentIfNotNull(convertStudioObjectFilter(filter?.get("AND") as Map<String, Map<String, *>>?)),
             OR = Optional.presentIfNotNull(convertStudioObjectFilter(filter?.get("OR") as Map<String, Map<String, *>>?)),
@@ -578,8 +581,9 @@ fun convertStudioObjectFilter(filter: Map<String, Map<String, *>>?): StudioFilte
     }
 }
 
-fun convertTagObjectFilter(filter: Map<String, Map<String, *>>?): TagFilterType? {
-    return if (filter != null) {
+fun convertTagObjectFilter(f: Any?): TagFilterType? {
+    return if (f != null) {
+        val filter = f as Map<String, Map<String, *>>
         TagFilterType(
             AND = Optional.presentIfNotNull(convertTagObjectFilter(filter?.get("AND") as Map<String, Map<String, *>>?)),
             OR = Optional.presentIfNotNull(convertTagObjectFilter(filter?.get("OR") as Map<String, Map<String, *>>?)),

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -15,7 +15,6 @@ import com.apollographql.apollo3.network.http.HttpInterceptor
 import com.apollographql.apollo3.network.http.HttpInterceptorChain
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.LazyHeaders
-import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.ServerInfoQuery
 import com.github.damontecres.stashapp.api.fragment.SavedFilterData
 import com.github.damontecres.stashapp.api.type.CircumcisionCriterionInput
@@ -41,7 +40,6 @@ import com.github.damontecres.stashapp.api.type.StringCriterionInput
 import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.api.type.TimestampCriterionInput
-import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 
 object Constants {

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -17,18 +17,29 @@ import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.LazyHeaders
 import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.ServerInfoQuery
+import com.github.damontecres.stashapp.api.type.CircumcisionCriterionInput
+import com.github.damontecres.stashapp.api.type.CircumisedEnum
 import com.github.damontecres.stashapp.api.type.CriterionModifier
+import com.github.damontecres.stashapp.api.type.DateCriterionInput
 import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.FloatCriterionInput
+import com.github.damontecres.stashapp.api.type.GenderCriterionInput
+import com.github.damontecres.stashapp.api.type.GenderEnum
 import com.github.damontecres.stashapp.api.type.HierarchicalMultiCriterionInput
 import com.github.damontecres.stashapp.api.type.IntCriterionInput
 import com.github.damontecres.stashapp.api.type.MultiCriterionInput
+import com.github.damontecres.stashapp.api.type.PHashDuplicationCriterionInput
 import com.github.damontecres.stashapp.api.type.PerformerFilterType
+import com.github.damontecres.stashapp.api.type.PhashDistanceCriterionInput
+import com.github.damontecres.stashapp.api.type.ResolutionCriterionInput
+import com.github.damontecres.stashapp.api.type.ResolutionEnum
 import com.github.damontecres.stashapp.api.type.SceneFilterType
+import com.github.damontecres.stashapp.api.type.StashIDCriterionInput
 import com.github.damontecres.stashapp.api.type.StringCriterionInput
 import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
+import com.github.damontecres.stashapp.api.type.TimestampCriterionInput
 import com.github.damontecres.stashapp.data.Scene
 
 object Constants {
@@ -305,10 +316,123 @@ fun convertBoolean(it: Map<String, *>?): Boolean? {
     }
 }
 
+fun convertDateCriterionInput(it: Map<String, *>?): DateCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, String?>
+        DateCriterionInput(
+            values["value"]!!,
+            Optional.presentIfNotNull(values["value2"]),
+            CriterionModifier.valueOf(it["modifier"]!! as String)
+        )
+    } else {
+        null
+    }
+}
+
+fun convertTimestampCriterionInput(it: Map<String, *>?): TimestampCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, String?>
+        TimestampCriterionInput(
+            values["value"]!!,
+            Optional.presentIfNotNull(values["value2"]),
+            CriterionModifier.valueOf(it["modifier"]!! as String)
+        )
+    } else {
+        null
+    }
+}
+
+fun convertCircumcisionCriterionInput(it: Map<String, *>?): CircumcisionCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, List<String>?>
+        CircumcisionCriterionInput(
+            Optional.presentIfNotNull(values["value"]?.map { CircumisedEnum.valueOf(it) }
+                ?.toList()),
+            CriterionModifier.valueOf(it["modifier"]!! as String)
+        )
+    } else {
+        null
+    }
+}
+
+fun convertGenderCriterionInput(it: Map<String, *>?): GenderCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, String?>
+        GenderCriterionInput(
+            Optional.presentIfNotNull(GenderEnum.valueOf(values["value"]!!)),
+            CriterionModifier.valueOf(it["modifier"]!! as String)
+        )
+    } else {
+        null
+    }
+}
+
+fun convertString(it: Map<String, *>?): String? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, String?>
+        return values["value"]
+    } else {
+        null
+    }
+}
+
+fun convertStashIDCriterionInput(it: Map<String, *>?): StashIDCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, String?>
+        StashIDCriterionInput(
+            Optional.presentIfNotNull(values["endpoint"]),
+            Optional.presentIfNotNull(values["stash_id"]),
+            CriterionModifier.valueOf(it["modifier"]!! as String)
+        )
+    } else {
+        null
+    }
+}
+
+fun convertPhashDistanceCriterionInput(it: Map<String, *>?): PhashDistanceCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, *>
+        PhashDistanceCriterionInput(
+            values["value"]!! as String,
+            CriterionModifier.valueOf(it["modifier"]!!.toString()),
+            Optional.presentIfNotNull(values["distance"].toString().toInt()),
+        )
+    } else {
+        null
+    }
+}
+
+fun convertPHashDuplicationCriterionInput(it: Map<String, *>?): PHashDuplicationCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, *>
+        PHashDuplicationCriterionInput(
+            Optional.presentIfNotNull(values["duplicated"].toString().toBoolean()),
+            Optional.presentIfNotNull(values["distance"].toString().toInt())
+        )
+    } else {
+        null
+    }
+}
+
+fun convertResolutionCriterionInput(it: Map<String, *>?): ResolutionCriterionInput? {
+    return if (it != null) {
+        val values = it["value"]!! as Map<String, String?>
+        ResolutionCriterionInput(
+            ResolutionEnum.valueOf(values["value"]!!),
+            CriterionModifier.valueOf(it["modifier"]!! as String)
+        )
+    } else {
+        null
+    }
+}
+
 fun convertPerformerObjectFilter(filter: Map<String, Map<String, *>>?): PerformerFilterType? {
     // TODO AND, OR, & NOT
     return if (filter != null) {
         PerformerFilterType(
+            AND = Optional.presentIfNotNull(convertPerformerObjectFilter(filter?.get("AND") as Map<String, Map<String, *>>?)),
+            OR = Optional.presentIfNotNull(convertPerformerObjectFilter(filter?.get("OR") as Map<String, Map<String, *>>?)),
+            NOT = Optional.presentIfNotNull(convertPerformerObjectFilter(filter?.get("NOT") as Map<String, Map<String, *>>?)),
             name = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("name"))),
             disambiguation = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("disambiguation"))),
             details = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("details"))),
@@ -322,20 +446,20 @@ fun convertPerformerObjectFilter(filter: Map<String, Map<String, *>>?): Performe
             measurements = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("measurements"))),
             fake_tits = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("fake_tits"))),
             penis_length = Optional.presentIfNotNull(convertFloatCriterionInput(filter?.get("penis_length"))),
-//        circumcised = Optional.presentIfNotNull(convertCircumcisionCriterionInput(filter?.get("circumcised"))),
+            circumcised = Optional.presentIfNotNull(convertCircumcisionCriterionInput(filter?.get("circumcised"))),
             career_length = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("career_length"))),
             tattoos = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("tattoos"))),
             piercings = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("piercings"))),
             aliases = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("aliases"))),
-//        gender = Optional.presentIfNotNull(convertGenderCriterionInput(filter?.get("gender"))),
-            // is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+            gender = Optional.presentIfNotNull(convertGenderCriterionInput(filter?.get("gender"))),
+            is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
             tags = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("tags"))),
             tag_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("tag_count"))),
             scene_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("scene_count"))),
             image_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("image_count"))),
             gallery_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("gallery_count"))),
             o_counter = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("o_counter"))),
-            //stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
+            stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
             rating100 = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("rating100"))),
             url = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("url"))),
             hair_color = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("hair_color"))),
@@ -344,10 +468,10 @@ fun convertPerformerObjectFilter(filter: Map<String, Map<String, *>>?): Performe
             studios = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("studios"))),
             performers = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("performers"))),
             ignore_auto_tag = Optional.presentIfNotNull(convertBoolean(filter?.get("ignore_auto_tag"))),
-//        birthdate = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("birthdate"))),
-//        death_date = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("death_date"))),
-//        created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
-//        updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at")))
+            birthdate = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("birthdate"))),
+            death_date = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("death_date"))),
+            created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
+            updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at")))
         )
     } else {
         null
@@ -357,9 +481,9 @@ fun convertPerformerObjectFilter(filter: Map<String, Map<String, *>>?): Performe
 fun convertSceneObjectFilter(filter: Map<String, Map<String, *>>?): SceneFilterType? {
     return if (filter != null) {
         SceneFilterType(
-//        AND = Optional.presentIfNotNull(convertSceneFilterType(filter?.get("AND"))),
-//        OR = Optional.presentIfNotNull(convertSceneFilterType(filter?.get("OR"))),
-//        NOT = Optional.presentIfNotNull(convertSceneFilterType(filter?.get("NOT"))),
+            AND = Optional.presentIfNotNull(convertSceneObjectFilter(filter?.get("AND") as Map<String, Map<String, *>>?)),
+            OR = Optional.presentIfNotNull(convertSceneObjectFilter(filter?.get("OR") as Map<String, Map<String, *>>?)),
+            NOT = Optional.presentIfNotNull(convertSceneObjectFilter(filter?.get("NOT") as Map<String, Map<String, *>>?)),
             id = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("id"))),
             title = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("title"))),
             code = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("code"))),
@@ -368,20 +492,32 @@ fun convertSceneObjectFilter(filter: Map<String, Map<String, *>>?): SceneFilterT
             oshash = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("oshash"))),
             checksum = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("checksum"))),
             phash = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("phash"))),
-//        phash_distance = Optional.presentIfNotNull(convertPhashDistanceCriterionInput(filter?.get("phash_distance"))),
+            phash_distance = Optional.presentIfNotNull(
+                convertPhashDistanceCriterionInput(
+                    filter?.get(
+                        "phash_distance"
+                    )
+                )
+            ),
             path = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("path"))),
             file_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("file_count"))),
             rating100 = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("rating100"))),
             organized = Optional.presentIfNotNull(convertBoolean(filter?.get("organized"))),
             o_counter = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("o_counter"))),
-//        duplicated = Optional.presentIfNotNull(convertPHashDuplicationCriterionInput(filter?.get("duplicated"))),
-//        resolution = Optional.presentIfNotNull(convertResolutionCriterionInput(filter?.get("resolution"))),
+            duplicated = Optional.presentIfNotNull(
+                convertPHashDuplicationCriterionInput(
+                    filter?.get(
+                        "duplicated"
+                    )
+                )
+            ),
+            resolution = Optional.presentIfNotNull(convertResolutionCriterionInput(filter?.get("resolution"))),
             framerate = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("framerate"))),
             video_codec = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("video_codec"))),
             audio_codec = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("audio_codec"))),
             duration = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("duration"))),
-//        has_markers = Optional.presentIfNotNull(convertString(filter?.get("has_markers"))),
-//        is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+            has_markers = Optional.presentIfNotNull(convertString(filter?.get("has_markers"))),
+            is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
             studios = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("studios"))),
             movies = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("movies"))),
             tags = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("tags"))),
@@ -397,7 +533,7 @@ fun convertSceneObjectFilter(filter: Map<String, Map<String, *>>?): SceneFilterT
             performer_age = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("performer_age"))),
             performers = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("performers"))),
             performer_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("performer_count"))),
-//        stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
+            stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
             url = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("url"))),
             interactive = Optional.presentIfNotNull(convertBoolean(filter?.get("interactive"))),
             interactive_speed = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("interactive_speed"))),
@@ -405,9 +541,9 @@ fun convertSceneObjectFilter(filter: Map<String, Map<String, *>>?): SceneFilterT
             resume_time = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("resume_time"))),
             play_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("play_count"))),
             play_duration = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("play_duration"))),
-//        date = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("date"))),
-//        created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
-//        updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
+            date = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("date"))),
+            created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
+            updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
         )
     } else {
         null
@@ -418,14 +554,14 @@ fun convertSceneObjectFilter(filter: Map<String, Map<String, *>>?): SceneFilterT
 fun convertStudioObjectFilter(filter: Map<String, Map<String, *>>?): StudioFilterType? {
     return if (filter != null) {
         StudioFilterType(
-//        AND = Optional.presentIfNotNull(convertStudioFilterType(filter?.get("AND"))),
-//        OR = Optional.presentIfNotNull(convertStudioFilterType(filter?.get("OR"))),
-//        NOT = Optional.presentIfNotNull(convertStudioFilterType(filter?.get("NOT"))),
+            AND = Optional.presentIfNotNull(convertStudioObjectFilter(filter?.get("AND") as Map<String, Map<String, *>>?)),
+            OR = Optional.presentIfNotNull(convertStudioObjectFilter(filter?.get("OR") as Map<String, Map<String, *>>?)),
+            NOT = Optional.presentIfNotNull(convertStudioObjectFilter(filter?.get("NOT") as Map<String, Map<String, *>>?)),
             name = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("name"))),
             details = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("details"))),
             parents = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("parents"))),
-//        stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
-//        is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+            stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
+            is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
             rating100 = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("rating100"))),
             scene_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("scene_count"))),
             image_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("image_count"))),
@@ -433,8 +569,8 @@ fun convertStudioObjectFilter(filter: Map<String, Map<String, *>>?): StudioFilte
             url = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("url"))),
             aliases = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("aliases"))),
             ignore_auto_tag = Optional.presentIfNotNull(convertBoolean(filter?.get("ignore_auto_tag"))),
-//        created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
-//        updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
+            created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
+            updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
         )
     } else {
         null
@@ -444,13 +580,13 @@ fun convertStudioObjectFilter(filter: Map<String, Map<String, *>>?): StudioFilte
 fun convertTagObjectFilter(filter: Map<String, Map<String, *>>?): TagFilterType? {
     return if (filter != null) {
         TagFilterType(
-//        AND = Optional.presentIfNotNull(convertTagFilterType(filter?.get("AND"))),
-//        OR = Optional.presentIfNotNull(convertTagFilterType(filter?.get("OR"))),
-//        NOT = Optional.presentIfNotNull(convertTagFilterType(filter?.get("NOT"))),
+            AND = Optional.presentIfNotNull(convertTagObjectFilter(filter?.get("AND") as Map<String, Map<String, *>>?)),
+            OR = Optional.presentIfNotNull(convertTagObjectFilter(filter?.get("OR") as Map<String, Map<String, *>>?)),
+            NOT = Optional.presentIfNotNull(convertTagObjectFilter(filter?.get("NOT") as Map<String, Map<String, *>>?)),
             name = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("name"))),
             aliases = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("aliases"))),
             description = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("description"))),
-//        is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+            is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
             scene_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("scene_count"))),
             image_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("image_count"))),
             gallery_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("gallery_count"))),
@@ -467,8 +603,8 @@ fun convertTagObjectFilter(filter: Map<String, Map<String, *>>?): TagFilterType?
             parent_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("parent_count"))),
             child_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("child_count"))),
             ignore_auto_tag = Optional.presentIfNotNull(convertBoolean(filter?.get("ignore_auto_tag"))),
-//        created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
-//        updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
+            created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
+            updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
         )
     } else {
         null

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -25,7 +25,10 @@ import com.github.damontecres.stashapp.api.type.HierarchicalMultiCriterionInput
 import com.github.damontecres.stashapp.api.type.IntCriterionInput
 import com.github.damontecres.stashapp.api.type.MultiCriterionInput
 import com.github.damontecres.stashapp.api.type.PerformerFilterType
+import com.github.damontecres.stashapp.api.type.SceneFilterType
 import com.github.damontecres.stashapp.api.type.StringCriterionInput
+import com.github.damontecres.stashapp.api.type.StudioFilterType
+import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.data.Scene
 
 object Constants {
@@ -304,45 +307,170 @@ fun convertBoolean(it: Map<String, *>?): Boolean? {
 
 fun convertPerformerObjectFilter(filter: Map<String, Map<String, *>>?): PerformerFilterType? {
     // TODO AND, OR, & NOT
-    return PerformerFilterType(
-        name = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("name"))),
-        disambiguation = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("disambiguation"))),
-        details = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("details"))),
-        filter_favorites = Optional.presentIfNotNull(convertBoolean(filter?.get("filter_favorites"))),
-        birth_year = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("birth_year"))),
-        age = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("age"))),
-        ethnicity = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("ethnicity"))),
-        country = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("country"))),
-        eye_color = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("eye_color"))),
-        height_cm = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("height_cm"))),
-        measurements = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("measurements"))),
-        fake_tits = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("fake_tits"))),
-        penis_length = Optional.presentIfNotNull(convertFloatCriterionInput(filter?.get("penis_length"))),
+    return if (filter != null) {
+        PerformerFilterType(
+            name = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("name"))),
+            disambiguation = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("disambiguation"))),
+            details = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("details"))),
+            filter_favorites = Optional.presentIfNotNull(convertBoolean(filter?.get("filter_favorites"))),
+            birth_year = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("birth_year"))),
+            age = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("age"))),
+            ethnicity = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("ethnicity"))),
+            country = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("country"))),
+            eye_color = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("eye_color"))),
+            height_cm = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("height_cm"))),
+            measurements = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("measurements"))),
+            fake_tits = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("fake_tits"))),
+            penis_length = Optional.presentIfNotNull(convertFloatCriterionInput(filter?.get("penis_length"))),
 //        circumcised = Optional.presentIfNotNull(convertCircumcisionCriterionInput(filter?.get("circumcised"))),
-        career_length = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("career_length"))),
-        tattoos = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("tattoos"))),
-        piercings = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("piercings"))),
-        aliases = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("aliases"))),
+            career_length = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("career_length"))),
+            tattoos = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("tattoos"))),
+            piercings = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("piercings"))),
+            aliases = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("aliases"))),
 //        gender = Optional.presentIfNotNull(convertGenderCriterionInput(filter?.get("gender"))),
-        // is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
-        tags = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("tags"))),
-        tag_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("tag_count"))),
-        scene_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("scene_count"))),
-        image_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("image_count"))),
-        gallery_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("gallery_count"))),
-        o_counter = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("o_counter"))),
-        //stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
-        rating100 = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("rating100"))),
-        url = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("url"))),
-        hair_color = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("hair_color"))),
-        weight = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("weight"))),
-        death_year = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("death_year"))),
-        studios = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("studios"))),
-        performers = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("performers"))),
-        ignore_auto_tag = Optional.presentIfNotNull(convertBoolean(filter?.get("ignore_auto_tag"))),
+            // is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+            tags = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("tags"))),
+            tag_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("tag_count"))),
+            scene_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("scene_count"))),
+            image_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("image_count"))),
+            gallery_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("gallery_count"))),
+            o_counter = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("o_counter"))),
+            //stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
+            rating100 = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("rating100"))),
+            url = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("url"))),
+            hair_color = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("hair_color"))),
+            weight = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("weight"))),
+            death_year = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("death_year"))),
+            studios = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("studios"))),
+            performers = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("performers"))),
+            ignore_auto_tag = Optional.presentIfNotNull(convertBoolean(filter?.get("ignore_auto_tag"))),
 //        birthdate = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("birthdate"))),
 //        death_date = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("death_date"))),
 //        created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
 //        updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at")))
-    )
+        )
+    } else {
+        null
+    }
+}
+
+fun convertSceneObjectFilter(filter: Map<String, Map<String, *>>?): SceneFilterType? {
+    return if (filter != null) {
+        SceneFilterType(
+//        AND = Optional.presentIfNotNull(convertSceneFilterType(filter?.get("AND"))),
+//        OR = Optional.presentIfNotNull(convertSceneFilterType(filter?.get("OR"))),
+//        NOT = Optional.presentIfNotNull(convertSceneFilterType(filter?.get("NOT"))),
+            id = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("id"))),
+            title = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("title"))),
+            code = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("code"))),
+            details = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("details"))),
+            director = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("director"))),
+            oshash = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("oshash"))),
+            checksum = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("checksum"))),
+            phash = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("phash"))),
+//        phash_distance = Optional.presentIfNotNull(convertPhashDistanceCriterionInput(filter?.get("phash_distance"))),
+            path = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("path"))),
+            file_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("file_count"))),
+            rating100 = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("rating100"))),
+            organized = Optional.presentIfNotNull(convertBoolean(filter?.get("organized"))),
+            o_counter = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("o_counter"))),
+//        duplicated = Optional.presentIfNotNull(convertPHashDuplicationCriterionInput(filter?.get("duplicated"))),
+//        resolution = Optional.presentIfNotNull(convertResolutionCriterionInput(filter?.get("resolution"))),
+            framerate = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("framerate"))),
+            video_codec = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("video_codec"))),
+            audio_codec = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("audio_codec"))),
+            duration = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("duration"))),
+//        has_markers = Optional.presentIfNotNull(convertString(filter?.get("has_markers"))),
+//        is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+            studios = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("studios"))),
+            movies = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("movies"))),
+            tags = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("tags"))),
+            tag_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("tag_count"))),
+            performer_tags = Optional.presentIfNotNull(
+                convertHierarchicalMultiCriterionInput(
+                    filter?.get(
+                        "performer_tags"
+                    )
+                )
+            ),
+            performer_favorite = Optional.presentIfNotNull(convertBoolean(filter?.get("performer_favorite"))),
+            performer_age = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("performer_age"))),
+            performers = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("performers"))),
+            performer_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("performer_count"))),
+//        stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
+            url = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("url"))),
+            interactive = Optional.presentIfNotNull(convertBoolean(filter?.get("interactive"))),
+            interactive_speed = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("interactive_speed"))),
+            captions = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("captions"))),
+            resume_time = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("resume_time"))),
+            play_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("play_count"))),
+            play_duration = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("play_duration"))),
+//        date = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("date"))),
+//        created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
+//        updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
+        )
+    } else {
+        null
+    }
+
+}
+
+fun convertStudioObjectFilter(filter: Map<String, Map<String, *>>?): StudioFilterType? {
+    return if (filter != null) {
+        StudioFilterType(
+//        AND = Optional.presentIfNotNull(convertStudioFilterType(filter?.get("AND"))),
+//        OR = Optional.presentIfNotNull(convertStudioFilterType(filter?.get("OR"))),
+//        NOT = Optional.presentIfNotNull(convertStudioFilterType(filter?.get("NOT"))),
+            name = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("name"))),
+            details = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("details"))),
+            parents = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("parents"))),
+//        stash_id_endpoint = Optional.presentIfNotNull(convertStashIDCriterionInput(filter?.get("stash_id_endpoint"))),
+//        is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+            rating100 = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("rating100"))),
+            scene_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("scene_count"))),
+            image_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("image_count"))),
+            gallery_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("gallery_count"))),
+            url = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("url"))),
+            aliases = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("aliases"))),
+            ignore_auto_tag = Optional.presentIfNotNull(convertBoolean(filter?.get("ignore_auto_tag"))),
+//        created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
+//        updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
+        )
+    } else {
+        null
+    }
+}
+
+fun convertTagObjectFilter(filter: Map<String, Map<String, *>>?): TagFilterType? {
+    return if (filter != null) {
+        TagFilterType(
+//        AND = Optional.presentIfNotNull(convertTagFilterType(filter?.get("AND"))),
+//        OR = Optional.presentIfNotNull(convertTagFilterType(filter?.get("OR"))),
+//        NOT = Optional.presentIfNotNull(convertTagFilterType(filter?.get("NOT"))),
+            name = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("name"))),
+            aliases = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("aliases"))),
+            description = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("description"))),
+//        is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+            scene_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("scene_count"))),
+            image_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("image_count"))),
+            gallery_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("gallery_count"))),
+            performer_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("performer_count"))),
+            marker_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("marker_count"))),
+            parents = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("parents"))),
+            children = Optional.presentIfNotNull(
+                convertHierarchicalMultiCriterionInput(
+                    filter?.get(
+                        "children"
+                    )
+                )
+            ),
+            parent_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("parent_count"))),
+            child_count = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("child_count"))),
+            ignore_auto_tag = Optional.presentIfNotNull(convertBoolean(filter?.get("ignore_auto_tag"))),
+//        created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
+//        updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
+        )
+    } else {
+        null
+    }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -302,46 +302,56 @@ class MainFragment : BrowseSupportFragment() {
                                     val filterId = frontPageFilter["savedFilterId"]
                                     val header = HeaderItem("")
                                     val listRow = ListRow(header, adapter)
-                                    rowsAdapter.add(listRow) // TODO check if supported
+                                    rowsAdapter.add(listRow)
                                     viewLifecycleOwner.lifecycleScope.launch(exHandler) {
                                         val result = queryEngine.getSavedFilter(filterId.toString())
 
                                         val index = rowsAdapter.indexOf(listRow)
                                         rowsAdapter.removeItems(index, 1)
-                                        rowsAdapter.add(
-                                            index,
-                                            ListRow(HeaderItem(result?.name ?: ""), adapter)
-                                        )
 
-                                        val filter = convertFilter(result?.find_filter)
-                                        val objectFilter = result?.object_filter
-                                        // TODO convert object filters
+                                        if (result?.mode in supportedFilterModes) {
+                                            // TODO doing it this way will result it adding an unsupported row then removing it which looks weird, in practice though it happens pretty fast
+                                            rowsAdapter.add(
+                                                index,
+                                                ListRow(HeaderItem(result?.name ?: ""), adapter)
+                                            )
 
-                                        when (result?.mode) {
-                                            FilterMode.SCENES -> {
-                                                adapter.addAll(0, queryEngine.findScenes(filter))
-                                            }
+                                            val filter = convertFilter(result?.find_filter)
+                                            val objectFilter = result?.object_filter
+                                            // TODO convert object filters
 
-                                            FilterMode.STUDIOS -> {
-                                                adapter.addAll(0, queryEngine.findStudios(filter))
-                                            }
+                                            when (result?.mode) {
+                                                FilterMode.SCENES -> {
+                                                    adapter.addAll(
+                                                        0,
+                                                        queryEngine.findScenes(filter)
+                                                    )
+                                                }
 
-                                            FilterMode.PERFORMERS -> {
-                                                adapter.addAll(
-                                                    0,
-                                                    queryEngine.findPerformers(filter)
-                                                )
-                                            }
+                                                FilterMode.STUDIOS -> {
+                                                    adapter.addAll(
+                                                        0,
+                                                        queryEngine.findStudios(filter)
+                                                    )
+                                                }
 
-                                            FilterMode.TAGS -> {
-                                                adapter.addAll(0, queryEngine.findTags(filter))
-                                            }
+                                                FilterMode.PERFORMERS -> {
+                                                    adapter.addAll(
+                                                        0,
+                                                        queryEngine.findPerformers(filter)
+                                                    )
+                                                }
 
-                                            else -> {
-                                                Log.i(
-                                                    TAG,
-                                                    "Unsupported mode in frontpage: ${result?.mode}"
-                                                )
+                                                FilterMode.TAGS -> {
+                                                    adapter.addAll(0, queryEngine.findTags(filter))
+                                                }
+
+                                                else -> {
+                                                    Log.i(
+                                                        TAG,
+                                                        "Unsupported mode in frontpage: ${result?.mode}"
+                                                    )
+                                                }
                                             }
                                         }
                                     }

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -34,6 +34,7 @@ import com.bumptech.glide.request.transition.Transition
 import com.github.damontecres.stashapp.api.ConfigurationQuery
 import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.api.type.PerformerFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
@@ -317,8 +318,10 @@ class MainFragment : BrowseSupportFragment() {
                                             )
 
                                             val filter = convertFilter(result?.find_filter)
-                                            val objectFilter = result?.object_filter
+                                            val objectFilter =
+                                                result?.object_filter as Map<String, Map<String, *>>
                                             // TODO convert object filters
+
 
                                             when (result?.mode) {
                                                 FilterMode.SCENES -> {
@@ -336,9 +339,14 @@ class MainFragment : BrowseSupportFragment() {
                                                 }
 
                                                 FilterMode.PERFORMERS -> {
+                                                    val performerFilter =
+                                                        convertPerformerObjectFilter(objectFilter)
                                                     adapter.addAll(
                                                         0,
-                                                        queryEngine.findPerformers(filter)
+                                                        queryEngine.findPerformers(
+                                                            filter,
+                                                            performerFilter
+                                                        )
                                                     )
                                                 }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -299,14 +299,20 @@ class MainFragment : BrowseSupportFragment() {
                                         }
                                     }
                                 } else if (filterType == "SavedFilter") {
-                                    val filterId = frontPageFilter["savedFilterId"] as String
-                                    rowsAdapter.add(
-                                        ListRow(
-                                            adapter
-                                        )
-                                    )
+                                    val filterId = frontPageFilter["savedFilterId"]
+                                    val header = HeaderItem("")
+                                    val listRow = ListRow(header, adapter)
+                                    rowsAdapter.add(listRow) // TODO check if supported
                                     viewLifecycleOwner.lifecycleScope.launch(exHandler) {
-                                        val result = queryEngine.getSavedFilter(filterId)
+                                        val result = queryEngine.getSavedFilter(filterId.toString())
+
+                                        val index = rowsAdapter.indexOf(listRow)
+                                        rowsAdapter.removeItems(index, 1)
+                                        rowsAdapter.add(
+                                            index,
+                                            ListRow(HeaderItem(result?.name ?: ""), adapter)
+                                        )
+
                                         val filter = convertFilter(result?.find_filter)
                                         val objectFilter = result?.object_filter
                                         // TODO convert object filters
@@ -325,6 +331,10 @@ class MainFragment : BrowseSupportFragment() {
                                                     0,
                                                     queryEngine.findPerformers(filter)
                                                 )
+                                            }
+
+                                            FilterMode.TAGS -> {
+                                                adapter.addAll(0, queryEngine.findTags(filter))
                                             }
 
                                             else -> {

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -31,11 +31,15 @@ import com.apollographql.apollo3.api.Optional
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
+import com.github.damontecres.stashapp.api.ConfigurationQuery
+import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
 import com.github.damontecres.stashapp.presenters.StudioPresenter
+import com.github.damontecres.stashapp.presenters.stashPresenterSelector
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import java.util.Timer
@@ -48,9 +52,11 @@ import java.util.TimerTask
 class MainFragment : BrowseSupportFragment() {
 
     private val rowsAdapter = ArrayObjectAdapter(ListRowPresenter())
-    private var performerAdapter: ArrayObjectAdapter = ArrayObjectAdapter(PerformerPresenter())
-    private var studioAdapter: ArrayObjectAdapter = ArrayObjectAdapter(StudioPresenter())
-    private var sceneAdapter: ArrayObjectAdapter = ArrayObjectAdapter(ScenePresenter())
+    private val adapters = ArrayList<ArrayObjectAdapter>()
+
+    //    private var performerAdapter: ArrayObjectAdapter = ArrayObjectAdapter(PerformerPresenter())
+//    private var studioAdapter: ArrayObjectAdapter = ArrayObjectAdapter(StudioPresenter())
+//    private var sceneAdapter: ArrayObjectAdapter = ArrayObjectAdapter(ScenePresenter())
     private val mHandler = Handler(Looper.myLooper()!!)
     private lateinit var mBackgroundManager: BackgroundManager
     private var mDefaultBackground: Drawable? = null
@@ -95,7 +101,6 @@ class MainFragment : BrowseSupportFragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             if (testStashConnection(requireContext(), false)) {
                 if (rowsAdapter.size() == 0) {
-                    addRowsIfNeeded()
                     fetchData()
                 }
             } else {
@@ -209,62 +214,130 @@ class MainFragment : BrowseSupportFragment() {
         override fun onUnbindViewHolder(viewHolder: Presenter.ViewHolder) {}
     }
 
-    private fun addRowsIfNeeded() {
-        if (rowsAdapter.size() == 0) {
-            rowsAdapter.add(ListRow(HeaderItem("RECENTLY RELEASED SCENES"), sceneAdapter))
-            rowsAdapter.add(ListRow(HeaderItem("RECENTLY ADDED STUDIOS"), studioAdapter))
-            rowsAdapter.add(ListRow(HeaderItem("RECENTLY ADDED PERFORMERS"), performerAdapter))
-        }
-    }
-
     private fun clearData() {
-        sceneAdapter.clear()
-        studioAdapter.clear()
-        performerAdapter.clear()
+        adapters.forEach { it.clear() }
     }
 
     private fun fetchData() {
         clearData()
         viewLifecycleOwner.lifecycleScope.launch {
             if (testStashConnection(requireContext(), false)) {
-                addRowsIfNeeded()
                 try {
                     val queryEngine = QueryEngine(requireContext(), showToasts = true)
 
-                    viewLifecycleOwner.lifecycleScope.async {
-                        sceneAdapter.addAll(
-                            0, queryEngine.findScenes(
-                                FindFilterType(
-                                    sort = Optional.present("date"),
-                                    direction = Optional.present(SortDirectionEnum.DESC),
-                                    per_page = Optional.present(25)
-                                )
-                            )
-                        )
+                    val exHandler = CoroutineExceptionHandler { _, ex ->
+                        Log.e(TAG, "Exception in coroutine", ex)
                     }
 
-                    viewLifecycleOwner.lifecycleScope.async {
-                        performerAdapter.addAll(
-                            0, queryEngine.findPerformers(
-                                FindFilterType(
-                                    sort = Optional.present("created_at"),
-                                    direction = Optional.present(SortDirectionEnum.DESC),
-                                    per_page = Optional.present(25)
-                                )
-                            )
-                        )
-                    }
+                    viewLifecycleOwner.lifecycleScope.launch(exHandler) {
+                        val query = ConfigurationQuery()
+                        val ui = queryEngine.executeQuery(query).data?.configuration?.ui
+                        if (ui != null) {
+                            val frontPageContent =
+                                (ui as Map<String, *>)["frontPageContent"] as List<Map<String, *>>
+                            for (frontPageFilter: Map<String, *> in frontPageContent) {
+                                val adapter = ArrayObjectAdapter(stashPresenterSelector)
+                                adapters.add(adapter)
 
-                    viewLifecycleOwner.lifecycleScope.async {
-                        studioAdapter.addAll(
-                            0, queryEngine.findStudios(
-                                FindFilterType(
-                                    sort = Optional.present("created_at"),
-                                    direction = Optional.present(SortDirectionEnum.DESC),
-                                    per_page = Optional.present(25)
-                                )
-                            )
-                        )
+                                val filterType = frontPageFilter["__typename"] as String
+                                if (filterType == "CustomFilter") {
+                                    val mode = FilterMode.valueOf(frontPageFilter["mode"] as String)
+                                    val direction = frontPageFilter["direction"] as String
+                                    val sortBy = frontPageFilter["sortBy"] as String
+                                    val filter = FindFilterType(
+                                        direction = Optional.present(
+                                            SortDirectionEnum.safeValueOf(
+                                                direction
+                                            )
+                                        ),
+                                        sort = Optional.present(sortBy),
+                                        per_page = Optional.present(25)
+                                    )
+
+                                    val msg = frontPageFilter["message"] as Map<String, *>
+                                    val objType =
+                                        (msg["values"] as Map<String, String>)["objects"] as String
+                                    val description = when (msg["id"] as String) {
+                                        "recently_added_objects" -> "Recently Added $objType"
+                                        "recently_released_objects" -> "Recently Released $objType"
+                                        else -> ""
+                                    }
+
+                                    when (mode) {
+                                        FilterMode.SCENES -> {
+                                            rowsAdapter.add(
+                                                ListRow(
+                                                    HeaderItem(description),
+                                                    adapter
+                                                )
+                                            )
+                                            adapter.addAll(0, queryEngine.findScenes(filter))
+                                        }
+
+                                        FilterMode.STUDIOS -> {
+                                            rowsAdapter.add(
+                                                ListRow(
+                                                    HeaderItem(description),
+                                                    adapter
+                                                )
+                                            )
+                                            adapter.addAll(0, queryEngine.findStudios(filter))
+                                        }
+
+                                        FilterMode.PERFORMERS -> {
+                                            rowsAdapter.add(
+                                                ListRow(
+                                                    HeaderItem(description),
+                                                    adapter
+                                                )
+                                            )
+                                            adapter.addAll(0, queryEngine.findPerformers(filter))
+                                        }
+
+                                        else -> {
+                                            Log.i(TAG, "Unsupported mode in frontpage: $mode")
+                                        }
+                                    }
+                                } else if (filterType == "SavedFilter") {
+                                    val filterId = frontPageFilter["savedFilterId"] as String
+                                    rowsAdapter.add(
+                                        ListRow(
+                                            adapter
+                                        )
+                                    )
+                                    viewLifecycleOwner.lifecycleScope.launch(exHandler) {
+                                        val result = queryEngine.getSavedFilter(filterId)
+                                        val filter = convertFilter(result?.find_filter)
+                                        val objectFilter = result?.object_filter
+                                        // TODO convert object filters
+
+                                        when (result?.mode) {
+                                            FilterMode.SCENES -> {
+                                                adapter.addAll(0, queryEngine.findScenes(filter))
+                                            }
+
+                                            FilterMode.STUDIOS -> {
+                                                adapter.addAll(0, queryEngine.findStudios(filter))
+                                            }
+
+                                            FilterMode.PERFORMERS -> {
+                                                adapter.addAll(
+                                                    0,
+                                                    queryEngine.findPerformers(filter)
+                                                )
+                                            }
+
+                                            else -> {
+                                                Log.i(
+                                                    TAG,
+                                                    "Unsupported mode in frontpage: ${result?.mode}"
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 } catch (ex: QueryEngine.StashNotConfiguredException) {
                     Toast.makeText(

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -34,14 +34,9 @@ import com.bumptech.glide.request.transition.Transition
 import com.github.damontecres.stashapp.api.ConfigurationQuery
 import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.FindFilterType
-import com.github.damontecres.stashapp.api.type.PerformerFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
-import com.github.damontecres.stashapp.presenters.PerformerPresenter
-import com.github.damontecres.stashapp.presenters.ScenePresenter
-import com.github.damontecres.stashapp.presenters.StudioPresenter
 import com.github.damontecres.stashapp.presenters.stashPresenterSelector
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import java.util.Timer
 import java.util.TimerTask

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerActivity.kt
@@ -4,8 +4,10 @@ import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 import com.apollographql.apollo3.api.Optional
 import com.github.damontecres.stashapp.api.type.CriterionModifier
+import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.MultiCriterionInput
 import com.github.damontecres.stashapp.api.type.SceneFilterType
+import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.data.Performer
 import com.github.damontecres.stashapp.suppliers.SceneDataSupplier
 
@@ -21,6 +23,10 @@ class PerformerActivity : FragmentActivity() {
                     R.id.performer_list_fragment,
                     StashGridFragment(
                         sceneComparator, SceneDataSupplier(
+                            FindFilterType(
+                                sort = Optional.present("date"),
+                                direction = Optional.present(SortDirectionEnum.DESC)
+                            ),
                             SceneFilterType(
                                 performers = Optional.present(
                                     MultiCriterionInput(

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerListActivity.kt
@@ -3,7 +3,10 @@ package com.github.damontecres.stashapp
 import android.os.Bundle
 import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.suppliers.PerformerDataSupplier
+import kotlinx.coroutines.launch
 
 class PerformerListActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -11,14 +14,22 @@ class PerformerListActivity : FragmentActivity() {
         setContentView(R.layout.activity_tag)
         if (savedInstanceState == null) {
             findViewById<TextView>(R.id.tag_title).text = "Performers"
-            getSupportFragmentManager().beginTransaction()
-                .replace(
-                    R.id.tag_fragment,
-                    StashGridFragment(
-                        performerComparator, PerformerDataSupplier()
+
+            val queryEngine = QueryEngine(this, true)
+            lifecycleScope.launch {
+                val filter = queryEngine.getDefaultFilter(DataType.PERFORMER)
+                getSupportFragmentManager().beginTransaction()
+                    .replace(
+                        R.id.tag_fragment,
+                        StashGridFragment(
+                            performerComparator, PerformerDataSupplier(
+                                convertFilter(filter?.find_filter),
+                                convertPerformerObjectFilter(filter?.object_filter)
+                            )
+                        )
                     )
-                )
-                .commitNow()
+                    .commitNow()
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.github.damontecres.stashapp.api.FindPerformersQuery
+import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.FindScenesQuery
 import com.github.damontecres.stashapp.api.FindStudiosQuery
 import com.github.damontecres.stashapp.api.FindTagsQuery
@@ -151,6 +152,11 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
         val tags =
             executeQuery(query).data?.findTags?.tags?.map { fromFindTag(it) }
         return tags.orEmpty()
+    }
+
+    suspend fun getSavedFilter(filterId: String): FindSavedFilterQuery.FindSavedFilter? {
+        val query = FindSavedFilterQuery(filterId)
+        return executeQuery(query).data?.findSavedFilter
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -17,6 +17,7 @@ import com.github.damontecres.stashapp.api.FindScenesQuery
 import com.github.damontecres.stashapp.api.FindStudiosQuery
 import com.github.damontecres.stashapp.api.FindTagsQuery
 import com.github.damontecres.stashapp.api.fragment.PerformerData
+import com.github.damontecres.stashapp.api.fragment.SavedFilterData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.api.fragment.StudioData
 import com.github.damontecres.stashapp.api.type.FindFilterType
@@ -154,9 +155,9 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
         return tags.orEmpty()
     }
 
-    suspend fun getSavedFilter(filterId: String): FindSavedFilterQuery.FindSavedFilter? {
+    suspend fun getSavedFilter(filterId: String): SavedFilterData? {
         val query = FindSavedFilterQuery(filterId)
-        return executeQuery(query).data?.findSavedFilter
+        return executeQuery(query).data?.findSavedFilter?.savedFilterData
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -93,9 +93,9 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
     ): List<SlimSceneData> {
         val query = client.query(
             FindScenesQuery(
-                filter = Optional.presentIfNotNull(findFilter),
-                scene_filter = Optional.presentIfNotNull(sceneFilter),
-                scene_ids = Optional.presentIfNotNull(sceneIds)
+                filter = findFilter,
+                scene_filter = sceneFilter,
+                scene_ids = sceneIds
             )
         )
         val scenes = executeQuery(query).data?.findScenes?.scenes?.map {
@@ -111,9 +111,9 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
     ): List<PerformerData> {
         val query = client.query(
             FindPerformersQuery(
-                filter = Optional.presentIfNotNull(findFilter),
-                performer_filter = Optional.presentIfNotNull(performerFilter),
-                performer_ids = Optional.presentIfNotNull(performerIds)
+                filter = findFilter,
+                performer_filter = performerFilter,
+                performer_ids = performerIds
             )
         )
         val performers = executeQuery(query).data?.findPerformers?.performers?.map {
@@ -129,8 +129,8 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
     ): List<StudioData> {
         val query = client.query(
             FindStudiosQuery(
-                filter = Optional.presentIfNotNull(findFilter),
-                studio_filter = Optional.presentIfNotNull(studioFilter),
+                filter = findFilter,
+                studio_filter = studioFilter,
             )
         )
         val studios = executeQuery(query).data?.findStudios?.studios?.map {
@@ -145,8 +145,8 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
     ): List<Tag> {
         val query = client.query(
             FindTagsQuery(
-                filter = Optional.presentIfNotNull(findFilter),
-                tag_filter = Optional.presentIfNotNull(tagFilter)
+                filter = findFilter,
+                tag_filter = tagFilter
             )
         )
         val tags =

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -11,6 +11,7 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.github.damontecres.stashapp.api.FindDefaultFilterQuery
 import com.github.damontecres.stashapp.api.FindPerformersQuery
 import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.FindScenesQuery
@@ -25,6 +26,7 @@ import com.github.damontecres.stashapp.api.type.PerformerFilterType
 import com.github.damontecres.stashapp.api.type.SceneFilterType
 import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Tag
 import com.github.damontecres.stashapp.data.fromFindTag
 
@@ -158,6 +160,12 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
     suspend fun getSavedFilter(filterId: String): SavedFilterData? {
         val query = FindSavedFilterQuery(filterId)
         return executeQuery(query).data?.findSavedFilter?.savedFilterData
+    }
+
+    suspend fun getDefaultFilter(type: DataType): SavedFilterData? {
+        val query = FindDefaultFilterQuery(type.filterMode)
+        return executeQuery(query).data?.findDefaultFilter?.savedFilterData
+
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException

--- a/app/src/main/java/com/github/damontecres/stashapp/SceneListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SceneListActivity.kt
@@ -3,21 +3,36 @@ package com.github.damontecres.stashapp
 import android.os.Bundle
 import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.suppliers.SceneDataSupplier
+import kotlinx.coroutines.launch
 
 
 class SceneListActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_tag)
-        if (savedInstanceState == null) {
-            findViewById<TextView>(R.id.tag_title).text = "Scenes"
-            getSupportFragmentManager().beginTransaction()
-                .replace(
-                    R.id.tag_fragment,
-                    StashGridFragment(sceneComparator, SceneDataSupplier())
-                )
-                .commitNow()
+
+        val queryEngine = QueryEngine(this, true)
+        lifecycleScope.launch {
+            val filter = queryEngine.getDefaultFilter(DataType.SCENE)
+
+            if (savedInstanceState == null) {
+                findViewById<TextView>(R.id.tag_title).text = "Scenes"
+                getSupportFragmentManager().beginTransaction()
+                    .replace(
+                        R.id.tag_fragment,
+                        StashGridFragment(
+                            sceneComparator,
+                            SceneDataSupplier(
+                                convertFilter(filter?.find_filter),
+                                convertSceneObjectFilter(filter?.object_filter)
+                            )
+                        )
+                    )
+                    .commitNow()
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -13,6 +13,8 @@ import androidx.paging.cachedIn
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.DiffUtil
 import com.apollographql.apollo3.api.Query
+import com.github.damontecres.stashapp.api.FindDefaultFilterQuery
+import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.presenters.StashPagingSource
 import com.github.damontecres.stashapp.presenters.stashPresenterSelector
 import kotlinx.coroutines.flow.collectLatest
@@ -63,8 +65,13 @@ class StashGridFragment<T : Query.Data, D : Any>(
             .cachedIn(viewLifecycleOwner.lifecycleScope)
 
         viewLifecycleOwner.lifecycleScope.launch {
-            flow.collectLatest {
-                mAdapter.submitData(it)
+            val queryEngine = QueryEngine(requireContext(), true)
+            val query = FindDefaultFilterQuery(FilterMode.TAGS)
+
+            viewLifecycleOwner.lifecycleScope.launch {
+                flow.collectLatest {
+                    mAdapter.submitData(it)
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/StudioActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StudioActivity.kt
@@ -5,8 +5,10 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
 import com.apollographql.apollo3.api.Optional
 import com.github.damontecres.stashapp.api.type.CriterionModifier
+import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.HierarchicalMultiCriterionInput
 import com.github.damontecres.stashapp.api.type.SceneFilterType
+import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.suppliers.SceneDataSupplier
 
 
@@ -23,6 +25,10 @@ class StudioActivity : FragmentActivity() {
                     R.id.tag_fragment,
                     StashGridFragment(
                         sceneComparator, SceneDataSupplier(
+                            FindFilterType(
+                                sort = Optional.present("date"),
+                                direction = Optional.present(SortDirectionEnum.DESC)
+                            ),
                             SceneFilterType(
                                 studios = Optional.present(
                                     HierarchicalMultiCriterionInput(

--- a/app/src/main/java/com/github/damontecres/stashapp/StudioListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StudioListActivity.kt
@@ -3,7 +3,10 @@ package com.github.damontecres.stashapp
 import android.os.Bundle
 import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.suppliers.StudioDataSupplier
+import kotlinx.coroutines.launch
 
 class StudioListActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -11,14 +14,22 @@ class StudioListActivity : FragmentActivity() {
         setContentView(R.layout.activity_tag)
         if (savedInstanceState == null) {
             findViewById<TextView>(R.id.tag_title).text = "Studios"
-            getSupportFragmentManager().beginTransaction()
-                .replace(
-                    R.id.tag_fragment,
-                    StashGridFragment(
-                        studioComparator, StudioDataSupplier()
+            val queryEngine = QueryEngine(this, true)
+            lifecycleScope.launch {
+                val filter = queryEngine.getDefaultFilter(DataType.STUDIO)
+
+                getSupportFragmentManager().beginTransaction()
+                    .replace(
+                        R.id.tag_fragment,
+                        StashGridFragment(
+                            studioComparator, StudioDataSupplier(
+                                convertFilter(filter?.find_filter),
+                                convertStudioObjectFilter(filter?.object_filter)
+                            )
+                        )
                     )
-                )
-                .commitNow()
+                    .commitNow()
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/TagActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/TagActivity.kt
@@ -5,8 +5,10 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
 import com.apollographql.apollo3.api.Optional
 import com.github.damontecres.stashapp.api.type.CriterionModifier
+import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.HierarchicalMultiCriterionInput
 import com.github.damontecres.stashapp.api.type.SceneFilterType
+import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.data.Tag
 import com.github.damontecres.stashapp.suppliers.SceneDataSupplier
 
@@ -23,6 +25,10 @@ class TagActivity : FragmentActivity() {
                     R.id.tag_fragment,
                     StashGridFragment(
                         sceneComparator, SceneDataSupplier(
+                            FindFilterType(
+                                sort = Optional.present("date"),
+                                direction = Optional.present(SortDirectionEnum.DESC)
+                            ),
                             SceneFilterType(
                                 tags = Optional.present(
                                     HierarchicalMultiCriterionInput(

--- a/app/src/main/java/com/github/damontecres/stashapp/TagListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/TagListActivity.kt
@@ -3,7 +3,10 @@ package com.github.damontecres.stashapp
 import android.os.Bundle
 import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.suppliers.TagDataSupplier
+import kotlinx.coroutines.launch
 
 class TagListActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -11,14 +14,22 @@ class TagListActivity : FragmentActivity() {
         setContentView(R.layout.activity_tag)
         if (savedInstanceState == null) {
             findViewById<TextView>(R.id.tag_title).text = "Tags"
-            getSupportFragmentManager().beginTransaction()
-                .replace(
-                    R.id.tag_fragment,
-                    StashGridFragment(
-                        tagComparator, TagDataSupplier()
+            val queryEngine = QueryEngine(this, true)
+            lifecycleScope.launch {
+                val filter = queryEngine.getDefaultFilter(DataType.TAG)
+                getSupportFragmentManager().beginTransaction()
+                    .replace(
+                        R.id.tag_fragment,
+                        StashGridFragment(
+                            tagComparator,
+                            TagDataSupplier(
+                                convertFilter(filter?.find_filter),
+                                convertTagObjectFilter(filter?.object_filter)
+                            )
+                        )
                     )
-                )
-                .commitNow()
+                    .commitNow()
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
@@ -1,0 +1,11 @@
+package com.github.damontecres.stashapp.data
+
+import com.github.damontecres.stashapp.api.type.FilterMode
+
+enum class DataType(val filterMode: FilterMode) {
+
+    PERFORMER(FilterMode.PERFORMERS),
+    SCENE(FilterMode.SCENES),
+    STUDIO(FilterMode.STUDIOS),
+    TAG(FilterMode.TAGS)
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPagingSource.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPagingSource.kt
@@ -9,6 +9,7 @@ import com.github.damontecres.stashapp.QueryEngine
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.data.CountAndList
+import com.github.damontecres.stashapp.data.DataType
 
 /**
  * A PagingSource for Stash
@@ -28,6 +29,9 @@ class StashPagingSource<T : Query.Data, D : Any>(
     private val queryEngine = QueryEngine(context, showToasts)
 
     interface DataSupplier<T : Query.Data, D : Any> {
+
+        val dataType: DataType
+
         /**
          * Create query with the given filter
          *
@@ -48,12 +52,7 @@ class StashPagingSource<T : Query.Data, D : Any>(
          *
          * By default, this sorts by name ascending
          */
-        fun getDefaultFilter(): FindFilterType {
-            return FindFilterType(
-                sort = Optional.present("name"),
-                direction = Optional.present(SortDirectionEnum.ASC)
-            )
-        }
+        fun getDefaultFilter(): FindFilterType
     }
 
     private suspend fun fetchPage(page: Int): CountAndList<D> {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPagingSource.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPagingSource.kt
@@ -7,7 +7,6 @@ import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Query
 import com.github.damontecres.stashapp.QueryEngine
 import com.github.damontecres.stashapp.api.type.FindFilterType
-import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.data.CountAndList
 import com.github.damontecres.stashapp.data.DataType
 

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/PerformerDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/PerformerDataSupplier.kt
@@ -7,13 +7,16 @@ import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.PerformerFilterType
 import com.github.damontecres.stashapp.data.CountAndList
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.presenters.StashPagingSource
 
-class PerformerDataSupplier(private val performerFilter: PerformerFilterType?) :
+class PerformerDataSupplier(
+    private val findFilter: FindFilterType?,
+    private val performerFilter: PerformerFilterType?
+) :
     StashPagingSource.DataSupplier<FindPerformersQuery.Data, PerformerData> {
 
-    constructor() : this(null) {
-    }
+    override val dataType: DataType get() = DataType.PERFORMER
 
     override fun createQuery(filter: FindFilterType?): Query<FindPerformersQuery.Data> {
         return FindPerformersQuery(
@@ -21,6 +24,10 @@ class PerformerDataSupplier(private val performerFilter: PerformerFilterType?) :
             performer_filter = performerFilter,
             performer_ids = null
         )
+    }
+
+    override fun getDefaultFilter(): FindFilterType {
+        return findFilter ?: FindFilterType()
     }
 
     override fun parseQuery(data: FindPerformersQuery.Data?): CountAndList<PerformerData> {

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/PerformerDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/PerformerDataSupplier.kt
@@ -17,8 +17,9 @@ class PerformerDataSupplier(private val performerFilter: PerformerFilterType?) :
 
     override fun createQuery(filter: FindFilterType?): Query<FindPerformersQuery.Data> {
         return FindPerformersQuery(
-            filter = Optional.presentIfNotNull(filter),
-            performer_filter = Optional.presentIfNotNull(performerFilter)
+            filter = filter,
+            performer_filter = performerFilter,
+            performer_ids = null
         )
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/PerformerDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/PerformerDataSupplier.kt
@@ -1,6 +1,5 @@
 package com.github.damontecres.stashapp.suppliers
 
-import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Query
 import com.github.damontecres.stashapp.api.FindPerformersQuery
 import com.github.damontecres.stashapp.api.fragment.PerformerData

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/SceneDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/SceneDataSupplier.kt
@@ -14,8 +14,9 @@ class SceneDataSupplier(private val sceneFilter: SceneFilterType? = null) :
     StashPagingSource.DataSupplier<FindScenesQuery.Data, SlimSceneData> {
     override fun createQuery(filter: FindFilterType?): Query<FindScenesQuery.Data> {
         return FindScenesQuery(
-            filter = Optional.presentIfNotNull(filter),
-            scene_filter = Optional.presentIfNotNull(sceneFilter)
+            filter = filter,
+            scene_filter = sceneFilter,
+            scene_ids = null
         )
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/SceneDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/SceneDataSupplier.kt
@@ -8,10 +8,17 @@ import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SceneFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.data.CountAndList
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.presenters.StashPagingSource
 
-class SceneDataSupplier(private val sceneFilter: SceneFilterType? = null) :
+class SceneDataSupplier(
+    private val findFilter: FindFilterType?,
+    private val sceneFilter: SceneFilterType? = null
+) :
     StashPagingSource.DataSupplier<FindScenesQuery.Data, SlimSceneData> {
+
+    override val dataType: DataType get() = DataType.SCENE
+
     override fun createQuery(filter: FindFilterType?): Query<FindScenesQuery.Data> {
         return FindScenesQuery(
             filter = filter,
@@ -27,9 +34,6 @@ class SceneDataSupplier(private val sceneFilter: SceneFilterType? = null) :
     }
 
     override fun getDefaultFilter(): FindFilterType {
-        return FindFilterType(
-            sort = Optional.present("date"),
-            direction = Optional.present(SortDirectionEnum.DESC)
-        )
+        return findFilter ?: FindFilterType()
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/SceneDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/SceneDataSupplier.kt
@@ -1,12 +1,10 @@
 package com.github.damontecres.stashapp.suppliers
 
-import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Query
 import com.github.damontecres.stashapp.api.FindScenesQuery
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SceneFilterType
-import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.data.CountAndList
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.presenters.StashPagingSource

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/StudioDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/StudioDataSupplier.kt
@@ -16,8 +16,8 @@ class StudioDataSupplier(private val studioFilter: StudioFilterType?) :
 
     override fun createQuery(filter: FindFilterType?): Query<FindStudiosQuery.Data> {
         return FindStudiosQuery(
-            filter = Optional.presentIfNotNull(filter),
-            studio_filter = Optional.presentIfNotNull(studioFilter)
+            filter = filter,
+            studio_filter = studioFilter
         )
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/StudioDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/StudioDataSupplier.kt
@@ -1,6 +1,5 @@
 package com.github.damontecres.stashapp.suppliers
 
-import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Query
 import com.github.damontecres.stashapp.api.FindStudiosQuery
 import com.github.damontecres.stashapp.api.fragment.StudioData

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/StudioDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/StudioDataSupplier.kt
@@ -7,18 +7,26 @@ import com.github.damontecres.stashapp.api.fragment.StudioData
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.data.CountAndList
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.presenters.StashPagingSource
 
-class StudioDataSupplier(private val studioFilter: StudioFilterType?) :
+class StudioDataSupplier(
+    private val findFilter: FindFilterType?,
+    private val studioFilter: StudioFilterType?
+) :
     StashPagingSource.DataSupplier<FindStudiosQuery.Data, StudioData> {
 
-    constructor() : this(null)
+    override val dataType: DataType get() = DataType.STUDIO
 
     override fun createQuery(filter: FindFilterType?): Query<FindStudiosQuery.Data> {
         return FindStudiosQuery(
             filter = filter,
             studio_filter = studioFilter
         )
+    }
+
+    override fun getDefaultFilter(): FindFilterType {
+        return findFilter ?: FindFilterType()
     }
 
     override fun parseQuery(data: FindStudiosQuery.Data?): CountAndList<StudioData> {

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/TagDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/TagDataSupplier.kt
@@ -6,20 +6,28 @@ import com.github.damontecres.stashapp.api.FindTagsQuery
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.data.CountAndList
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Tag
 import com.github.damontecres.stashapp.data.fromFindTag
 import com.github.damontecres.stashapp.presenters.StashPagingSource
 
-class TagDataSupplier(private val tagFilter: TagFilterType?) :
+class TagDataSupplier(
+    private val findFilter: FindFilterType?,
+    private val tagFilter: TagFilterType?
+) :
     StashPagingSource.DataSupplier<FindTagsQuery.Data, Tag> {
 
-    constructor() : this(null)
+    override val dataType: DataType get() = DataType.TAG
 
     override fun createQuery(filter: FindFilterType?): Query<FindTagsQuery.Data> {
         return FindTagsQuery(
             filter = filter,
             tag_filter = tagFilter
         )
+    }
+
+    override fun getDefaultFilter(): FindFilterType {
+        return findFilter ?: FindFilterType()
     }
 
     override fun parseQuery(data: FindTagsQuery.Data?): CountAndList<Tag> {

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/TagDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/TagDataSupplier.kt
@@ -17,8 +17,8 @@ class TagDataSupplier(private val tagFilter: TagFilterType?) :
 
     override fun createQuery(filter: FindFilterType?): Query<FindTagsQuery.Data> {
         return FindTagsQuery(
-            filter = Optional.presentIfNotNull(filter),
-            tag_filter = Optional.presentIfNotNull(tagFilter)
+            filter = filter,
+            tag_filter = tagFilter
         )
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/TagDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/TagDataSupplier.kt
@@ -1,6 +1,5 @@
 package com.github.damontecres.stashapp.suppliers
 
-import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Query
 import com.github.damontecres.stashapp.api.FindTagsQuery
 import com.github.damontecres.stashapp.api.type.FindFilterType


### PR DESCRIPTION
Closes #17

This PR does two major things:
1. Use the UI configured on the Stash server for the main page
2. Use the default filters for supported data types on their respective list pages

This significantly aligns the app's UI with the web UI.

A significant amount of manual parsing is done for object filters since they do not have a graphql schema. I have not tested every single possible filter, but I suspect most (or all) will work just fine.