### PR TITLE
Main screen UX enhancements

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainActivity.kt
@@ -6,13 +6,21 @@ import android.os.Bundle
  * Loads [MainFragment].
  */
 class MainActivity() : SecureFragmentActivity() {
+    private val fragment = MainFragment()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
-                .replace(R.id.main_browse_fragment, MainFragment())
+                .replace(R.id.main_browse_fragment, fragment)
                 .commitNow()
+        }
+    }
+
+    override fun onBackPressed() {
+        if (!fragment.onBackPressed()) {
+            super.onBackPressed()
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
@@ -123,6 +123,10 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
         return scenes.orEmpty()
     }
 
+    suspend fun getScene(sceneId: Int): SlimSceneData? {
+        return findScenes(sceneIds = listOf(sceneId)).firstOrNull()
+    }
+
     suspend fun findPerformers(
         findFilter: FindFilterType? = null,
         performerFilter: PerformerFilterType? = null,


### PR DESCRIPTION
When returning to the main screen from a scene's page, that scene's data will be refreshed from the server. This means the playback position, tags, and performers will be updated if they changed.

Additionally, the back button navigation on the main screen is now consistent with [Android's recommendations](https://developer.android.com/training/tv/start/navigation#back_button_navigation). When back is pressed, it will return to the start of the row, then to the first row, then finally quit the app.

This PR partially resolves #73 (for the main page, but other scene lists still have this issue)