### PR TITLE
Fix randomization for front page filter with random sort

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
@@ -58,7 +58,7 @@ class StashPagingSource<T : Query.Data, D : Any>(
                 per_page = Optional.present(pageSize),
                 page = Optional.present(page),
             )
-        val query = dataSupplier.createQuery(filter)
+        val query = dataSupplier.createQuery(queryEngine.updateFilter(filter))
         val results = queryEngine.executeQuery(query)
         return dataSupplier.parseQuery(results.data)
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
@@ -236,7 +236,7 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
      *
      * Handles updating the random sort if requested
      */
-    private fun updateFilter(filter: FindFilterType?): FindFilterType? {
+    fun updateFilter(filter: FindFilterType?): FindFilterType? {
         return if (filter != null) {
             if (filter.sort.getOrNull()?.startsWith("random_") == true) {
                 filter.copy(sort = Optional.present("random_" + Random.nextInt(1e8.toInt())))


### PR DESCRIPTION
Fixes a bug where clicking `View All` at the end of a list on the front page whose filter's sort by is `random` was not actually random.

Now the sort by random will be updated and send to the server.