### PR TITLE
Use ExoPlayer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,6 +122,8 @@ tasks.create("generateStrings", Exec::class.java) {
 
 tasks.preBuild.dependsOn("generateStrings")
 
+val mediaVersion = "1.2.1"
+
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.leanback:leanback:1.1.0-rc02")
@@ -136,6 +138,11 @@ dependencies {
 
     implementation("com.apollographql.apollo3:apollo-runtime:3.8.2")
     implementation("androidx.preference:preference-ktx:1.2.1")
+
+    implementation("androidx.media3:media3-exoplayer:$mediaVersion")
+    implementation("androidx.media3:media3-ui:$mediaVersion")
+    implementation("androidx.media3:media3-exoplayer-dash:$mediaVersion")
+    implementation("androidx.media3:media3-exoplayer-hls:$mediaVersion")
 
     testImplementation("androidx.test:core-ktx:1.5.0")
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
@@ -3,10 +3,13 @@ package com.github.damontecres.stashapp
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.annotation.OptIn
+import androidx.fragment.app.Fragment
+import androidx.media3.common.util.UnstableApi
 
 /** Loads [PlaybackVideoFragment]. */
 class PlaybackActivity : SecureFragmentActivity() {
-    private val fragment: PlaybackVideoFragment = PlaybackVideoFragment()
+    private val fragment: Fragment = PlaybackExoFragment()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -17,11 +20,14 @@ class PlaybackActivity : SecureFragmentActivity() {
         }
     }
 
+    @OptIn(UnstableApi::class)
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         // TODO: deprecated, so use https://stackoverflow.com/a/72634975/608317 eventually
-        returnPosition()
-        super.onBackPressed()
+        if (!(fragment as StashVideoPlayer).hideControlsIfVisible()) {
+            returnPosition()
+            super.onBackPressed()
+        }
     }
 
     override fun onStop() {
@@ -34,8 +40,19 @@ class PlaybackActivity : SecureFragmentActivity() {
      */
     private fun returnPosition() {
         val intent = Intent()
-        intent.putExtra("position", fragment.currentVideoPosition)
+        intent.putExtra("position", (fragment as StashVideoPlayer).currentVideoPosition)
         setResult(Activity.RESULT_OK, intent)
         finish()
+    }
+
+    interface StashVideoPlayer {
+        val currentVideoPosition: Long
+
+        /**
+         * Hide the controls if needed
+         *
+         * @return true if the controls needed to be hidden
+         */
+        fun hideControlsIfVisible(): Boolean
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
@@ -3,6 +3,7 @@ package com.github.damontecres.stashapp
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.annotation.OptIn
 import androidx.fragment.app.Fragment
 import androidx.media3.common.util.UnstableApi
@@ -49,7 +50,9 @@ class PlaybackActivity : SecureFragmentActivity() {
      */
     private fun returnPosition() {
         val intent = Intent()
-        intent.putExtra("position", (fragment as StashVideoPlayer).currentVideoPosition)
+        val position = (fragment as StashVideoPlayer).currentVideoPosition
+        Log.d(TAG, "Video playback ending, currentVideoPosition=$position")
+        intent.putExtra("position", position)
         setResult(Activity.RESULT_OK, intent)
         finish()
     }
@@ -63,5 +66,9 @@ class PlaybackActivity : SecureFragmentActivity() {
          * @return true if the controls needed to be hidden
          */
         fun hideControlsIfVisible(): Boolean
+    }
+
+    companion object {
+        const val TAG = "PlaybackActivity"
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
@@ -6,14 +6,23 @@ import android.os.Bundle
 import androidx.annotation.OptIn
 import androidx.fragment.app.Fragment
 import androidx.media3.common.util.UnstableApi
+import androidx.preference.PreferenceManager
 
 /** Loads [PlaybackVideoFragment]. */
 class PlaybackActivity : SecureFragmentActivity() {
-    private val fragment: Fragment = PlaybackExoFragment()
+    private lateinit var fragment: Fragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (savedInstanceState == null) {
+            val useExo =
+                PreferenceManager.getDefaultSharedPreferences(this).getBoolean("playerChoice", true)
+            fragment =
+                if (useExo) {
+                    PlaybackExoFragment()
+                } else {
+                    PlaybackVideoFragment()
+                }
             supportFragmentManager.beginTransaction()
                 .replace(android.R.id.content, fragment)
                 .commit()

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -1,0 +1,225 @@
+package com.github.damontecres.stashapp
+
+import android.os.Bundle
+import android.util.Log
+import android.view.KeyEvent
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.annotation.OptIn
+import androidx.fragment.app.Fragment
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.common.util.Util
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.ui.PlayerView
+import androidx.preference.PreferenceManager
+import com.github.damontecres.stashapp.data.Scene
+import com.github.damontecres.stashapp.util.Constants
+
+@OptIn(UnstableApi::class)
+class PlaybackExoFragment :
+    Fragment(R.layout.video_playback),
+    PlaybackActivity.StashVideoPlayer {
+    var player: ExoPlayer? = null
+    private lateinit var scene: Scene
+    lateinit var videoView: PlayerView
+
+    private var playWhenReady = true
+    private var mediaItemIndex = 0
+    private var playbackPosition = 0L
+
+    override val currentVideoPosition get() = player!!.currentPosition
+
+    override fun hideControlsIfVisible(): Boolean {
+        if (videoView.isControllerFullyVisible) {
+            videoView.hideController()
+            return true
+        }
+        return false
+    }
+
+    private fun releasePlayer() {
+        player?.let { exoPlayer ->
+            playbackPosition = exoPlayer.currentPosition
+            mediaItemIndex = exoPlayer.currentMediaItemIndex
+            playWhenReady = exoPlayer.playWhenReady
+            exoPlayer.release()
+        }
+        player = null
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun initializePlayer(position: Long) {
+        val apiKey =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getString("stashApiKey", "")
+
+        val dataSourceFactory =
+            DataSource.Factory {
+                val dataSource = DefaultHttpDataSource.Factory().createDataSource()
+                dataSource.setRequestProperty(Constants.STASH_API_HEADER, apiKey!!)
+                dataSource.setRequestProperty("apikey", apiKey!!)
+                dataSource
+            }
+
+        player =
+            ExoPlayer.Builder(requireContext())
+                .setMediaSourceFactory(
+                    DefaultMediaSourceFactory(requireContext()).setDataSourceFactory(
+                        dataSourceFactory,
+                    ),
+                )
+                .build()
+                .also { exoPlayer ->
+                    videoView.player = exoPlayer
+                }.also { exoPlayer ->
+                    var mediaItem: MediaItem? = null
+                    var streamUrl = scene.streams.get("Direct stream")
+                    if (streamUrl != null) {
+                        mediaItem = MediaItem.fromUri(streamUrl)
+                    } else {
+                        val streamChoice =
+                            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                                .getString("stream_choice", "MP4")
+                        streamUrl = scene.streams.get(streamChoice)
+                        val mimeType =
+                            if (streamChoice == "DASH") {
+                                MimeTypes.APPLICATION_MPD
+                            } else if (streamChoice == "HLS") {
+                                MimeTypes.APPLICATION_M3U8
+                            } else if (streamChoice == "MP4") {
+                                MimeTypes.VIDEO_MP4
+                            } else {
+                                MimeTypes.VIDEO_WEBM
+                            }
+
+                        mediaItem =
+                            MediaItem.Builder()
+                                .setUri(streamUrl)
+                                .setMimeType(mimeType)
+                                .build()
+                    }
+
+                    exoPlayer.setMediaItem(mediaItem)
+                    exoPlayer.playWhenReady = true
+                    exoPlayer.prepare()
+                    exoPlayer.addListener(
+                        object : Player.Listener {
+                            private var initialSeek = true
+
+                            override fun onAvailableCommandsChanged(availableCommands: Player.Commands) {
+                                if (initialSeek && position > 0 && Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM in availableCommands) {
+                                    exoPlayer.seekTo(position)
+                                    initialSeek = false
+                                }
+                            }
+                        },
+                    )
+                }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    @OptIn(UnstableApi::class)
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val scene = requireActivity().intent.getParcelableExtra(DetailsActivity.MOVIE) as Scene?
+        if (scene == null) {
+            throw RuntimeException()
+        }
+        this.scene = scene
+        val position = requireActivity().intent.getLongExtra(VideoDetailsFragment.POSITION_ARG, -1)
+        Log.d(TAG, "scene=${scene?.id}")
+        Log.d(TAG, "${VideoDetailsFragment.POSITION_ARG}=$position")
+
+        videoView = view.findViewById<PlayerView>(R.id.video_view)
+        videoView.requestFocus()
+        videoView.controllerShowTimeoutMs = 2000
+
+        val callback = ControlsListener(videoView)
+        videoView.setControllerVisibilityListener(callback)
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            callback,
+        )
+    }
+
+    fun dispatchKeyEvent(event: KeyEvent?): Boolean {
+        return videoView.dispatchKeyEvent(event!!)
+    }
+
+    @OptIn(UnstableApi::class)
+    override fun onStart() {
+        super.onStart()
+        if (Util.SDK_INT > 23) {
+            val position =
+                requireActivity().intent.getLongExtra(VideoDetailsFragment.POSITION_ARG, -1)
+            initializePlayer(position)
+        }
+    }
+
+    @OptIn(UnstableApi::class)
+    override fun onResume() {
+        super.onResume()
+//        hideSystemUi()
+        if ((Util.SDK_INT <= 23 || player == null)) {
+            val position =
+                requireActivity().intent.getLongExtra(VideoDetailsFragment.POSITION_ARG, -1)
+            initializePlayer(position)
+        }
+    }
+
+    @OptIn(UnstableApi::class)
+    override fun onPause() {
+        super.onPause()
+        if (Util.SDK_INT <= 23) {
+            releasePlayer()
+        }
+    }
+
+    @OptIn(UnstableApi::class)
+    override fun onStop() {
+        super.onStop()
+        if (Util.SDK_INT > 23) {
+            releasePlayer()
+        }
+    }
+
+    companion object {
+        const val TAG = "PlaybackExoFragment"
+    }
+
+    class ControlsListener(private val view: PlayerView) : PlayerView.ControllerVisibilityListener,
+        OnBackPressedCallback(
+            view.isControllerFullyVisible,
+        ) {
+        init {
+//            Log.d(TAG, "ControlsListener initial isEnabled=$isEnabled")
+        }
+
+        override fun onVisibilityChanged(visibility: Int) {
+            when (visibility) {
+                View.VISIBLE -> isEnabled = true
+                View.GONE -> isEnabled = false
+            }
+//            Log.d(TAG, "ControlsListener isEnabled=$isEnabled")
+        }
+
+        @OptIn(UnstableApi::class)
+        override fun handleOnBackPressed() {
+//            Log.d(TAG, "ControlsListener handleOnBackPressed, isEnabled=$isEnabled")
+            view.hideController()
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -6,6 +6,7 @@ import android.view.KeyEvent
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.OptIn
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
@@ -25,9 +26,9 @@ import com.github.damontecres.stashapp.util.Constants
 class PlaybackExoFragment :
     Fragment(R.layout.video_playback),
     PlaybackActivity.StashVideoPlayer {
-    var player: ExoPlayer? = null
+    private var player: ExoPlayer? = null
     private lateinit var scene: Scene
-    lateinit var videoView: PlayerView
+    private lateinit var videoView: PlayerView
 
     private var playWhenReady = true
     private var mediaItemIndex = 0
@@ -163,6 +164,50 @@ class PlaybackExoFragment :
             viewLifecycleOwner,
             callback,
         )
+
+        val mFocusedZoom =
+            requireContext().resources.getFraction(
+                androidx.leanback.R.fraction.lb_focus_zoom_factor_large,
+                1,
+                1,
+            )
+        val onFocusChangeListener =
+            View.OnFocusChangeListener { v, hasFocus ->
+                val zoom = if (hasFocus) mFocusedZoom else 1f
+                v.animate().scaleX(zoom).scaleY(zoom).setDuration(150.toLong()).start()
+
+                if (hasFocus) {
+                    v.setBackgroundColor(
+                        ContextCompat.getColor(
+                            requireContext(),
+                            R.color.selected_background,
+                        ),
+                    )
+                } else {
+                    v.setBackgroundColor(
+                        ContextCompat.getColor(
+                            requireContext(),
+                            android.R.color.transparent,
+                        ),
+                    )
+                }
+            }
+
+        val buttons =
+            listOf(
+                androidx.media3.ui.R.id.exo_rew_with_amount,
+                androidx.media3.ui.R.id.exo_ffwd_with_amount,
+                androidx.media3.ui.R.id.exo_settings,
+                androidx.media3.ui.R.id.exo_prev,
+                androidx.media3.ui.R.id.exo_play_pause,
+                androidx.media3.ui.R.id.exo_next,
+            )
+        buttons.forEach {
+            view.findViewById<View>(it)?.onFocusChangeListener = onFocusChangeListener
+        }
+
+//        val timeBar: DefaultTimeBar =
+//            view.findViewById(androidx.media3.ui.R.id.exo_progress)
     }
 
     fun dispatchKeyEvent(event: KeyEvent?): Boolean {

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -89,7 +89,7 @@ class PlaybackExoFragment :
                 }.also { exoPlayer ->
                     var mediaItem: MediaItem? = null
                     var streamUrl = scene.streams.get("Direct stream")
-                    if (streamUrl != null) {
+                    if (streamUrl != null && scene.videoCodec != "av1") {
                         mediaItem = MediaItem.fromUri(streamUrl)
                     } else {
                         val streamChoice =

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -58,6 +58,12 @@ class PlaybackExoFragment :
         val apiKey =
             PreferenceManager.getDefaultSharedPreferences(requireContext())
                 .getString("stashApiKey", "")
+        val skipForward =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getInt("skip_forward_time", 30)
+        val skipBack =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getInt("skip_back_time", 10)
 
         val dataSourceFactory =
             DataSource.Factory {
@@ -74,6 +80,8 @@ class PlaybackExoFragment :
                         dataSourceFactory,
                     ),
                 )
+                .setSeekBackIncrementMs(skipBack * 1000L)
+                .setSeekForwardIncrementMs(skipForward * 1000L)
                 .build()
                 .also { exoPlayer ->
                     videoView.player = exoPlayer
@@ -108,6 +116,7 @@ class PlaybackExoFragment :
                     exoPlayer.setMediaItem(mediaItem)
                     exoPlayer.playWhenReady = true
                     exoPlayer.prepare()
+                    videoView.hideController()
                     exoPlayer.addListener(
                         object : Player.Listener {
                             private var initialSeek = true
@@ -146,6 +155,7 @@ class PlaybackExoFragment :
         videoView = view.findViewById<PlayerView>(R.id.video_view)
         videoView.requestFocus()
         videoView.controllerShowTimeoutMs = 2000
+        videoView.hideController()
 
         val callback = ControlsListener(videoView)
         videoView.setControllerVisibilityListener(callback)

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
@@ -32,11 +32,15 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 /** Handles video playback with media controls. */
-class PlaybackVideoFragment : VideoSupportFragment() {
+class PlaybackVideoFragment : VideoSupportFragment(), PlaybackActivity.StashVideoPlayer {
     private lateinit var mTransportControlGlue: BasicTransportControlsGlue
     private lateinit var playerAdapter: BasicMediaPlayerAdapter
 
-    val currentVideoPosition get() = playerAdapter.currentPosition
+    override val currentVideoPosition get() = playerAdapter.currentPosition
+
+    override fun hideControlsIfVisible(): Boolean {
+        return false
+    }
 
     override fun onViewCreated(
         view: View,

--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
@@ -13,6 +13,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceDialogFragmentCompat
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreference
 import com.github.damontecres.stashapp.util.MutationEngine
 import com.github.damontecres.stashapp.util.testStashConnection
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -128,6 +129,18 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
                         ).show()
                     }
                     true
+                }
+
+            val playerChoice = findPreference<SwitchPreference>("playerChoice")
+            playerChoice?.summaryProvider =
+                object : Preference.SummaryProvider<SwitchPreference> {
+                    override fun provideSummary(preference: SwitchPreference): CharSequence {
+                        return if (preference.isChecked) {
+                            "Using ExoPlayer (recommended)"
+                        } else {
+                            "Using default player"
+                        }
+                    }
                 }
         }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/data/Scene.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/Scene.kt
@@ -17,6 +17,7 @@ data class Scene(
     val streams: Map<String, String>,
     val duration: Double?,
     val resumeTime: Double?,
+    val videoCodec: String?,
 ) : Parcelable {
     companion object {
         fun fromSlimSceneData(data: SlimSceneData): Scene {
@@ -36,7 +37,7 @@ data class Scene(
                 } else {
                     data.title
                 }
-            val duration = data.files.firstOrNull()?.videoFileData?.duration
+            val fileData = data.files.firstOrNull()?.videoFileData
             return Scene(
                 id = data.id.toLong(),
                 title = title,
@@ -46,8 +47,9 @@ data class Scene(
                 studioId = data.studio?.id,
                 studioName = data.studio?.name,
                 streams = streams,
-                duration = duration,
+                duration = fileData?.duration,
                 resumeTime = data.resume_time,
+                videoCodec = fileData?.video_codec,
             )
         }
     }

--- a/app/src/main/res/layout/video_playback.xml
+++ b/app/src/main/res/layout/video_playback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/video_playback_frame"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.media3.ui.PlayerView
+        android:id="@+id/video_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:show_buffering="when_playing"
+        app:auto_show="true"
+        app:hide_on_touch="true"
+        app:animation_enabled="true"
+        app:scrubber_color="@color/light_blue_400"
+        />
+
+</FrameLayout>

--- a/app/src/main/res/layout/video_playback.xml
+++ b/app/src/main/res/layout/video_playback.xml
@@ -13,7 +13,7 @@
         app:auto_show="true"
         app:hide_on_touch="true"
         app:animation_enabled="true"
-        app:scrubber_color="@color/light_blue_400"
-        />
+        app:scrubber_dragged_size="22dp"
+        app:played_color="@color/selected_background" />
 
 </FrameLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,8 +1,8 @@
 <resources>
     <string-array name="stream_options">
-        <item>MP4</item>
-        <item>WEBM</item>
         <item>HLS</item>
         <item>DASH</item>
+        <item>MP4</item>
+        <item>WEBM</item>
     </string-array>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -74,6 +74,10 @@
             app:defaultValue="MP4"
             app:entries="@array/stream_options"
             app:entryValues="@array/stream_options" />
+        <SwitchPreference
+            app:key="playerChoice"
+            app:title="Which player to use for playback"
+            app:defaultValue="true" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/stashapp_config_tasks_job_queue">

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -71,7 +71,7 @@
             app:key="stream_choice"
             app:title="Stream Choice"
             app:summary="Which stream type to use when direct is unavailable"
-            app:defaultValue="MP4"
+            app:defaultValue="HLS"
             app:entries="@array/stream_options"
             app:entryValues="@array/stream_options" />
         <SwitchPreference


### PR DESCRIPTION
Closes #6 
Closes #18 
Workaround for #59 (`av1` files are always transcoded)

Adds using ExoPlayer instead of the default player. There's a setting to toggle between the two if you need the default for some reason.

When using the ExoPlayer, it is recommended to use HLS or DASH for transcoded streams (can be changed in settings). HLS is the default now. From my testing on my setup, HLS tends to start playing faster and seeks faster, so that's why it's the default now.

With ExoPlayer and HLS/DASH, videos that needs to be transcoded now play & seek successfully!

The ExoPlayer UI is different and I'd like to change it a bit, but getting a working player is more important, so I'll follow up with UI changes.