### PR TITLE
Fix when direction or sortBy is null from server

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -287,17 +287,23 @@ class MainFragment : BrowseSupportFragment() {
             ),
         )
         viewLifecycleOwner.lifecycleScope.launch(exHandler) {
-            val direction = frontPageFilter["direction"] as String
-            val sortBy = frontPageFilter["sortBy"] as String
+            val direction = frontPageFilter["direction"] as String?
+            val directionEnum =
+                if (direction != null) {
+                    val enum = SortDirectionEnum.safeValueOf(direction.uppercase())
+                    if (enum == SortDirectionEnum.UNKNOWN__) {
+                        SortDirectionEnum.ASC
+                    }
+                    enum
+                } else {
+                    SortDirectionEnum.ASC
+                }
+
+            val sortBy = frontPageFilter["sortBy"] as String?
             val filter =
                 FindFilterType(
-                    direction =
-                        Optional.present(
-                            SortDirectionEnum.safeValueOf(
-                                direction,
-                            ),
-                        ),
-                    sort = Optional.present(sortBy),
+                    direction = Optional.presentIfNotNull(directionEnum),
+                    sort = Optional.presentIfNotNull(sortBy),
                     per_page = Optional.present(25),
                 )
 
@@ -312,6 +318,10 @@ class MainFragment : BrowseSupportFragment() {
 
                 FilterMode.PERFORMERS -> {
                     adapter.addAll(0, queryEngine.findPerformers(filter))
+                }
+
+                FilterMode.MOVIES -> {
+                    adapter.addAll(0, queryEngine.findMovies(filter))
                 }
 
                 else -> {

--- a/app/src/main/java/com/github/damontecres/stashapp/data/StashCustomFilter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/StashCustomFilter.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class StashCustomFilter(
     val mode: FilterMode,
-    val direction: String,
-    val sortBy: String,
+    val direction: String?,
+    val sortBy: String?,
     val description: String,
 ) : Parcelable

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashFilterPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashFilterPresenter.kt
@@ -54,6 +54,13 @@ class StashFilterPresenter : StashPresenter() {
                     TagPresenter.CARD_HEIGHT,
                 )
 
+            FilterMode.MOVIES -> {
+                cardView.setMainImageDimensions(
+                    MoviePresenter.CARD_WIDTH,
+                    MoviePresenter.CARD_HEIGHT,
+                )
+            }
+
             else -> {}
         }
 


### PR DESCRIPTION
Fixes #35

We should not assume that the `direction` and/or `sortBy` is not-null as returned from the server. So this PR, updates the parsing for custom filters (aka premade filters).

Also enables Movies on the front page which was missed in #33.