### PR TITLE
Fix parsing saved filters

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,11 @@ apollo {
         packageName.set("com.github.damontecres.stashapp.api")
         schemaFiles.setFrom(fileTree("../stash-server/graphql/schema/").filter { it.extension == "graphql" }.files.map { it.path })
         generateOptionalOperationVariables.set(false)
+        outputDirConnection {
+            // Fixes where classes aren't detected in unit tests
+            // See: https://community.apollographql.com/t/android-warning-duplicate-content-roots-detected-after-just-adding-apollo3-kotlin-client/4529/6
+            connectToKotlinSourceSet("main")
+        }
     }
 }
 
@@ -90,4 +95,5 @@ dependencies {
 
     implementation("com.apollographql.apollo3:apollo-runtime:3.8.2")
     implementation("androidx.preference:preference-ktx:1.2.1")
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -234,7 +234,7 @@ fun convertIntCriterionInput(it: Map<String, *>?): IntCriterionInput? {
     return if (it != null) {
         val values = it["value"]!! as Map<String, Int?>
         IntCriterionInput(
-            values["value"] ?: -1,
+            values["value"] ?: 0,
             Optional.presentIfNotNull(values["value2"]),
             CriterionModifier.valueOf(it["modifier"]!! as String)
         )
@@ -247,7 +247,7 @@ fun convertFloatCriterionInput(it: Map<String, *>?): FloatCriterionInput? {
     return if (it != null) {
         val values = it["value"]!! as Map<String, Number?> // Might be an int or double
         FloatCriterionInput(
-            values["value"]?.toDouble() ?: -1.0,
+            values["value"]?.toDouble() ?: 0.0,
             Optional.presentIfNotNull(values["value2"]?.toDouble()),
             CriterionModifier.valueOf(it["modifier"]!! as String)
         )

--- a/app/src/test/java/com/github/damontecres/stashapp/ObjectFilterParsingTests.kt
+++ b/app/src/test/java/com/github/damontecres/stashapp/ObjectFilterParsingTests.kt
@@ -1,0 +1,75 @@
+package com.github.damontecres.stashapp
+
+import com.apollographql.apollo3.api.json.BufferedSourceJsonReader
+import com.apollographql.apollo3.api.parseJsonResponse
+import com.github.damontecres.stashapp.api.FindSavedFilterQuery
+import com.github.damontecres.stashapp.api.fragment.SavedFilterData
+import com.github.damontecres.stashapp.api.type.FilterMode
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import org.junit.Assert
+import org.junit.Test
+
+class ObjectFilterParsingTests {
+
+    /**
+     * Get the SavedFilterData from a json file resource
+     */
+    private fun getSavedFilterData(file: String): SavedFilterData {
+        val path = file.toPath()
+        FileSystem.RESOURCES.read(path) {
+            val jsonReader = BufferedSourceJsonReader(this)
+            val response = FindSavedFilterQuery("1").parseJsonResponse(jsonReader)
+            return response.data!!.findSavedFilter!!.savedFilterData
+        }
+    }
+
+    @Test
+    fun testSceneFilter() {
+        val savedFilterData = getSavedFilterData("scene_savedfilter.json")
+        val sceneFilter =
+            convertSceneObjectFilter(savedFilterData.object_filter)
+        Assert.assertNotNull(sceneFilter!!)
+        Assert.assertEquals(FilterMode.SCENES, savedFilterData.mode)
+        Assert.assertEquals(
+            "33",
+            sceneFilter.studios.getOrThrow()!!.value.getOrThrow()!!.first()
+        )
+        Assert.assertEquals(
+            listOf("8", "148"),
+            sceneFilter.tags.getOrThrow()!!.value.getOrThrow()!!
+        )
+        Assert.assertEquals(
+            1,
+            sceneFilter.play_count.getOrThrow()!!.value
+        )
+        Assert.assertEquals(
+            4,
+            sceneFilter.resume_time.getOrThrow()!!.value
+        )
+        Assert.assertEquals(
+            9,
+            sceneFilter.resume_time.getOrThrow()!!.value2.getOrThrow()!!
+        )
+        Assert.assertEquals(
+            "2024-01-01 23:00",
+            sceneFilter.updated_at.getOrThrow()!!.value
+        )
+    }
+
+    @Test
+    fun testPerformerFilter() {
+        val savedFilterData = getSavedFilterData("performer_savedfilter.json")
+        val performerFilter = convertPerformerObjectFilter(savedFilterData.object_filter)
+        Assert.assertNotNull(performerFilter!!)
+        Assert.assertEquals(FilterMode.PERFORMERS, savedFilterData.mode)
+
+        Assert.assertEquals(3, performerFilter.tags.getOrThrow()!!.value.getOrThrow()!!.size)
+        Assert.assertEquals(3, performerFilter.studios.getOrThrow()!!.value.getOrThrow()!!.size)
+        Assert.assertEquals(1, performerFilter.studios.getOrThrow()!!.excludes.getOrThrow()!!.size)
+        Assert.assertEquals(
+            "94",
+            performerFilter.studios.getOrThrow()!!.excludes.getOrThrow()!!.first()
+        )
+    }
+}

--- a/app/src/test/resources/performer_savedfilter.json
+++ b/app/src/test/resources/performer_savedfilter.json
@@ -1,0 +1,252 @@
+{
+  "data": {
+    "findSavedFilter": {
+      "id": "8",
+      "mode": "PERFORMERS",
+      "name": "Test Filter",
+      "find_filter": {
+        "q": "",
+        "page": 1,
+        "per_page": 40,
+        "sort": "name",
+        "direction": "ASC",
+        "__typename": "SavedFindFilterType"
+      },
+      "object_filter": {
+        "age": {
+          "modifier": "EQUALS",
+          "value": {
+            "value": 25
+          }
+        },
+        "aliases": {
+          "modifier": "INCLUDES",
+          "value": "alias"
+        },
+        "birth_year": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": 1990
+          }
+        },
+        "birthdate": {
+          "modifier": "NOT_BETWEEN",
+          "value": {
+            "value": "1990-01-05",
+            "value2": "1990-01-01"
+          }
+        },
+        "career_length": {
+          "modifier": "NOT_EQUALS",
+          "value": "66"
+        },
+        "circumcised": {
+          "modifier": "INCLUDES",
+          "value": [
+            "Uncut"
+          ]
+        },
+        "country": {
+          "modifier": "EXCLUDES",
+          "value": "USA"
+        },
+        "created_at": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": "2023-12-31 00:00"
+          }
+        },
+        "death_date": {
+          "modifier": "IS_NULL",
+          "value": {
+            "value": ""
+          }
+        },
+        "death_year": {
+          "modifier": "NOT_NULL",
+          "value": {}
+        },
+        "details": {
+          "modifier": "INCLUDES",
+          "value": "words"
+        },
+        "disambiguation": {
+          "modifier": "NOT_MATCHES_REGEX",
+          "value": "regex"
+        },
+        "ethnicity": {
+          "modifier": "NOT_EQUALS",
+          "value": "eth"
+        },
+        "eye_color": {
+          "modifier": "INCLUDES",
+          "value": "blue"
+        },
+        "fake_tits": {
+          "modifier": "EQUALS",
+          "value": "yes"
+        },
+        "filter_favorites": {
+          "modifier": "EQUALS",
+          "value": "false"
+        },
+        "gallery_count": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": 4
+          }
+        },
+        "gender": {
+          "modifier": "EQUALS",
+          "value": "Female"
+        },
+        "hair_color": {
+          "modifier": "NOT_MATCHES_REGEX",
+          "value": "dddd"
+        },
+        "height_cm": {
+          "modifier": "LESS_THAN",
+          "value": {
+            "value": 200
+          }
+        },
+        "ignore_auto_tag": {
+          "modifier": "EQUALS",
+          "value": "true"
+        },
+        "image_count": {
+          "modifier": "NOT_EQUALS",
+          "value": {
+            "value": 1
+          }
+        },
+        "is_missing": {
+          "modifier": "EQUALS",
+          "value": "piercings"
+        },
+        "measurements": {
+          "modifier": "INCLUDES",
+          "value": "something"
+        },
+        "name": {
+          "modifier": "EXCLUDES",
+          "value": "name"
+        },
+        "o_counter": {
+          "modifier": "LESS_THAN",
+          "value": {
+            "value": 5
+          }
+        },
+        "penis_length": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": 11
+          }
+        },
+        "piercings": {
+          "modifier": "NOT_NULL",
+          "value": ""
+        },
+        "rating100": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": 20
+          }
+        },
+        "scene_count": {
+          "modifier": "LESS_THAN",
+          "value": {
+            "value": 55
+          }
+        },
+        "stash_id_endpoint": {
+          "modifier": "IS_NULL",
+          "value": {
+            "endpoint": "endpoint",
+            "stashID": ""
+          }
+        },
+        "studios": {
+          "modifier": "INCLUDES",
+          "value": {
+            "depth": 0,
+            "excluded": [
+              {
+                "id": "94",
+                "label": "Excluded Studio"
+              }
+            ],
+            "items": [
+              {
+                "id": "1",
+                "label": "Studio1"
+              },
+              {
+                "id": "2",
+                "label": "Studio2"
+              },
+              {
+                "id": "3",
+                "label": "Studio3"
+              }
+            ]
+          }
+        },
+        "tag_count": {
+          "modifier": "BETWEEN",
+          "value": {
+            "value": 7,
+            "value2": 10
+          }
+        },
+        "tags": {
+          "modifier": "INCLUDES_ALL",
+          "value": {
+            "depth": 1,
+            "excluded": [],
+            "items": [
+              {
+                "id": "1",
+                "label": "Tag1"
+              },
+              {
+                "id": "11",
+                "label": "Tag2"
+              },
+              {
+                "id": "33",
+                "label": "Tag3"
+              }
+            ]
+          }
+        },
+        "tattoos": {
+          "modifier": "IS_NULL",
+          "value": ""
+        },
+        "updated_at": {
+          "modifier": "LESS_THAN",
+          "value": {
+            "value": "2024-01-01 14:00"
+          }
+        },
+        "url": {
+          "modifier": "NOT_NULL",
+          "value": ""
+        },
+        "weight": {
+          "modifier": "LESS_THAN",
+          "value": {
+            "value": 196
+          }
+        }
+      },
+      "ui_options": {
+        "display_mode": 0,
+        "zoom_index": 1
+      },
+      "__typename": "SavedFilter"
+    }
+  }
+}

--- a/app/src/test/resources/scene_savedfilter.json
+++ b/app/src/test/resources/scene_savedfilter.json
@@ -1,0 +1,262 @@
+{
+  "data": {
+    "findSavedFilter": {
+      "id": "1",
+      "mode": "SCENES",
+      "name": "Test filter",
+      "find_filter": {
+        "q": "",
+        "page": 1,
+        "per_page": 40,
+        "sort": "created_at",
+        "direction": "DESC",
+        "__typename": "SavedFindFilterType"
+      },
+      "object_filter": {
+        "audio_codec": {
+          "modifier": "EQUALS",
+          "value": "aac"
+        },
+        "captions": {
+          "modifier": "EXCLUDES",
+          "value": "English"
+        },
+        "checksum": {
+          "modifier": "NOT_NULL",
+          "value": ""
+        },
+        "code": {
+          "modifier": "NOT_NULL",
+          "value": ""
+        },
+        "created_at": {
+          "modifier": "BETWEEN",
+          "value": {
+            "value": "2024-01-01 10:30",
+            "value2": "2024-01-05 11:00"
+          }
+        },
+        "date": {
+          "modifier": "LESS_THAN",
+          "value": {
+            "value": "2024-01-05"
+          }
+        },
+        "details": {
+          "modifier": "INCLUDES",
+          "value": "something"
+        },
+        "director": {
+          "modifier": "MATCHES_REGEX",
+          "value": "test(\\w+)"
+        },
+        "duplicated": {
+          "modifier": "EQUALS",
+          "value": "true"
+        },
+        "duration": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": 10
+          }
+        },
+        "file_count": {
+          "modifier": "NOT_BETWEEN",
+          "value": {
+            "value": 2,
+            "value2": 6
+          }
+        },
+        "framerate": {
+          "modifier": "NOT_EQUALS",
+          "value": {
+            "value": 24
+          }
+        },
+        "has_markers": {
+          "modifier": "EQUALS",
+          "value": "false"
+        },
+        "interactive": {
+          "modifier": "EQUALS",
+          "value": "true"
+        },
+        "interactive_speed": {
+          "modifier": "EQUALS",
+          "value": {
+            "value": 12
+          }
+        },
+        "is_missing": {
+          "modifier": "EQUALS",
+          "value": "movie"
+        },
+        "movies": {
+          "modifier": "NOT_NULL",
+          "value": []
+        },
+        "o_counter": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": 1
+          }
+        },
+        "organized": {
+          "modifier": "EQUALS",
+          "value": "false"
+        },
+        "oshash": {
+          "modifier": "NOT_MATCHES_REGEX",
+          "value": "\\s\\s\\d{1,2}"
+        },
+        "path": {
+          "modifier": "NOT_NULL",
+          "value": ""
+        },
+        "performer_age": {
+          "modifier": "LESS_THAN",
+          "value": {
+            "value": 35
+          }
+        },
+        "performer_count": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": 2
+          }
+        },
+        "performer_favorite": {
+          "modifier": "EQUALS",
+          "value": "true"
+        },
+        "performer_tags": {
+          "modifier": "INCLUDES_ALL",
+          "value": {
+            "depth": -1,
+            "excluded": [],
+            "items": [
+              {
+                "id": "8",
+                "label": "Anal"
+              }
+            ]
+          }
+        },
+        "performers": {
+          "modifier": "INCLUDES",
+          "value": {
+            "excluded": [],
+            "items": [
+              {
+                "id": "1131",
+                "label": "Aaron"
+              }
+            ]
+          }
+        },
+        "phash_distance": {
+          "modifier": "NOT_EQUALS",
+          "value": {
+            "distance": 0,
+            "value": "aaa"
+          }
+        },
+        "play_count": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": 1
+          }
+        },
+        "play_duration": {
+          "modifier": "LESS_THAN",
+          "value": {
+            "value": 5085
+          }
+        },
+        "rating100": {
+          "modifier": "EQUALS",
+          "value": {
+            "value": 80
+          }
+        },
+        "resolution": {
+          "modifier": "EQUALS",
+          "value": "1080p"
+        },
+        "resume_time": {
+          "modifier": "BETWEEN",
+          "value": {
+            "value": 4,
+            "value2": 9
+          }
+        },
+        "stash_id_endpoint": {
+          "modifier": "IS_NULL",
+          "value": {
+            "endpoint": "1234",
+            "stashID": ""
+          }
+        },
+        "studios": {
+          "modifier": "INCLUDES",
+          "value": {
+            "depth": 0,
+            "excluded": [],
+            "items": [
+              {
+                "id": "33",
+                "label": "Test Studio"
+              }
+            ]
+          }
+        },
+        "tag_count": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": 2
+          }
+        },
+        "tags": {
+          "modifier": "INCLUDES_ALL",
+          "value": {
+            "depth": 0,
+            "excluded": [],
+            "items": [
+              {
+                "id": "8",
+                "label": "AAA"
+              },
+              {
+                "id": "148",
+                "label": "BBB"
+              }
+            ]
+          }
+        },
+        "title": {
+          "modifier": "EXCLUDES",
+          "value": "whatever"
+        },
+        "updated_at": {
+          "modifier": "GREATER_THAN",
+          "value": {
+            "value": "2024-01-01 23:00"
+          }
+        },
+        "url": {
+          "modifier": "NOT_NULL",
+          "value": ""
+        },
+        "video_codec": {
+          "modifier": "INCLUDES",
+          "value": "264"
+        }
+      },
+      "ui_options": {
+        "display_mode": 0,
+        "zoom_index": 1
+      },
+      "__typename": "SavedFilter"
+    }
+  }
+}


### PR DESCRIPTION
Follow up to #22

Adds some basic unit tests for parsing saved filters for scenes & performers by adding a filter for every available attribute.

These tests uncovered some bugs in the parsing code which are now fixed.