### PR TITLE
Use a tag for the stash server submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "stash"]
 	path = stash-server
 	url = https://github.com/stashapp/stash.git
-	branch = develop
+	tag = v0.24.1


### PR DESCRIPTION
Use a tagged release of `stashapp/stash` instead of the `develop` branch.

I generally want the Android TV to work with the latest released Stash version.