### PR TITLE
Better version checking & handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ The app does not auto-update, so you will need to repeat this process for each n
     - Do not enter an API Key if authentication is not enabled on your Stash server!
 1. Select `Test Connection` to verify that the app can connect to your Stash server
 
+### Compatibility
+
+The app strives to be compatible with the latest released version of Stash.
+
+Currently, the minimum supported server version is Stash `0.23.0`.
+
 ## Contributions
 
 Issues and pull requests are always welcome! UI/UX improvements are especially desired!

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -49,6 +49,38 @@ object Constants {
     const val STASH_API_HEADER = "ApiKey"
     const val PREF_KEY_STASH_URL = "stashUrl"
     const val PREF_KEY_STASH_API_KEY = "stashApi"
+
+    val MINIMUM_STASH_VERSION = Version("0.23.0")
+}
+
+data class Version(val version: String) {
+    val major: Int
+    val minor: Int
+    val patch: Int
+
+    init {
+        val splits = version.removePrefix("v").split(".").map { it.toInt() }.toList()
+        major = splits[0]
+        minor = splits[1]
+        patch = splits[2]
+    }
+
+    fun isAtLeast(version: Version): Boolean {
+        return this.major > version.major || (
+            this.major == version.major &&
+                (
+                    this.minor > version.minor || this.minor == version.minor &&
+                        this.patch >= version.patch
+                )
+        )
+    }
+}
+
+fun isStashVersionSupported(version: Version?): Boolean {
+    if (version == null) {
+        return false
+    }
+    return version.isAtLeast(Constants.MINIMUM_STASH_VERSION)
 }
 
 /**
@@ -147,7 +179,7 @@ fun createApolloClient(context: Context): ApolloClient? {
 suspend fun testStashConnection(
     context: Context,
     showToast: Boolean,
-): Boolean {
+): ServerInfoQuery.Data? {
     val client = createApolloClient(context)
     if (client == null) {
         if (showToast) {
@@ -178,7 +210,7 @@ suspend fun testStashConnection(
                         Toast.LENGTH_SHORT,
                     ).show()
                 }
-                return true
+                return info.data
             }
         } catch (ex: ApolloHttpException) {
             Log.e("Constants", "ApolloHttpException", ex)
@@ -210,7 +242,7 @@ suspend fun testStashConnection(
             }
         }
     }
-    return false
+    return null
 }
 
 fun convertFilter(filter: SavedFilterData.Find_filter?): FindFilterType? {


### PR DESCRIPTION
Adds some logic to check for the minimum supported Stash version (`0.23.0`).

I have not thoroughly vetted every version, but `0.23.0` included https://github.com/stashapp/stash/pull/4054 and all of the filter parsing code in this app depends on that change.