### PR TITLE
Add ability to add a new tag to a scene

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -91,6 +91,10 @@
             android:name=".MovieListActivity"
             android:exported="false"
             android:theme="@style/NoTitleTheme" />
+        <activity
+            android:name=".SearchForActivity"
+            android:exported="false"
+            android:theme="@style/NoTitleTheme" />
 
     </application>
 

--- a/app/src/main/graphql/FindPerformers.graphql
+++ b/app/src/main/graphql/FindPerformers.graphql
@@ -44,7 +44,7 @@ fragment PerformerData on Performer {
   performer_count
   o_counter
   tags {
-    ...SlimTagData
+    ...TagData
     __typename
   }
   stash_ids {
@@ -57,15 +57,5 @@ fragment PerformerData on Performer {
   death_date
   hair_color
   weight
-  __typename
-}
-
-fragment SlimTagData on Tag {
-  id
-  name
-  aliases
-  image_path
-  parent_count
-  child_count
   __typename
 }

--- a/app/src/main/graphql/FindScenes.graphql
+++ b/app/src/main/graphql/FindScenes.graphql
@@ -89,11 +89,7 @@ fragment SlimSceneData on Scene {
     __typename
   }
   tags {
-    id
-    name
-    scene_count
-    performer_count
-    image_path
+    ...TagData
     __typename
   }
   performers {

--- a/app/src/main/graphql/FindTags.graphql
+++ b/app/src/main/graphql/FindTags.graphql
@@ -1,11 +1,7 @@
 query FindTags($filter: FindFilterType, $tag_filter: TagFilterType)  {
   findTags(filter: $filter, tag_filter: $tag_filter){
     tags {
-      id
-      name
-      scene_count
-      performer_count
-      image_path
+      ...TagData
       __typename
     }
     count

--- a/app/src/main/graphql/Fragments.graphql
+++ b/app/src/main/graphql/Fragments.graphql
@@ -1,0 +1,9 @@
+fragment TagData on Tag {
+  id
+  name
+  description
+  aliases
+  scene_count
+  performer_count
+  image_path
+}

--- a/app/src/main/graphql/SetTagsScene.graphql
+++ b/app/src/main/graphql/SetTagsScene.graphql
@@ -1,0 +1,8 @@
+mutation SetSceneTags($input: SceneUpdateInput!) {
+  sceneUpdate(input: $input) {
+    id
+    tags {
+      ...TagData
+    }
+  }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MutationEngine.kt
@@ -5,10 +5,13 @@ import android.util.Log
 import android.widget.Toast
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Mutation
+import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.github.damontecres.stashapp.api.SceneSaveActivityMutation
+import com.github.damontecres.stashapp.api.SetSceneTagsMutation
+import com.github.damontecres.stashapp.api.type.SceneUpdateInput
 
 /**
  * Class for sending graphql mutations
@@ -85,6 +88,23 @@ class MutationEngine(private val context: Context, private val showToasts: Boole
             SceneSaveActivityMutation(scene_id = sceneId.toString(), resume_time = resumeTime)
         val result = executeMutation(mutation)
         return result.data!!.sceneSaveActivity
+    }
+
+    suspend fun setTagsOnScene(
+        sceneId: Long,
+        tagIds: List<Int>,
+    ): SetSceneTagsMutation.SceneUpdate? {
+        Log.v(TAG, "setTagsOnScene sceneId=$sceneId, tagIds=$tagIds")
+        val mutation =
+            SetSceneTagsMutation(
+                input =
+                    SceneUpdateInput(
+                        id = sceneId.toString(),
+                        tag_ids = Optional.present(tagIds.map { it.toString() }),
+                    ),
+            )
+        val result = executeMutation(mutation)
+        return result.data?.sceneUpdate
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -31,7 +31,6 @@ import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Tag
-import com.github.damontecres.stashapp.data.fromFindTag
 import kotlin.random.Random
 
 class QueryEngine(private val context: Context, private val showToasts: Boolean = false) {
@@ -165,7 +164,7 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
                 ),
             )
         val tags =
-            executeQuery(query).data?.findTags?.tags?.map { fromFindTag(it) }
+            executeQuery(query).data?.findTags?.tags?.map { Tag(it.tagData) }
         return tags.orEmpty()
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/QueryEngine.kt
@@ -184,6 +184,22 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
         return tags.orEmpty()
     }
 
+    /**
+     * Search for a type of data with the given query. Users will need to cast the returned List.
+     */
+    suspend fun find(
+        type: DataType,
+        findFilter: FindFilterType,
+    ): List<*> {
+        return when (type) {
+            DataType.SCENE -> findScenes(findFilter)
+            DataType.PERFORMER -> findPerformers(findFilter)
+            DataType.TAG -> findTags(findFilter)
+            DataType.STUDIO -> findStudios(findFilter)
+            DataType.MOVIE -> findMovies(findFilter)
+        }
+    }
+
     suspend fun getSavedFilter(filterId: String): SavedFilterData? {
         val query = FindSavedFilterQuery(filterId)
         return executeQuery(query).data?.findSavedFilter?.savedFilterData

--- a/app/src/main/java/com/github/damontecres/stashapp/SearchForActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SearchForActivity.kt
@@ -1,0 +1,19 @@
+package com.github.damontecres.stashapp
+
+import android.os.Bundle
+import com.github.damontecres.stashapp.data.DataType
+
+/**
+ * Search for something
+ */
+class SearchForActivity : SecureFragmentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        if (savedInstanceState == null) {
+            val dataType = DataType.valueOf(intent.getStringExtra("dataType")!!)
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.main_browse_fragment, SearchForFragment(dataType)).commitNow()
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
@@ -45,11 +45,13 @@ class SearchForFragment(
     private val exceptionHandler =
         CoroutineExceptionHandler { _: CoroutineContext, ex: Throwable ->
             Log.e(TAG, "Exception in search", ex)
-            Toast.makeText(requireContext(), "Search failed: ${ex.message}", Toast.LENGTH_LONG).show()
+            Toast.makeText(requireContext(), "Search failed: ${ex.message}", Toast.LENGTH_LONG)
+                .show()
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        title = getString(dataType.pluralStringId)
         setSearchResultProvider(this)
         setOnItemViewClickedListener {
                 itemViewHolder: Presenter.ViewHolder,

--- a/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
@@ -1,0 +1,128 @@
+package com.github.damontecres.stashapp
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.text.TextUtils
+import android.util.Log
+import android.widget.Toast
+import androidx.leanback.app.SearchSupportFragment
+import androidx.leanback.widget.ArrayObjectAdapter
+import androidx.leanback.widget.HeaderItem
+import androidx.leanback.widget.ListRow
+import androidx.leanback.widget.ListRowPresenter
+import androidx.leanback.widget.ObjectAdapter
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.Row
+import androidx.leanback.widget.RowPresenter
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.PreferenceManager
+import com.apollographql.apollo3.api.Optional
+import com.github.damontecres.stashapp.api.fragment.MovieData
+import com.github.damontecres.stashapp.api.fragment.PerformerData
+import com.github.damontecres.stashapp.api.fragment.SlimSceneData
+import com.github.damontecres.stashapp.api.fragment.StudioData
+import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.data.Tag
+import com.github.damontecres.stashapp.presenters.StashPresenter
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+class SearchForFragment(
+    private val dataType: DataType,
+) :
+    SearchSupportFragment(),
+        SearchSupportFragment.SearchResultProvider {
+    private var taskJob: Job? = null
+
+    private val adapter = ArrayObjectAdapter(ListRowPresenter())
+    private val resultsAdapter = ArrayObjectAdapter(StashPresenter.SELECTOR)
+
+    private val exceptionHandler =
+        CoroutineExceptionHandler { _: CoroutineContext, ex: Throwable ->
+            Log.e(TAG, "Exception in search", ex)
+            Toast.makeText(requireContext(), "Search failed: ${ex.message}", Toast.LENGTH_LONG).show()
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setSearchResultProvider(this)
+        setOnItemViewClickedListener {
+                itemViewHolder: Presenter.ViewHolder,
+                item: Any,
+                rowViewHolder: RowPresenter.ViewHolder?,
+                row: Row?,
+            ->
+            val result = Intent()
+            val resultId =
+                when (dataType) {
+                    DataType.TAG -> (item as Tag).id.toString()
+                    DataType.SCENE -> (item as SlimSceneData).id
+                    DataType.MOVIE -> (item as MovieData).id
+                    DataType.STUDIO -> (item as StudioData).id
+                    DataType.PERFORMER -> (item as PerformerData).id
+                }
+            result.putExtra(RESULT_ID_KEY, resultId)
+            result.putExtra(ID_KEY, requireActivity().intent.getLongExtra("id", -1))
+            requireActivity().setResult(Activity.RESULT_OK, result)
+            requireActivity().finish()
+        }
+        adapter.add(ListRow(HeaderItem("Results"), resultsAdapter))
+    }
+
+    override fun getResultsAdapter(): ObjectAdapter {
+        return adapter
+    }
+
+    override fun onQueryTextChange(newQuery: String): Boolean {
+        taskJob?.cancel()
+        taskJob =
+            viewLifecycleOwner.lifecycleScope.launch {
+                val searchDelay =
+                    PreferenceManager.getDefaultSharedPreferences(requireContext())
+                        .getInt("searchDelay", 500)
+                delay(searchDelay.toLong())
+                search(newQuery)
+            }
+        return true
+    }
+
+    override fun onQueryTextSubmit(query: String): Boolean {
+        taskJob?.cancel()
+        taskJob =
+            viewLifecycleOwner.lifecycleScope.launch {
+                search(query)
+            }
+        return true
+    }
+
+    private suspend fun search(query: String) {
+        resultsAdapter.clear()
+
+        if (!TextUtils.isEmpty(query)) {
+            val perPage =
+                PreferenceManager.getDefaultSharedPreferences(requireContext())
+                    .getInt("maxSearchResults", 25)
+            val filter =
+                FindFilterType(
+                    q = Optional.present(query),
+                    per_page = Optional.present(perPage),
+                )
+            val queryEngine = QueryEngine(requireContext(), true)
+            viewLifecycleOwner.lifecycleScope.launch(exceptionHandler) {
+                resultsAdapter.addAll(0, queryEngine.find(dataType, filter))
+            }
+        }
+    }
+
+    companion object {
+        const val TAG = "SearchForFragment"
+
+        const val ID_KEY = "id"
+        const val RESULT_ID_KEY = "resultId"
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
@@ -9,6 +9,7 @@ import androidx.leanback.widget.OnItemViewClickedListener
 import androidx.leanback.widget.Presenter
 import androidx.leanback.widget.Row
 import androidx.leanback.widget.RowPresenter
+import com.github.damontecres.stashapp.actions.StashAction
 import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
@@ -23,7 +24,10 @@ import com.github.damontecres.stashapp.data.sceneFromSlimSceneData
 /**
  * A OnItemViewClickedListener that starts activities for scenes, performers, etc
  */
-class StashItemViewClickListener(private val activity: Activity) : OnItemViewClickedListener {
+class StashItemViewClickListener(
+    private val activity: Activity,
+    private val actionListener: OnItemViewClickedListener? = null,
+) : OnItemViewClickedListener {
     override fun onItemClicked(
         itemViewHolder: Presenter.ViewHolder,
         item: Any,
@@ -90,6 +94,12 @@ class StashItemViewClickListener(private val activity: Activity) : OnItemViewCli
             intent.putExtra("mode", item.mode.rawValue)
             intent.putExtra("description", item.description)
             activity.startActivity(intent)
+        } else if (item is StashAction) {
+            if (actionListener != null) {
+                actionListener.onItemClicked(itemViewHolder, item, rowViewHolder, row)
+            } else {
+                throw RuntimeException("Action $item clicked, but no actionListener was provided!")
+            }
         } else {
             Log.e(TAG, "Unknown item type: $item")
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -39,8 +39,6 @@ import com.github.damontecres.stashapp.actions.AddTagAction
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.data.Tag
-import com.github.damontecres.stashapp.data.fromSlimSceneDataTag
-import com.github.damontecres.stashapp.data.fromTagData
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
 import com.github.damontecres.stashapp.presenters.StashPresenter
@@ -130,7 +128,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                                     mSelectedMovie!!.id,
                                     tagIds,
                                 )
-                            val newTags = mutResult?.tags?.map { fromTagData(it.tagData) }
+                            val newTags = mutResult?.tags?.map { Tag(it.tagData) }
                             val newTagName =
                                 newTags?.first { it.id == tagId.toInt() }?.name
                             tagsAdapter.clear()
@@ -178,7 +176,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     queryEngine.findScenes(sceneIds = listOf(mSelectedMovie!!.id.toInt()))
                         .first()
                 if (scene.tags.isNotEmpty()) {
-                    tagsAdapter.addAll(0, scene.tags.map { fromSlimSceneDataTag(it) })
+                    tagsAdapter.addAll(0, scene.tags.map { Tag(it.tagData) })
                 }
 
                 val performerIds =

--- a/app/src/main/java/com/github/damontecres/stashapp/actions/AddTagAction.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/actions/AddTagAction.kt
@@ -1,0 +1,12 @@
+package com.github.damontecres.stashapp.actions
+
+import android.content.Context
+
+class AddTagAction : StashAction {
+    override val name: String
+        get() = "Add Tag"
+
+    override fun execute(context: Context) {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/actions/StashAction.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/actions/StashAction.kt
@@ -1,0 +1,9 @@
+package com.github.damontecres.stashapp.actions
+
+import android.content.Context
+
+interface StashAction {
+    val name: String
+
+    fun execute(context: Context)
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
@@ -1,11 +1,12 @@
 package com.github.damontecres.stashapp.data
 
+import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.type.FilterMode
 
-enum class DataType(val filterMode: FilterMode) {
-    PERFORMER(FilterMode.PERFORMERS),
-    SCENE(FilterMode.SCENES),
-    STUDIO(FilterMode.STUDIOS),
-    TAG(FilterMode.TAGS),
-    MOVIE(FilterMode.MOVIES),
+enum class DataType(val filterMode: FilterMode, val stringId: Int, val pluralStringId: Int) {
+    PERFORMER(FilterMode.PERFORMERS, R.string.stashapp_performer, R.string.stashapp_performers),
+    SCENE(FilterMode.SCENES, R.string.stashapp_scene, R.string.stashapp_scenes),
+    STUDIO(FilterMode.STUDIOS, R.string.stashapp_studio, R.string.stashapp_studios),
+    TAG(FilterMode.TAGS, R.string.stashapp_tag, R.string.stashapp_tags),
+    MOVIE(FilterMode.MOVIES, R.string.stashapp_movie, R.string.stashapp_movies),
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/data/Tag.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/Tag.kt
@@ -3,6 +3,7 @@ package com.github.damontecres.stashapp.data
 import android.os.Parcelable
 import com.github.damontecres.stashapp.api.FindTagsQuery
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
+import com.github.damontecres.stashapp.api.fragment.TagData
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -31,5 +32,15 @@ fun fromFindTag(findTag: FindTagsQuery.Tag): Tag {
         findTag.scene_count,
         findTag.performer_count,
         findTag.image_path,
+    )
+}
+
+fun fromTagData(tag: TagData): Tag {
+    return Tag(
+        tag.id.toInt(),
+        tag.name,
+        tag.scene_count,
+        tag.performer_count,
+        tag.image_path,
     )
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/data/Tag.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/Tag.kt
@@ -1,8 +1,6 @@
 package com.github.damontecres.stashapp.data
 
 import android.os.Parcelable
-import com.github.damontecres.stashapp.api.FindTagsQuery
-import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.api.fragment.TagData
 import kotlinx.parcelize.Parcelize
 
@@ -13,30 +11,8 @@ data class Tag(
     var sceneCount: Int?,
     var performerCount: Int?,
     var imagePath: String?,
-) : Parcelable
-
-fun fromSlimSceneDataTag(sceneTag: SlimSceneData.Tag): Tag {
-    return Tag(
-        sceneTag.id.toInt(),
-        sceneTag.name,
-        sceneTag.scene_count,
-        sceneTag.performer_count,
-        sceneTag.image_path,
-    )
-}
-
-fun fromFindTag(findTag: FindTagsQuery.Tag): Tag {
-    return Tag(
-        findTag.id.toInt(),
-        findTag.name,
-        findTag.scene_count,
-        findTag.performer_count,
-        findTag.image_path,
-    )
-}
-
-fun fromTagData(tag: TagData): Tag {
-    return Tag(
+) : Parcelable {
+    constructor(tag: TagData) : this(
         tag.id.toInt(),
         tag.name,
         tag.scene_count,

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ActionPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ActionPresenter.kt
@@ -1,0 +1,23 @@
+package com.github.damontecres.stashapp.presenters
+
+import androidx.leanback.widget.ImageCardView
+import com.github.damontecres.stashapp.actions.StashAction
+
+class ActionPresenter : StashPresenter() {
+    override fun onBindViewHolder(
+        viewHolder: ViewHolder,
+        item: Any,
+    ) {
+        val action = item as StashAction
+        val cardView = viewHolder.view as ImageCardView
+        cardView.titleText = action.name
+        cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
+    }
+
+    companion object {
+        private const val TAG = "ActionPresenter"
+
+        const val CARD_WIDTH = 250
+        const val CARD_HEIGHT = 250
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -7,6 +7,7 @@ import androidx.leanback.widget.ClassPresenterSelector
 import androidx.leanback.widget.ImageCardView
 import androidx.leanback.widget.Presenter
 import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.actions.AddTagAction
 import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
@@ -77,5 +78,6 @@ abstract class StashPresenter : Presenter() {
                 .addClassPresenter(MovieData::class.java, MoviePresenter())
                 .addClassPresenter(StashSavedFilter::class.java, StashFilterPresenter())
                 .addClassPresenter(StashCustomFilter::class.java, StashFilterPresenter())
+                .addClassPresenter(AddTagAction::class.java, ActionPresenter())
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/TagDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/TagDataSupplier.kt
@@ -7,7 +7,6 @@ import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.data.CountAndList
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Tag
-import com.github.damontecres.stashapp.data.fromFindTag
 import com.github.damontecres.stashapp.presenters.StashPagingSource
 
 class TagDataSupplier(
@@ -32,7 +31,7 @@ class TagDataSupplier(
         val count = data?.findTags?.count ?: -1
         val studios =
             data?.findTags?.tags?.map {
-                fromFindTag(it)
+                Tag(it.tagData)
             }.orEmpty()
         return CountAndList(count, studios)
     }


### PR DESCRIPTION
Part of #3 

Adds a new row to the video details page for actions. The only action currently is to add a tag to the scene.

This PR adds a generic "Search For" activity that allows for searching any supported data type and returning the ID of the selected item.

Also refactors the Tag parsing from graphql by introducing a fragment to reduce redundant code.