### PR TITLE
Add basic support for movies

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,6 +86,14 @@
             android:name=".FilterListActivity"
             android:exported="false"
             android:theme="@style/NoTitleTheme" />
+        <activity
+            android:name=".MovieActivity"
+            android:exported="false"
+            android:theme="@style/NoTitleTheme" />
+        <activity
+            android:name=".MovieListActivity"
+            android:exported="false"
+            android:theme="@style/NoTitleTheme" />
 
     </application>
 

--- a/app/src/main/graphql/FindMovies.graphql
+++ b/app/src/main/graphql/FindMovies.graphql
@@ -1,0 +1,21 @@
+query FindMovies($filter: FindFilterType, $movie_filter: MovieFilterType){
+  findMovies(filter: $filter, movie_filter: $movie_filter){
+    count
+    movies{
+      ...MovieData
+    }
+  }
+}
+
+fragment MovieData on Movie {
+  id
+  name
+  aliases
+  studio {
+    id
+    name
+  }
+  scene_count
+  front_image_path
+  back_image_path
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/Comparators.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Comparators.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.stashapp
 
 import androidx.recyclerview.widget.DiffUtil
+import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.api.fragment.StudioData
@@ -65,6 +66,22 @@ object TagComparator : DiffUtil.ItemCallback<Tag>() {
     override fun areContentsTheSame(
         oldItem: Tag,
         newItem: Tag,
+    ): Boolean {
+        return oldItem == newItem
+    }
+}
+
+object MovieComparator : DiffUtil.ItemCallback<MovieData>() {
+    override fun areItemsTheSame(
+        oldItem: MovieData,
+        newItem: MovieData,
+    ): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(
+        oldItem: MovieData,
+        newItem: MovieData,
     ): Boolean {
         return oldItem == newItem
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -21,13 +21,13 @@ import com.github.damontecres.stashapp.api.type.CircumcisionCriterionInput
 import com.github.damontecres.stashapp.api.type.CircumisedEnum
 import com.github.damontecres.stashapp.api.type.CriterionModifier
 import com.github.damontecres.stashapp.api.type.DateCriterionInput
-import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.FloatCriterionInput
 import com.github.damontecres.stashapp.api.type.GenderCriterionInput
 import com.github.damontecres.stashapp.api.type.GenderEnum
 import com.github.damontecres.stashapp.api.type.HierarchicalMultiCriterionInput
 import com.github.damontecres.stashapp.api.type.IntCriterionInput
+import com.github.damontecres.stashapp.api.type.MovieFilterType
 import com.github.damontecres.stashapp.api.type.MultiCriterionInput
 import com.github.damontecres.stashapp.api.type.PHashDuplicationCriterionInput
 import com.github.damontecres.stashapp.api.type.PerformerFilterType
@@ -40,6 +40,7 @@ import com.github.damontecres.stashapp.api.type.StringCriterionInput
 import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.api.type.TimestampCriterionInput
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 
 object Constants {
@@ -244,8 +245,7 @@ fun convertFilter(filter: SavedFilterData.Find_filter?): FindFilterType? {
     }
 }
 
-val supportedFilterModes =
-    setOf(FilterMode.SCENES, FilterMode.STUDIOS, FilterMode.PERFORMERS, FilterMode.TAGS)
+val supportedFilterModes = DataType.entries.map { it.filterMode }.toSet()
 
 fun convertIntCriterionInput(it: Map<String, *>?): IntCriterionInput? {
     return if (it != null) {
@@ -645,6 +645,28 @@ fun convertTagObjectFilter(f: Any?): TagFilterType? {
             ignore_auto_tag = Optional.presentIfNotNull(convertBoolean(filter.get("ignore_auto_tag"))),
             created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter.get("created_at"))),
             updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter.get("updated_at"))),
+        )
+    } else {
+        null
+    }
+}
+
+fun convertMovieObjectFilter(f: Any?): MovieFilterType? {
+    return if (f != null) {
+        val filter = f as Map<String, Map<String, *>>
+        MovieFilterType(
+            name = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("name"))),
+            director = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("director"))),
+            synopsis = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("synopsis"))),
+            duration = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("duration"))),
+            rating100 = Optional.presentIfNotNull(convertIntCriterionInput(filter?.get("rating100"))),
+            studios = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter?.get("studios"))),
+            is_missing = Optional.presentIfNotNull(convertString(filter?.get("is_missing"))),
+            url = Optional.presentIfNotNull(convertStringCriterionInput(filter?.get("url"))),
+            performers = Optional.presentIfNotNull(convertMultiCriterionInput(filter?.get("performers"))),
+            date = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("date"))),
+            created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
+            updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
         )
     } else {
         null

--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo3.api.Query
 import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
+import com.github.damontecres.stashapp.suppliers.MovieDataSupplier
 import com.github.damontecres.stashapp.suppliers.PerformerDataSupplier
 import com.github.damontecres.stashapp.suppliers.SceneDataSupplier
 import com.github.damontecres.stashapp.suppliers.StudioDataSupplier
@@ -46,6 +47,11 @@ class FilterListActivity : SecureFragmentActivity() {
                 val tagFilter =
                     convertTagObjectFilter(objectFilter)
                 StashGridFragment(TagComparator, TagDataSupplier(findFilter, tagFilter))
+            }
+
+            FilterMode.MOVIES -> {
+                val movieFilter = convertMovieObjectFilter(objectFilter)
+                StashGridFragment(MovieComparator, MovieDataSupplier(findFilter, movieFilter))
             }
 
             else -> {

--- a/app/src/main/java/com/github/damontecres/stashapp/MainTitleView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainTitleView.kt
@@ -55,7 +55,12 @@ class MainTitleView : RelativeLayout, TitleViewAdapter.Provider {
                 v.animate().scaleX(zoom).scaleY(zoom).setDuration(mScaleDurationMs.toLong()).start()
 
                 if (hasFocus) {
-                    v.setBackgroundColor(ContextCompat.getColor(context, R.color.selected_background))
+                    v.setBackgroundColor(
+                        ContextCompat.getColor(
+                            context,
+                            R.color.selected_background,
+                        ),
+                    )
                 } else {
                     v.setBackgroundColor(
                         ContextCompat.getColor(
@@ -95,6 +100,13 @@ class MainTitleView : RelativeLayout, TitleViewAdapter.Provider {
             startActivity(context, intent, null)
         }
         tagsButton.onFocusChangeListener = onFocusChangeListener
+
+        val moviesButton = root.findViewById<Button>(R.id.movies_button)
+        moviesButton.setOnClickListener {
+            val intent = Intent(context, MovieListActivity::class.java)
+            startActivity(context, intent, null)
+        }
+        moviesButton.onFocusChangeListener = onFocusChangeListener
     }
 
     override fun getTitleViewAdapter(): TitleViewAdapter {

--- a/app/src/main/java/com/github/damontecres/stashapp/MovieActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MovieActivity.kt
@@ -1,0 +1,45 @@
+package com.github.damontecres.stashapp
+
+import android.os.Bundle
+import com.apollographql.apollo3.api.Optional
+import com.github.damontecres.stashapp.api.type.CriterionModifier
+import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.api.type.MultiCriterionInput
+import com.github.damontecres.stashapp.api.type.SceneFilterType
+import com.github.damontecres.stashapp.api.type.SortDirectionEnum
+import com.github.damontecres.stashapp.data.Movie
+import com.github.damontecres.stashapp.suppliers.SceneDataSupplier
+
+class MovieActivity : SecureFragmentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_performer)
+        if (savedInstanceState == null) {
+            val movie = this.intent.getParcelableExtra<Movie>("movie")
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.performer_fragment, MovieFragment())
+                .replace(
+                    R.id.performer_list_fragment,
+                    StashGridFragment(
+                        SceneComparator,
+                        SceneDataSupplier(
+                            FindFilterType(
+                                sort = Optional.present("movie_scene_number"),
+                                direction = Optional.present(SortDirectionEnum.DESC),
+                            ),
+                            SceneFilterType(
+                                movies =
+                                    Optional.present(
+                                        MultiCriterionInput(
+                                            value = Optional.present(listOf(movie?.id.toString())),
+                                            modifier = CriterionModifier.INCLUDES,
+                                        ),
+                                    ),
+                            ),
+                        ),
+                    ),
+                )
+                .commitNow()
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/MovieActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MovieActivity.kt
@@ -25,7 +25,7 @@ class MovieActivity : SecureFragmentActivity() {
                         SceneDataSupplier(
                             FindFilterType(
                                 sort = Optional.present("movie_scene_number"),
-                                direction = Optional.present(SortDirectionEnum.DESC),
+                                direction = Optional.present(SortDirectionEnum.ASC),
                             ),
                             SceneFilterType(
                                 movies =

--- a/app/src/main/java/com/github/damontecres/stashapp/MovieFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MovieFragment.kt
@@ -1,0 +1,49 @@
+package com.github.damontecres.stashapp
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.bumptech.glide.Glide
+import com.github.damontecres.stashapp.data.Movie
+import kotlinx.coroutines.async
+
+class MovieFragment : Fragment(R.layout.performer_view) {
+    private lateinit var mPerformerImage: ImageView
+    private lateinit var mPerformerName: TextView
+    private lateinit var mPerformerDisambiguation: TextView
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        mPerformerImage = view.findViewById(R.id.performer_image)
+        mPerformerName = view.findViewById(R.id.performer_name)
+        mPerformerDisambiguation = view.findViewById(R.id.performer_disambiguation)
+
+        val movie = requireActivity().intent.getParcelableExtra<Movie>("movie")
+        if (movie != null) {
+            mPerformerName.text = movie.name
+            mPerformerDisambiguation.text = movie.aliases
+
+            if (movie.front_image_path != null) {
+                viewLifecycleOwner.lifecycleScope.async {
+                    val url = createGlideUrl(movie.front_image_path, requireContext())
+                    Glide.with(requireActivity())
+                        .load(url)
+                        .centerCrop()
+                        .error(R.drawable.default_background)
+                        .into(mPerformerImage)
+                }
+            }
+        } else {
+            val intent = Intent(requireActivity(), MainActivity::class.java)
+            startActivity(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/MovieListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MovieListActivity.kt
@@ -1,0 +1,35 @@
+package com.github.damontecres.stashapp
+
+import android.os.Bundle
+import android.widget.TextView
+import androidx.lifecycle.lifecycleScope
+import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.suppliers.MovieDataSupplier
+import kotlinx.coroutines.launch
+
+class MovieListActivity : SecureFragmentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_tag)
+        if (savedInstanceState == null) {
+            findViewById<TextView>(R.id.tag_title).text = "Movies"
+
+            val queryEngine = QueryEngine(this, true)
+            lifecycleScope.launch {
+                val filter = queryEngine.getDefaultFilter(DataType.MOVIE)
+                supportFragmentManager.beginTransaction()
+                    .replace(
+                        R.id.tag_fragment,
+                        StashGridFragment(
+                            MovieComparator,
+                            MovieDataSupplier(
+                                convertFilter(filter?.find_filter),
+                                convertMovieObjectFilter(filter?.object_filter),
+                            ),
+                        ),
+                    )
+                    .commitNow()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -11,16 +11,19 @@ import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.github.damontecres.stashapp.api.FindDefaultFilterQuery
+import com.github.damontecres.stashapp.api.FindMoviesQuery
 import com.github.damontecres.stashapp.api.FindPerformersQuery
 import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.FindScenesQuery
 import com.github.damontecres.stashapp.api.FindStudiosQuery
 import com.github.damontecres.stashapp.api.FindTagsQuery
+import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SavedFilterData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.api.fragment.StudioData
 import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.api.type.MovieFilterType
 import com.github.damontecres.stashapp.api.type.PerformerFilterType
 import com.github.damontecres.stashapp.api.type.SceneFilterType
 import com.github.damontecres.stashapp.api.type.StudioFilterType
@@ -159,6 +162,21 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
             )
         val tags =
             executeQuery(query).data?.findTags?.tags?.map { fromFindTag(it) }
+        return tags.orEmpty()
+    }
+
+    suspend fun findMovies(
+        findFilter: FindFilterType? = null,
+        movieFilter: MovieFilterType? = null,
+    ): List<MovieData> {
+        val query =
+            client.query(
+                FindMoviesQuery(
+                    filter = findFilter,
+                    movie_filter = movieFilter,
+                ),
+            )
+        val tags = executeQuery(query).data?.findMovies?.movies?.map { it.movieData }
         return tags.orEmpty()
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
@@ -9,12 +9,14 @@ import androidx.leanback.widget.OnItemViewClickedListener
 import androidx.leanback.widget.Presenter
 import androidx.leanback.widget.Row
 import androidx.leanback.widget.RowPresenter
+import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.api.fragment.StudioData
 import com.github.damontecres.stashapp.data.StashCustomFilter
 import com.github.damontecres.stashapp.data.StashSavedFilter
 import com.github.damontecres.stashapp.data.Tag
+import com.github.damontecres.stashapp.data.fromMovieData
 import com.github.damontecres.stashapp.data.performerFromPerformerData
 import com.github.damontecres.stashapp.data.sceneFromSlimSceneData
 
@@ -72,6 +74,10 @@ class StashItemViewClickListener(private val activity: Activity) : OnItemViewCli
                     DetailsActivity.SHARED_ELEMENT_NAME,
                 ).toBundle()
             activity.startActivity(intent, bundle)
+        } else if (item is MovieData) {
+            val intent = Intent(activity, MovieActivity::class.java)
+            intent.putExtra("movie", fromMovieData(item))
+            activity.startActivity(intent)
         } else if (item is StashSavedFilter) {
             val intent = Intent(activity, FilterListActivity::class.java)
             intent.putExtra("savedFilterId", item.savedFilterId)

--- a/app/src/main/java/com/github/damontecres/stashapp/StashSearchFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashSearchFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo3.api.Optional
 import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.presenters.MoviePresenter
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
 import com.github.damontecres.stashapp.presenters.StudioPresenter
@@ -30,6 +31,7 @@ class StashSearchFragment : SearchSupportFragment(), SearchSupportFragment.Searc
     private val studioAdapter = ArrayObjectAdapter(StudioPresenter())
     private val performerAdapter = ArrayObjectAdapter(PerformerPresenter())
     private val tagAdapter = ArrayObjectAdapter(TagPresenter())
+    private val movieAdapter = ArrayObjectAdapter(MoviePresenter())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,6 +41,7 @@ class StashSearchFragment : SearchSupportFragment(), SearchSupportFragment.Searc
         rowsAdapter.add(ListRow(HeaderItem("Studios"), studioAdapter))
         rowsAdapter.add(ListRow(HeaderItem("Performers"), performerAdapter))
         rowsAdapter.add(ListRow(HeaderItem("Tags"), tagAdapter))
+        rowsAdapter.add(ListRow(HeaderItem("Movies"), movieAdapter))
     }
 
     override fun getResultsAdapter(): ObjectAdapter {
@@ -72,6 +75,7 @@ class StashSearchFragment : SearchSupportFragment(), SearchSupportFragment.Searc
         studioAdapter.clear()
         performerAdapter.clear()
         tagAdapter.clear()
+        movieAdapter.clear()
 
         if (!TextUtils.isEmpty(query)) {
             val perPage =
@@ -94,6 +98,9 @@ class StashSearchFragment : SearchSupportFragment(), SearchSupportFragment.Searc
             }
             viewLifecycleOwner.lifecycleScope.async {
                 tagAdapter.addAll(0, queryEngine.findTags(filter))
+            }
+            viewLifecycleOwner.lifecycleScope.async {
+                movieAdapter.addAll(0, queryEngine.findMovies(filter))
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
@@ -7,4 +7,5 @@ enum class DataType(val filterMode: FilterMode) {
     SCENE(FilterMode.SCENES),
     STUDIO(FilterMode.STUDIOS),
     TAG(FilterMode.TAGS),
+    MOVIE(FilterMode.MOVIES),
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/data/Movie.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/Movie.kt
@@ -1,0 +1,26 @@
+package com.github.damontecres.stashapp.data
+
+import android.os.Parcelable
+import com.github.damontecres.stashapp.api.fragment.MovieData
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Movie(
+    val id: String,
+    val name: String,
+    val aliases: String?,
+    val studioId: String?,
+    val front_image_path: String?,
+    val back_image_path: String?,
+) : Parcelable
+
+fun fromMovieData(movie: MovieData): Movie {
+    return Movie(
+        movie.id,
+        movie.name,
+        movie.aliases,
+        movie.studio?.id,
+        movie.front_image_path,
+        movie.back_image_path,
+    )
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MoviePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MoviePresenter.kt
@@ -1,0 +1,39 @@
+package com.github.damontecres.stashapp.presenters
+
+import androidx.leanback.widget.ImageCardView
+import androidx.preference.PreferenceManager
+import com.bumptech.glide.Glide
+import com.github.damontecres.stashapp.api.fragment.MovieData
+import com.github.damontecres.stashapp.createGlideUrl
+
+class MoviePresenter : StashPresenter() {
+    override fun onBindViewHolder(
+        viewHolder: ViewHolder,
+        item: Any?,
+    ) {
+        val movie = item as MovieData
+        val cardView = viewHolder.view as ImageCardView
+
+        if (movie.front_image_path != null) {
+            cardView.titleText = movie.name
+            cardView.contentText = "${movie.scene_count} Scenes"
+            cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
+            val apiKey =
+                PreferenceManager.getDefaultSharedPreferences(vParent.context)
+                    .getString("stashApiKey", "")
+            val url = createGlideUrl(movie.front_image_path, apiKey)
+            Glide.with(viewHolder.view.context)
+                .load(url)
+                .centerCrop()
+                .error(mDefaultCardImage)
+                .into(cardView.mainImageView!!)
+        }
+    }
+
+    companion object {
+        private const val TAG = "CardPresenter"
+
+        const val CARD_HEIGHT = 381
+        const val CARD_WIDTH = CARD_HEIGHT * 2 / 3
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -7,6 +7,7 @@ import androidx.leanback.widget.ClassPresenterSelector
 import androidx.leanback.widget.ImageCardView
 import androidx.leanback.widget.Presenter
 import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.api.fragment.StudioData
@@ -73,6 +74,7 @@ abstract class StashPresenter : Presenter() {
                 .addClassPresenter(SlimSceneData::class.java, ScenePresenter())
                 .addClassPresenter(StudioData::class.java, StudioPresenter())
                 .addClassPresenter(Tag::class.java, TagPresenter())
+                .addClassPresenter(MovieData::class.java, MoviePresenter())
                 .addClassPresenter(StashSavedFilter::class.java, StashFilterPresenter())
                 .addClassPresenter(StashCustomFilter::class.java, StashFilterPresenter())
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/MovieDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/MovieDataSupplier.kt
@@ -1,0 +1,38 @@
+package com.github.damontecres.stashapp.suppliers
+
+import com.apollographql.apollo3.api.Query
+import com.github.damontecres.stashapp.api.FindMoviesQuery
+import com.github.damontecres.stashapp.api.fragment.MovieData
+import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.api.type.MovieFilterType
+import com.github.damontecres.stashapp.data.CountAndList
+import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.presenters.StashPagingSource
+
+class MovieDataSupplier(
+    private val findFilter: FindFilterType?,
+    private val movieFilter: MovieFilterType?,
+) :
+    StashPagingSource.DataSupplier<FindMoviesQuery.Data, MovieData> {
+    override val dataType: DataType get() = DataType.PERFORMER
+
+    override fun createQuery(filter: FindFilterType?): Query<FindMoviesQuery.Data> {
+        return FindMoviesQuery(
+            filter = filter,
+            movie_filter = movieFilter,
+        )
+    }
+
+    override fun getDefaultFilter(): FindFilterType {
+        return findFilter ?: FindFilterType()
+    }
+
+    override fun parseQuery(data: FindMoviesQuery.Data?): CountAndList<MovieData> {
+        val count = data?.findMovies?.count ?: -1
+        val performers =
+            data?.findMovies?.movies?.map {
+                it.movieData
+            }.orEmpty()
+        return CountAndList(count, performers)
+    }
+}

--- a/app/src/main/res/layout/title.xml
+++ b/app/src/main/res/layout/title.xml
@@ -29,11 +29,19 @@
         style="@style/TitleBarButton" />
 
     <Button
+        android:id="@+id/movies_button"
+        android:text="Movies"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:layout_toEndOf="@+id/scenes_button"
+        style="@style/TitleBarButton" />
+
+    <Button
         android:id="@+id/performers_button"
         android:text="Performers"
         android:layout_width="120dp"
         android:layout_height="80dp"
-        android:layout_toEndOf="@+id/scenes_button"
+        android:layout_toEndOf="@+id/movies_button"
         style="@style/TitleBarButton" />
 
     <Button


### PR DESCRIPTION
A big step for #21 & part of #13

Adds basic support for movies which just lists the scenes that are part of a movie. It reuses the performer view which is not great.

Searching, default filters, etc are all supported