### PR TITLE
Add triggering a library scan & generate task in settings

### DIFF
--- a/app/src/main/graphql/Configuration.graphql
+++ b/app/src/main/graphql/Configuration.graphql
@@ -1,5 +1,37 @@
 query Configuration {
   configuration {
+    defaults{
+      scan{
+        scanGenerateClipPreviews
+        scanGenerateCovers
+        scanGenerateImagePreviews
+        scanGeneratePhashes
+        scanGeneratePreviews
+        scanGenerateSprites
+        scanGenerateThumbnails
+      }
+      generate{
+        clipPreviews
+        covers
+        imagePreviews
+        interactiveHeatmapsSpeeds
+        markerImagePreviews
+        markers
+        markerScreenshots
+        phashes
+        previews
+        sprites
+        transcodes
+      }
+    }
     ui
   }
+}
+
+mutation MetadataScan($input: ScanMetadataInput!){
+  metadataScan(input: $input)
+}
+
+mutation MetadataGenerate($input: GenerateMetadataInput!){
+  metadataGenerate(input: $input)
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ServerPreferences.kt
@@ -29,11 +29,65 @@ class ServerPreferences(context: Context) {
                     PREF_TRACK_ACTIVITY,
                     (ui.getCaseInsensitive(PREF_TRACK_ACTIVITY) as Boolean?) ?: false,
                 )
+
+                val scan = config.defaults.scan
+                if (scan != null) {
+                    putBoolean(PREF_SCAN_GENERATE_COVERS, scan.scanGenerateCovers)
+                    putBoolean(PREF_SCAN_GENERATE_PREVIEWS, scan.scanGeneratePreviews)
+                    putBoolean(PREF_SCAN_GENERATE_IMAGE_PREVIEWS, scan.scanGenerateImagePreviews)
+                    putBoolean(PREF_SCAN_GENERATE_SPRITES, scan.scanGenerateSprites)
+                    putBoolean(PREF_SCAN_GENERATE_PHASHES, scan.scanGeneratePhashes)
+                    putBoolean(PREF_SCAN_GENERATE_THUMBNAILS, scan.scanGenerateThumbnails)
+                    putBoolean(PREF_SCAN_GENERATE_CLIP_PREVIEWS, scan.scanGenerateClipPreviews)
+                }
+
+                val generate = config.defaults.generate
+                if (generate != null) {
+                    putBoolean(PREF_GEN_CLIP_PREVIEWS, generate.clipPreviews ?: false)
+                    putBoolean(PREF_GEN_COVERS, generate.covers ?: false)
+                    putBoolean(PREF_GEN_IMAGE_PREVIEWS, generate.imagePreviews ?: false)
+                    putBoolean(
+                        PREF_GEN_INTERACTIVE_HEATMAPS_SPEEDS,
+                        generate.interactiveHeatmapsSpeeds ?: false,
+                    )
+                    putBoolean(
+                        PREF_GEN_MARKER_IMAGE_PREVIEWS,
+                        generate.markerImagePreviews ?: false,
+                    )
+                    putBoolean(PREF_GEN_MARKERS, generate.markers ?: false)
+                    putBoolean(PREF_GEN_MARKER_SCREENSHOTS, generate.markerScreenshots ?: false)
+                    putBoolean(PREF_GEN_PHASHES, generate.phashes ?: false)
+                    putBoolean(PREF_GEN_PREVIEWS, generate.previews ?: false)
+                    putBoolean(PREF_GEN_SPRITES, generate.sprites ?: false)
+                    putBoolean(PREF_GEN_TRANSCODES, generate.transcodes ?: false)
+                }
             }
         }
     }
 
     companion object {
         const val PREF_TRACK_ACTIVITY = "trackActivity"
+
+        // Scan default settings
+        const val PREF_SCAN_GENERATE_COVERS = "scanGenerateCovers"
+        const val PREF_SCAN_GENERATE_PREVIEWS = "scanGeneratePreviews"
+        const val PREF_SCAN_GENERATE_IMAGE_PREVIEWS = "scanGenerateImagePreviews"
+        const val PREF_SCAN_GENERATE_SPRITES = "scanGenerateSprites"
+        const val PREF_SCAN_GENERATE_PHASHES = "scanGeneratePhashes"
+        const val PREF_SCAN_GENERATE_THUMBNAILS = "scanGenerateThumbnails"
+        const val PREF_SCAN_GENERATE_CLIP_PREVIEWS = "scanGenerateClipPreviews"
+
+        // Generate default settings
+        const val PREF_GEN_CLIP_PREVIEWS = "clipPreviews"
+        const val PREF_GEN_COVERS = "covers"
+        const val PREF_GEN_IMAGE_PREVIEWS = "imagePreviews"
+        const val PREF_GEN_INTERACTIVE_HEATMAPS_SPEEDS = "interactiveHeatmapsSpeeds"
+        const val PREF_GEN_MARKER_IMAGE_PREVIEWS = "markerImagePreviews"
+        const val PREF_GEN_MARKERS = "markers"
+        const val PREF_GEN_MARKER_SCREENSHOTS = "markerScreenshots"
+        const val PREF_GEN_PHASHES = "phashes"
+        const val PREF_GEN_PREVIEWS = "previews"
+        const val PREF_GEN_SPRITES = "sprites"
+        const val PREF_GEN_TRANSCODES = "transcodes"
     }
 }

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -76,6 +76,18 @@
             app:entryValues="@array/stream_options" />
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="@string/stashapp_config_tasks_job_queue">
+        <Preference
+            app:key="triggerScan"
+            app:title="Trigger Default Library Scan"
+            app:summary="@string/stashapp_config_tasks_scan_for_content_desc" />
+
+        <Preference
+            app:key="triggerGenerate"
+            app:title="Trigger Default Generate"
+            app:summary="@string/stashapp_config_tasks_generate_desc" />
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="About">
         <Preference
             app:key="versionName"


### PR DESCRIPTION
Another addition to #3 based on a [suggestion](https://github.com/damontecres/StashAppAndroidTV/issues/3#issuecomment-1872447939)

Allows for triggering a library scan and generate task using the default settings (that the server provides).

They can be triggered in the settings menu.