### PR TITLE
Disable release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,30 +16,8 @@ jobs:
         with:
           fetch-depth: 0 # Need the tags to build
           submodules: true # Need the submodules to build
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: zulu
-          java-version: '17'
-          cache: 'gradle'
-      - name: Build app
-        run: ./gradlew assembleRelease
-      - name: Sign APK
-        uses: r0adkll/sign-android-release@v1
-        id: sign_app
-        with:
-          releaseDirectory: app/build/outputs/apk/release
-          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
-          alias: ${{ secrets.KEY_ALIAS }}
-          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
-          keyPassword: ${{ secrets.KEY_PASSWORD }}
-        env:
-          BUILD_TOOLS_VERSION: "34.0.5"
-      - name: Copy signed APK to generic name
-        run: |
-          cp ${{ steps.sign_app.outputs.signedReleaseFile }} StashAppAndroidTV.apk
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "${{ steps.sign_app.outputs.signedReleaseFile }},StashAppAndroidTV.apk"
+          artifacts: ""
           generateReleaseNotes: true


### PR DESCRIPTION
`r0adkll/sign-android-release` is unmaintained and failed for the `v0.0.5` release ([here](https://github.com/damontecres/StashAppAndroidTV/actions/runs/7496976245) & [here](https://github.com/damontecres/StashAppAndroidTV/actions/runs/7497082811)), so just remove it for now.