### PR TITLE
Add support for markers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,11 @@ You acknowledge that, if applicable, submitting and subsequent acceptance of any
 Certain assets are provided by the Stash repo (https://github.com/stashapp/stash) which is included as a submodule. Make sure to run `git submodule update --init --recursive --remote` after cloning this repo to get the latest version of the submodule.
 
 If you get compile errors such as `java.nio.file.NoSuchFileException: .../StashAppAndroidTV/app/src/main/res/mipmap-nodpi/stash_logo.png`, you need to update the submodule (or the paths in `stashapp/stash` have changed!).
+
+### Creating an object filter
+
+1. Copy the text of data class for the filter (e.g. `app/build/generated/source/apollo/app/com/github/damontecres/stashapp/api/type/SceneMarkerFilterType.kt`)
+2. Apply a find-replace
+    a. Find: `public val (\w+): Optional<(\w+)\?> = Optional.Absent,`
+    b. Replace: `$1 = Optional.presentIfNotNull(convert$2(filter["$1"])),`
+3. Copy the results to the constructor of the filter class

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
@@ -89,6 +88,10 @@
             android:theme="@style/NoTitleTheme" />
         <activity
             android:name=".MovieListActivity"
+            android:exported="false"
+            android:theme="@style/NoTitleTheme" />
+        <activity
+            android:name=".MarkerListActivity"
             android:exported="false"
             android:theme="@style/NoTitleTheme" />
         <activity

--- a/app/src/main/graphql/FindSceneMarkers.graphql
+++ b/app/src/main/graphql/FindSceneMarkers.graphql
@@ -1,0 +1,33 @@
+query FindMarkers($filter: FindFilterType, $scene_marker_filter: SceneMarkerFilterType) {
+  findSceneMarkers(filter: $filter, scene_marker_filter: $scene_marker_filter) {
+    count
+    scene_markers {
+      ...MarkerData
+    }
+    __typename
+  }
+}
+
+fragment MarkerData on SceneMarker {
+  id
+  title
+  created_at
+  updated_at
+  stream
+  screenshot
+  seconds
+  preview
+  primary_tag {
+    ...TagData
+    __typename
+  }
+  tags {
+    ...TagData
+    __typename
+  }
+  scene {
+    ...SlimSceneData
+    __typename
+  }
+  __typename
+}

--- a/app/src/main/graphql/FindScenes.graphql
+++ b/app/src/main/graphql/FindScenes.graphql
@@ -105,6 +105,16 @@ fragment SlimSceneData on Scene {
     stash_id
     __typename
   }
+  scene_markers {
+    id
+    title
+    primary_tag{
+      ...TagData
+    }
+    screenshot
+    seconds
+    __typename
+  }
   __typename
 }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -11,12 +11,14 @@ import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.suppliers.MarkerDataSupplier
 import com.github.damontecres.stashapp.suppliers.MovieDataSupplier
 import com.github.damontecres.stashapp.suppliers.PerformerDataSupplier
 import com.github.damontecres.stashapp.suppliers.SceneDataSupplier
 import com.github.damontecres.stashapp.suppliers.StudioDataSupplier
 import com.github.damontecres.stashapp.suppliers.TagDataSupplier
 import com.github.damontecres.stashapp.util.FilterParser
+import com.github.damontecres.stashapp.util.MarkerComparator
 import com.github.damontecres.stashapp.util.MovieComparator
 import com.github.damontecres.stashapp.util.PerformerComparator
 import com.github.damontecres.stashapp.util.QueryEngine
@@ -63,6 +65,11 @@ class FilterListActivity : SecureFragmentActivity() {
             DataType.MOVIE -> {
                 val movieFilter = FilterParser.instance.convertMovieObjectFilter(objectFilter)
                 StashGridFragment(MovieComparator, MovieDataSupplier(findFilter, movieFilter))
+            }
+
+            DataType.MARKER -> {
+                val markerFilter = FilterParser.instance.convertMarkerObjectFilter(objectFilter)
+                StashGridFragment(MarkerComparator, MarkerDataSupplier(findFilter, markerFilter))
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/MainTitleView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainTitleView.kt
@@ -107,6 +107,13 @@ class MainTitleView : RelativeLayout, TitleViewAdapter.Provider {
             startActivity(context, intent, null)
         }
         moviesButton.onFocusChangeListener = onFocusChangeListener
+
+        val markersButton = root.findViewById<Button>(R.id.markers_button)
+        markersButton.setOnClickListener {
+            val intent = Intent(context, MarkerListActivity::class.java)
+            startActivity(context, intent, null)
+        }
+        markersButton.onFocusChangeListener = onFocusChangeListener
     }
 
     override fun getTitleViewAdapter(): TitleViewAdapter {

--- a/app/src/main/java/com/github/damontecres/stashapp/MarkerListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MarkerListActivity.kt
@@ -1,0 +1,40 @@
+package com.github.damontecres.stashapp
+
+import android.os.Bundle
+import android.widget.TextView
+import androidx.lifecycle.lifecycleScope
+import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.suppliers.MarkerDataSupplier
+import com.github.damontecres.stashapp.util.FilterParser
+import com.github.damontecres.stashapp.util.MarkerComparator
+import com.github.damontecres.stashapp.util.QueryEngine
+import com.github.damontecres.stashapp.util.convertFilter
+import kotlinx.coroutines.launch
+
+class MarkerListActivity : SecureFragmentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_tag)
+
+        val queryEngine = QueryEngine(this, true)
+        lifecycleScope.launch {
+            val filter = queryEngine.getDefaultFilter(DataType.MARKER)
+
+            if (savedInstanceState == null) {
+                findViewById<TextView>(R.id.tag_title).text = getString(R.string.stashapp_markers)
+                supportFragmentManager.beginTransaction()
+                    .replace(
+                        R.id.tag_fragment,
+                        StashGridFragment(
+                            MarkerComparator,
+                            MarkerDataSupplier(
+                                convertFilter(filter?.find_filter),
+                                FilterParser.instance.convertMarkerObjectFilter(filter?.object_filter),
+                            ),
+                        ),
+                    )
+                    .commitNow()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
@@ -18,6 +18,7 @@ import androidx.leanback.widget.RowPresenter
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo3.api.Optional
+import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
@@ -68,6 +69,7 @@ class SearchForFragment(
                     DataType.MOVIE -> (item as MovieData).id
                     DataType.STUDIO -> (item as StudioData).id
                     DataType.PERFORMER -> (item as PerformerData).id
+                    DataType.MARKER -> (item as MarkerData).id
                 }
             result.putExtra(RESULT_ID_KEY, resultId)
             result.putExtra(ID_KEY, requireActivity().intent.getLongExtra("id", -1))

--- a/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
@@ -9,8 +9,10 @@ import androidx.leanback.widget.OnItemViewClickedListener
 import androidx.leanback.widget.Presenter
 import androidx.leanback.widget.Row
 import androidx.leanback.widget.RowPresenter
+import com.github.damontecres.stashapp.VideoDetailsFragment.Companion.POSITION_ARG
 import com.github.damontecres.stashapp.actions.StashAction
 import com.github.damontecres.stashapp.actions.StashActionClickedListener
+import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
@@ -82,6 +84,14 @@ class StashItemViewClickListener(
         } else if (item is MovieData) {
             val intent = Intent(activity, MovieActivity::class.java)
             intent.putExtra("movie", Movie(item))
+            activity.startActivity(intent)
+        } else if (item is MarkerData) {
+            val intent = Intent(activity, PlaybackActivity::class.java)
+            intent.putExtra(
+                DetailsActivity.MOVIE,
+                Scene.fromSlimSceneData(item.scene.slimSceneData),
+            )
+            intent.putExtra(POSITION_ARG, (item.seconds * 1000).toLong())
             activity.startActivity(intent)
         } else if (item is StashSavedFilter) {
             val intent = Intent(activity, FilterListActivity::class.java)

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -33,11 +33,13 @@ import com.bumptech.glide.request.transition.Transition
 import com.github.damontecres.stashapp.PlaybackVideoFragment.Companion.coroutineExceptionHandler
 import com.github.damontecres.stashapp.actions.StashAction
 import com.github.damontecres.stashapp.actions.StashActionClickedListener
+import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.data.Tag
 import com.github.damontecres.stashapp.presenters.DetailsDescriptionPresenter
+import com.github.damontecres.stashapp.presenters.MarkerPresenter
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
 import com.github.damontecres.stashapp.presenters.StashPresenter
@@ -58,6 +60,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
 
     private var performersAdapter: ArrayObjectAdapter = ArrayObjectAdapter(PerformerPresenter())
     private var tagsAdapter: ArrayObjectAdapter = ArrayObjectAdapter(TagPresenter())
+    private var markersAdapter: ArrayObjectAdapter = ArrayObjectAdapter(MarkerPresenter())
     private var actionsAdapter = ArrayObjectAdapter(StashPresenter.SELECTOR)
 
     private lateinit var mDetailsBackground: DetailsSupportFragmentBackgroundController
@@ -220,6 +223,28 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     tagsAdapter.addAll(0, scene.tags.map { Tag(it.tagData) })
                 }
 
+                if (scene.scene_markers.isNotEmpty()) {
+                    markersAdapter.addAll(
+                        0,
+                        scene.scene_markers.map {
+                            MarkerData(
+                                id = it.id,
+                                title = it.title,
+                                created_at = "",
+                                updated_at = "",
+                                stream = "",
+                                screenshot = it.screenshot,
+                                seconds = it.seconds,
+                                preview = "",
+                                primary_tag = MarkerData.Primary_tag("", it.primary_tag.tagData),
+                                scene = MarkerData.Scene("", scene),
+                                tags = emptyList(),
+                                __typename = "",
+                            )
+                        },
+                    )
+                }
+
                 val performerIds =
                     scene.performers.map {
                         it.id.toInt()
@@ -349,9 +374,15 @@ class VideoDetailsFragment : DetailsSupportFragment() {
 
     private fun setupRelatedMovieListRow() {
         // TODO related scenes
-        mAdapter.add(ListRow(HeaderItem(0, "Performers"), performersAdapter))
-        mAdapter.add(ListRow(HeaderItem(1, "Tags"), tagsAdapter))
-        mAdapter.add(ListRow(HeaderItem(2, "Actions"), actionsAdapter))
+        mAdapter.add(
+            ListRow(
+                HeaderItem(0, getString(R.string.stashapp_performers)),
+                performersAdapter,
+            ),
+        )
+        mAdapter.add(ListRow(HeaderItem(1, getString(R.string.stashapp_tags)), tagsAdapter))
+        mAdapter.add(ListRow(HeaderItem(2, getString(R.string.stashapp_markers)), markersAdapter))
+        mAdapter.add(ListRow(HeaderItem(3, "Actions"), actionsAdapter))
         mPresenterSelector.addClassPresenter(ListRow::class.java, ListRowPresenter())
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
@@ -9,6 +9,7 @@ enum class DataType(val filterMode: FilterMode, val stringId: Int, val pluralStr
     STUDIO(FilterMode.STUDIOS, R.string.stashapp_studio, R.string.stashapp_studios),
     TAG(FilterMode.TAGS, R.string.stashapp_tag, R.string.stashapp_tags),
     MOVIE(FilterMode.MOVIES, R.string.stashapp_movie, R.string.stashapp_movies),
+    MARKER(FilterMode.SCENE_MARKERS, R.string.stashapp_markers, R.string.stashapp_markers),
     ;
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
@@ -1,0 +1,40 @@
+package com.github.damontecres.stashapp.presenters
+
+import androidx.leanback.widget.ImageCardView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import com.github.damontecres.stashapp.api.fragment.MarkerData
+import com.github.damontecres.stashapp.util.createGlideUrl
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+class MarkerPresenter : StashPresenter() {
+    override fun onBindViewHolder(
+        viewHolder: ViewHolder,
+        item: Any?,
+    ) {
+        val marker = item as MarkerData
+        val cardView = viewHolder.view as ImageCardView
+        val title =
+            marker.title.ifBlank {
+                marker.primary_tag.tagData.name
+            }
+        cardView.titleText = "$title - ${marker.seconds.toInt().toDuration(DurationUnit.SECONDS)}"
+        cardView.contentText = marker.primary_tag.tagData.name
+
+        cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
+        val url = createGlideUrl(marker.screenshot, viewHolder.view.context)
+        Glide.with(viewHolder.view.context)
+            .load(url)
+            .transform(CenterCrop())
+            .error(mDefaultCardImage)
+            .into(cardView.mainImageView!!)
+    }
+
+    companion object {
+        private val TAG = "MarkerPresenter"
+
+        const val CARD_WIDTH = 351
+        const val CARD_HEIGHT = 198
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -8,6 +8,7 @@ import androidx.leanback.widget.ImageCardView
 import androidx.leanback.widget.Presenter
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.actions.StashAction
+import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
@@ -79,5 +80,6 @@ abstract class StashPresenter : Presenter() {
                 .addClassPresenter(StashSavedFilter::class.java, StashFilterPresenter())
                 .addClassPresenter(StashCustomFilter::class.java, StashFilterPresenter())
                 .addClassPresenter(StashAction::class.java, ActionPresenter())
+                .addClassPresenter(MarkerData::class.java, MarkerPresenter())
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/MarkerDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/MarkerDataSupplier.kt
@@ -1,0 +1,35 @@
+package com.github.damontecres.stashapp.suppliers
+
+import com.apollographql.apollo3.api.Query
+import com.github.damontecres.stashapp.api.FindMarkersQuery
+import com.github.damontecres.stashapp.api.fragment.MarkerData
+import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.api.type.SceneMarkerFilterType
+import com.github.damontecres.stashapp.data.CountAndList
+import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.presenters.StashPagingSource
+
+class MarkerDataSupplier(
+    private val findFilter: FindFilterType?,
+    private val markerFilter: SceneMarkerFilterType? = null,
+) :
+    StashPagingSource.DataSupplier<FindMarkersQuery.Data, MarkerData> {
+    override val dataType: DataType get() = DataType.MARKER
+
+    override fun createQuery(filter: FindFilterType?): Query<FindMarkersQuery.Data> {
+        return FindMarkersQuery(
+            filter = filter,
+            markerFilter,
+        )
+    }
+
+    override fun parseQuery(data: FindMarkersQuery.Data?): CountAndList<MarkerData> {
+        val markers = data?.findSceneMarkers?.scene_markers?.map { it.markerData }.orEmpty()
+        val count = data?.findSceneMarkers?.count ?: -1
+        return CountAndList(count, markers)
+    }
+
+    override fun getDefaultFilter(): FindFilterType {
+        return findFilter ?: FindFilterType()
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Comparators.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Comparators.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.stashapp.util
 
 import androidx.recyclerview.widget.DiffUtil
+import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
@@ -82,6 +83,22 @@ object MovieComparator : DiffUtil.ItemCallback<MovieData>() {
     override fun areContentsTheSame(
         oldItem: MovieData,
         newItem: MovieData,
+    ): Boolean {
+        return oldItem == newItem
+    }
+}
+
+object MarkerComparator : DiffUtil.ItemCallback<MarkerData>() {
+    override fun areItemsTheSame(
+        oldItem: MarkerData,
+        newItem: MarkerData,
+    ): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(
+        oldItem: MarkerData,
+        newItem: MarkerData,
     ): Boolean {
         return oldItem == newItem
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/FilterParser.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/FilterParser.kt
@@ -20,6 +20,7 @@ import com.github.damontecres.stashapp.api.type.PhashDistanceCriterionInput
 import com.github.damontecres.stashapp.api.type.ResolutionCriterionInput
 import com.github.damontecres.stashapp.api.type.ResolutionEnum
 import com.github.damontecres.stashapp.api.type.SceneFilterType
+import com.github.damontecres.stashapp.api.type.SceneMarkerFilterType
 import com.github.damontecres.stashapp.api.type.StashIDCriterionInput
 import com.github.damontecres.stashapp.api.type.StringCriterionInput
 import com.github.damontecres.stashapp.api.type.StudioFilterType
@@ -518,6 +519,24 @@ class FilterParser private constructor(context: Context, serverInfoQuery: Server
                 date = Optional.presentIfNotNull(convertDateCriterionInput(filter?.get("date"))),
                 created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("created_at"))),
                 updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter?.get("updated_at"))),
+            )
+        } else {
+            null
+        }
+    }
+
+    fun convertMarkerObjectFilter(f: Any?): SceneMarkerFilterType? {
+        return if (f != null) {
+            val filter = f as Map<String, Map<String, *>>
+            SceneMarkerFilterType(
+                tags = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter["tags"])),
+                scene_tags = Optional.presentIfNotNull(convertHierarchicalMultiCriterionInput(filter["scene_tags"])),
+                performers = Optional.presentIfNotNull(convertMultiCriterionInput(filter["performers"])),
+                created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter["created_at"])),
+                updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter["updated_at"])),
+                scene_date = Optional.presentIfNotNull(convertDateCriterionInput(filter["scene_date"])),
+                scene_created_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter["scene_created_at"])),
+                scene_updated_at = Optional.presentIfNotNull(convertTimestampCriterionInput(filter["scene_updated_at"])),
             )
         } else {
             null

--- a/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
@@ -12,12 +12,14 @@ import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.github.damontecres.stashapp.api.FindDefaultFilterQuery
+import com.github.damontecres.stashapp.api.FindMarkersQuery
 import com.github.damontecres.stashapp.api.FindMoviesQuery
 import com.github.damontecres.stashapp.api.FindPerformersQuery
 import com.github.damontecres.stashapp.api.FindSavedFilterQuery
 import com.github.damontecres.stashapp.api.FindScenesQuery
 import com.github.damontecres.stashapp.api.FindStudiosQuery
 import com.github.damontecres.stashapp.api.FindTagsQuery
+import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.MovieData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SavedFilterData
@@ -27,6 +29,7 @@ import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.MovieFilterType
 import com.github.damontecres.stashapp.api.type.PerformerFilterType
 import com.github.damontecres.stashapp.api.type.SceneFilterType
+import com.github.damontecres.stashapp.api.type.SceneMarkerFilterType
 import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.data.DataType
@@ -186,6 +189,21 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
         return tags.orEmpty()
     }
 
+    suspend fun findMarkers(
+        findFilter: FindFilterType? = null,
+        markerFilter: SceneMarkerFilterType? = null,
+    ): List<MarkerData> {
+        val query =
+            client.query(
+                FindMarkersQuery(
+                    filter = updateFilter(findFilter),
+                    scene_marker_filter = markerFilter,
+                ),
+            )
+        return executeQuery(query).data?.findSceneMarkers?.scene_markers?.map { it.markerData }
+            .orEmpty()
+    }
+
     /**
      * Search for a type of data with the given query. Users will need to cast the returned List.
      */
@@ -199,6 +217,7 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
             DataType.TAG -> findTags(findFilter)
             DataType.STUDIO -> findStudios(findFilter)
             DataType.MOVIE -> findMovies(findFilter)
+            DataType.MARKER -> findMarkers(findFilter)
         }
     }
 

--- a/app/src/main/res/layout/title.xml
+++ b/app/src/main/res/layout/title.xml
@@ -37,11 +37,19 @@
         style="@style/TitleBarButton" />
 
     <Button
+        android:id="@+id/markers_button"
+        android:text="@string/stashapp_markers"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:layout_toEndOf="@+id/movies_button"
+        style="@style/TitleBarButton" />
+
+    <Button
         android:id="@+id/performers_button"
         android:text="@string/stashapp_performers"
         android:layout_width="120dp"
         android:layout_height="80dp"
-        android:layout_toEndOf="@+id/movies_button"
+        android:layout_toEndOf="@+id/markers_button"
         style="@style/TitleBarButton" />
 
     <Button


### PR DESCRIPTION
Adds support for Scene Markers.

1. Browse the list of markers from main page top bar using the default filter
2. Browse the list of markers on the video details page

Clicking a marker will play the video at that marker point.