### PR TITLE
Override video details max lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,3 @@ If you plan to submit a pull request, please read the [contributing guide](CONTR
 
 ### Default filtered performers
 ![performers screenshot](https://github.com/damontecres/StashAppAndroidTV/assets/154766448/7dded398-e327-414e-a2a3-fa60c11c92f1)
-

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <integer tools:override="true" name="lb_details_description_body_max_lines">18</integer>
+</resources>


### PR DESCRIPTION
Increase the max lines from the default of 5 to 18. 18 seems to be the limit that fits on the screen well.

Ideally, the details would be "clickable" which would expand to the full description, but I haven't figured out how to add that yet. It would likely require implementing a custom `VideoDetailsFragment`/`DetailsSupportFragment`.