### PR TITLE
Add preference for which stream to use

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -220,10 +220,10 @@ fun selectStream(scene: Scene?): String? {
     }
     var stream = scene.streams["Direct stream"]
     if (stream == null) {
-        stream = scene.streams["WEBM"]
+        stream = scene.streams["DASH"]
     }
     if (stream == null) {
-        stream = scene.streams["MP4"]
+        stream = scene.streams["WEBM"]
     }
     if (stream == null) {
         stream = scene.streamUrl

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -41,7 +41,6 @@ import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.api.type.TimestampCriterionInput
 import com.github.damontecres.stashapp.data.DataType
-import com.github.damontecres.stashapp.data.Scene
 
 object Constants {
     /**
@@ -212,23 +211,6 @@ suspend fun testStashConnection(
         }
     }
     return false
-}
-
-fun selectStream(scene: Scene?): String? {
-    if (scene == null) {
-        return null
-    }
-    var stream = scene.streams["Direct stream"]
-    if (stream == null) {
-        stream = scene.streams["DASH"]
-    }
-    if (stream == null) {
-        stream = scene.streams["WEBM"]
-    }
-    if (stream == null) {
-        stream = scene.streamUrl
-    }
-    return stream
 }
 
 fun convertFilter(filter: SavedFilterData.Find_filter?): FindFilterType? {

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
@@ -54,14 +54,14 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         mTransportControlGlue.subtitle = scene?.details
         mTransportControlGlue.playWhenPrepared()
 
-        val streamChoice =
-            PreferenceManager.getDefaultSharedPreferences(requireContext())
-                .getString("stream_choice", "MP4")
-        val streamUrl =
-            scene?.streams?.getOrDefault(
-                "Direct stream",
-                scene.streams.getOrDefault(streamChoice, scene.streamUrl),
-            )
+        var streamUrl = scene?.streams?.get("Direct stream")
+        if (streamUrl == null) {
+            val streamChoice =
+                PreferenceManager.getDefaultSharedPreferences(requireContext())
+                    .getString("stream_choice", "MP4")
+            streamUrl = scene?.streams?.get(streamChoice)
+        }
+
         if (streamUrl != null) {
             playerAdapter.setDataSource(Uri.parse(streamUrl))
             if (position > 0) {

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
@@ -54,7 +54,14 @@ class PlaybackVideoFragment : VideoSupportFragment() {
         mTransportControlGlue.subtitle = scene?.details
         mTransportControlGlue.playWhenPrepared()
 
-        val streamUrl = selectStream(scene)
+        val streamChoice =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getString("stream_choice", "MP4")
+        val streamUrl =
+            scene?.streams?.getOrDefault(
+                "Direct stream",
+                scene.streams.getOrDefault(streamChoice, scene.streamUrl),
+            )
         if (streamUrl != null) {
             playerAdapter.setDataSource(Uri.parse(streamUrl))
             if (position > 0) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,12 +1,8 @@
 <resources>
-    <!-- Reply Preference -->
-    <string-array name="reply_entries">
-        <item>Reply</item>
-        <item>Reply to all</item>
-    </string-array>
-
-    <string-array name="reply_values">
-        <item>reply</item>
-        <item>reply_all</item>
+    <string-array name="stream_options">
+        <item>MP4</item>
+        <item>WEBM</item>
+        <item>HLS</item>
+        <item>DASH</item>
     </string-array>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,5 +1,4 @@
-<PreferenceScreen
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory app:title="@string/pref_stash_server">
@@ -17,7 +16,7 @@
         <Preference
             app:key="testStashServer"
             app:title="Test Connection"
-            app:summary="Test connecting to Stash using the above settings"/>
+            app:summary="Test connecting to Stash using the above settings" />
 
     </PreferenceCategory>
 
@@ -29,8 +28,7 @@
             app:showSeekBarValue="true"
             android:min="1"
             android:max="100"
-            app:defaultValue="25"
-            />
+            app:defaultValue="25" />
         <SeekBarPreference
             app:key="searchDelay"
             app:title="Wait for searching (ms)"
@@ -38,8 +36,7 @@
             app:showSeekBarValue="true"
             android:min="50"
             android:max="2000"
-            app:defaultValue="500"
-            />
+            app:defaultValue="500" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Interface">
@@ -50,8 +47,7 @@
             app:showSeekBarValue="true"
             android:min="1"
             android:max="12"
-            app:defaultValue="5"
-            />
+            app:defaultValue="5" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Playback">
@@ -62,8 +58,7 @@
             app:showSeekBarValue="true"
             android:min="5"
             android:max="300"
-            app:defaultValue="30"
-            />
+            app:defaultValue="30" />
         <SeekBarPreference
             app:key="skip_back_time"
             app:title="Skip back (seconds)"
@@ -71,19 +66,25 @@
             app:showSeekBarValue="true"
             android:min="5"
             android:max="300"
-            app:defaultValue="10"
-            />
+            app:defaultValue="10" />
+        <ListPreference
+            app:key="stream_choice"
+            app:title="Stream Choice"
+            app:summary="Which stream type to use when direct is unavailable"
+            app:defaultValue="MP4"
+            app:entries="@array/stream_options"
+            app:entryValues="@array/stream_options" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="About">
         <Preference
             app:key="versionName"
             app:title="Version"
-            app:summary=""/>
+            app:summary="" />
         <Preference
             app:key="versionCode"
             app:title="Version Code"
-            app:summary=""/>
+            app:summary="" />
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.2.0" apply false
+    id("com.android.application") version "8.2.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.10" apply false
 }


### PR DESCRIPTION
The app will always use a direct stream if possible, but if not, it will fallback on the stream selected by this new preferences. It defaults to `MP4`.

From my testing the best option can vary between devices. Maybe in the future, there will be a way to automatically select the best option.

Maybe helps with #6 