### PR TITLE
Retrieve & persist the resume time from the server

### DIFF
--- a/app/src/main/graphql/SaveSceneActivity.graphql
+++ b/app/src/main/graphql/SaveSceneActivity.graphql
@@ -1,0 +1,3 @@
+mutation SceneSaveActivity($scene_id: ID!, $resume_time: Float!){
+  sceneSaveActivity(id: $scene_id, resume_time: $resume_time)
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/Constants.kt
@@ -691,3 +691,13 @@ fun convertMovieObjectFilter(f: Any?): MovieFilterType? {
         null
     }
 }
+
+/**
+ * Gets the value for the key trying first the key as provided and next the key lower cased
+ */
+fun <V> Map<String, V>.getCaseInsensitive(k: String?): V? {
+    if (k == null) {
+        return null
+    }
+    return this[k] ?: this[k.lowercase()]
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MutationEngine.kt
@@ -10,6 +10,9 @@ import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.github.damontecres.stashapp.api.SceneSaveActivityMutation
 
+/**
+ * Class for sending graphql mutations
+ */
 class MutationEngine(private val context: Context, private val showToasts: Boolean = false) {
     private val client =
         createApolloClient(context) ?: throw QueryEngine.StashNotConfiguredException()
@@ -66,6 +69,12 @@ class MutationEngine(private val context: Context, private val showToasts: Boole
         }
     }
 
+    /**
+     * Saves the resume time for a given scene
+     *
+     * @param sceneId the scene ID
+     * @param position the video playback position in milliseconds
+     */
     suspend fun saveSceneActivity(
         sceneId: Long,
         position: Long,
@@ -79,7 +88,7 @@ class MutationEngine(private val context: Context, private val showToasts: Boole
     }
 
     companion object {
-        const val TAG = "mutationEngine"
+        const val TAG = "MutationEngine"
     }
 
     open class MutationException(msg: String? = null, cause: ApolloException? = null) :

--- a/app/src/main/java/com/github/damontecres/stashapp/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MutationEngine.kt
@@ -1,0 +1,87 @@
+package com.github.damontecres.stashapp
+
+import android.content.Context
+import android.util.Log
+import android.widget.Toast
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Mutation
+import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.exception.ApolloHttpException
+import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.github.damontecres.stashapp.api.SceneSaveActivityMutation
+
+class MutationEngine(private val context: Context, private val showToasts: Boolean = false) {
+    private val client =
+        createApolloClient(context) ?: throw QueryEngine.StashNotConfiguredException()
+
+    private suspend fun <D : Mutation.Data> executeMutation(mutation: Mutation<D>): ApolloResponse<D> {
+        val mutationName = mutation.name()
+        try {
+            val response = client.mutation(mutation).execute()
+            if (response.errors.isNullOrEmpty()) {
+                Log.d(TAG, "executeMutation $mutationName successful")
+                return response
+            } else {
+                val errorMsgs = response.errors!!.map { it.message }.joinToString("\n")
+                if (showToasts) {
+                    Toast.makeText(
+                        context,
+                        "${response.errors!!.size} errors in response ($mutationName)\n$errorMsgs",
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+                Log.e(TAG, "Errors in $mutationName: ${response.errors}")
+                throw MutationException("($mutationName), ${response.errors!!.size} errors in graphql response")
+            }
+        } catch (ex: ApolloNetworkException) {
+            if (showToasts) {
+                Toast.makeText(
+                    context,
+                    "Network error ($mutationName). Message: ${ex.message}, ${ex.cause?.message}",
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+            Log.e(TAG, "Network error in $mutationName", ex)
+            throw MutationException("Network error ($mutationName)", ex)
+        } catch (ex: ApolloHttpException) {
+            if (showToasts) {
+                Toast.makeText(
+                    context,
+                    "HTTP error ($mutationName). Status=${ex.statusCode}, Msg=${ex.message}",
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+            Log.e(TAG, "HTTP ${ex.statusCode} error in $mutationName", ex)
+            throw MutationException("HTTP ${ex.statusCode} ($mutationName)", ex)
+        } catch (ex: ApolloException) {
+            if (showToasts) {
+                Toast.makeText(
+                    context,
+                    "Server query error ($mutationName). Msg=${ex.message}, ${ex.cause?.message}",
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+            Log.e(TAG, "ApolloException in $mutationName", ex)
+            throw MutationException("Apollo exception ($mutationName)", ex)
+        }
+    }
+
+    suspend fun saveSceneActivity(
+        sceneId: Long,
+        position: Long,
+    ): Boolean {
+        Log.v(TAG, "SceneSaveActivity sceneId=$sceneId, position=$position")
+        val resumeTime = position / 1000.0
+        val mutation =
+            SceneSaveActivityMutation(scene_id = sceneId.toString(), resume_time = resumeTime)
+        val result = executeMutation(mutation)
+        return result.data!!.sceneSaveActivity
+    }
+
+    companion object {
+        const val TAG = "mutationEngine"
+    }
+
+    open class MutationException(msg: String? = null, cause: ApolloException? = null) :
+        RuntimeException(msg, cause)
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ServerPreferences.kt
@@ -1,0 +1,34 @@
+package com.github.damontecres.stashapp
+
+import android.content.Context
+import androidx.core.content.edit
+import com.github.damontecres.stashapp.api.ConfigurationQuery
+
+class ServerPreferences(context: Context) {
+    val preferences =
+        context.getSharedPreferences(
+            context.packageName + "_server_preferences",
+            Context.MODE_PRIVATE,
+        )
+
+    val trackActivity get() = preferences.getBoolean(PREF_TRACK_ACTIVITY, false)
+
+    /**
+     * Update the local preferences from the server configuration
+     */
+    fun updatePreferences(config: ConfigurationQuery.Configuration?) {
+        if (config != null) {
+            val ui = config.ui as Map<String, *>
+            preferences.edit {
+                putBoolean(
+                    PREF_TRACK_ACTIVITY,
+                    (ui.getCaseInsensitive(PREF_TRACK_ACTIVITY) as Boolean?) ?: false,
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val PREF_TRACK_ACTIVITY = "trackActivity"
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ServerPreferences.kt
@@ -4,6 +4,11 @@ import android.content.Context
 import androidx.core.content.edit
 import com.github.damontecres.stashapp.api.ConfigurationQuery
 
+/**
+ * Represents configuration that users have set server-side
+ *
+ * Configuration is loaded into a SharedPreferences and made available throughout the app
+ */
 class ServerPreferences(context: Context) {
     val preferences =
         context.getSharedPreferences(

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -29,6 +29,7 @@ import androidx.preference.PreferenceManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
+import com.github.damontecres.stashapp.PlaybackVideoFragment.Companion.coroutineExceptionHandler
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.data.fromSlimSceneDataTag
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
@@ -82,12 +83,22 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 if (result.resultCode == Activity.RESULT_OK) {
                     val data: Intent? = result.data
                     position = data!!.getLongExtra(POSITION_ARG, -1)
-                    if (position > 0) {
+                    if (position > 10_000) {
                         // If some of the video played, reset the available actions
                         // This also causes the focused action to default to resume which is an added bonus
                         actionAdapter.clear()
                         actionAdapter.add(Action(ACTION_RESUME_SCENE, "Resume"))
                         actionAdapter.add(Action(ACTION_PLAY_SCENE, "Restart"))
+
+                        val serverPreferences = ServerPreferences(requireContext())
+                        if (serverPreferences.trackActivity) {
+                            viewLifecycleOwner.lifecycleScope.launch(coroutineExceptionHandler) {
+                                MutationEngine(requireContext(), false).saveSceneActivity(
+                                    mSelectedMovie!!.id,
+                                    position,
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -184,12 +184,20 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 )
         }
 
-        actionAdapter.add(
-            Action(
-                ACTION_PLAY_SCENE,
-                resources.getString(R.string.play_scene),
-            ),
-        )
+        val serverPreferences = ServerPreferences(requireContext())
+        if (serverPreferences.trackActivity && mSelectedMovie?.resumeTime != null && mSelectedMovie?.resumeTime!! > 0) {
+            position = (mSelectedMovie?.resumeTime!! * 1000).toLong()
+            actionAdapter.add(Action(ACTION_RESUME_SCENE, "Resume"))
+            actionAdapter.add(Action(ACTION_PLAY_SCENE, "Restart"))
+        } else {
+            actionAdapter.add(
+                Action(
+                    ACTION_PLAY_SCENE,
+                    resources.getString(R.string.play_scene),
+                ),
+            )
+        }
+
         row.actionsAdapter = actionAdapter
 
         mAdapter.add(row)

--- a/app/src/main/java/com/github/damontecres/stashapp/data/Scene.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/Scene.kt
@@ -16,6 +16,7 @@ data class Scene(
     var studioName: String?,
     var streams: Map<String, String>,
     val duration: Double?,
+    val resumeTime: Double?,
 ) : Parcelable
 
 fun sceneFromSlimSceneData(data: SlimSceneData): Scene {
@@ -46,5 +47,6 @@ fun sceneFromSlimSceneData(data: SlimSceneData): Scene {
         studioName = data.studio?.name,
         streams = streams,
         duration = duration,
+        resumeTime = data.resume_time,
     )
 }


### PR DESCRIPTION
Closes #32 

This PR adds a few things:
1. Loading configuration from the server and persisting it locally in `ServerPreferences`
2. Adds `MutationEngine` - similar to `QueryEngine` but for submitting mutation
3. Adds `sceneSaveActivity` graphql mutation
4. Retrieves & persists the resume time from the server