### PR TITLE
Ensure tags/performers are shown after adding the first

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -154,6 +154,10 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                                 newTags?.first { it.id == tagId.toInt() }?.name
                             tagsAdapter.clear()
                             tagsAdapter.addAll(0, newTags)
+                            mAdapter.set(
+                                TAG_POS,
+                                ListRow(HeaderItem(getString(R.string.stashapp_tags)), tagsAdapter),
+                            )
 
                             Toast.makeText(
                                 requireContext(),
@@ -188,6 +192,13 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                                 resultPerformers?.first { it.id == performerId }
                             performersAdapter.clear()
                             performersAdapter.addAll(0, resultPerformers)
+                            mAdapter.set(
+                                PERFORMER_POS,
+                                ListRow(
+                                    HeaderItem(getString(R.string.stashapp_performers)),
+                                    performersAdapter,
+                                ),
+                            )
 
                             Toast.makeText(
                                 requireContext(),


### PR DESCRIPTION
Just fixes a small UI bug where if a scene has no tags and/or performers and you add one, the list of tags/performers wouldn't be displayed.

This change ensure that the tags & performers list are always shown if a new item is added.