### PR TITLE
Support proxy by URL prefix

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -95,9 +95,13 @@ fun createApolloClient(
             cleanedStashUrl = "http://$cleanedStashUrl"
         }
         var url = Uri.parse(cleanedStashUrl)
+        val pathSegments = url.pathSegments.toMutableList()
+        if (pathSegments.isEmpty() || pathSegments.last() != "graphql") {
+            pathSegments.add("graphql")
+        }
         url =
             url.buildUpon()
-                .path("/graphql") // Ensure the URL is the graphql endpoint
+                .path(pathSegments.joinToString("/")) // Ensure the URL is the graphql endpoint
                 .build()
         Log.d(Constants.TAG, "StashUrl: $stashUrl => $url")
         ApolloClient.Builder()


### PR DESCRIPTION
Closes #58 

Use the path segments provided by the user and just ensure the last one is `graph` instead of replacing the path completely.