### PR TITLE
Ensure the tag used for version is not develop

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ fun getVersionCode(): Int {
 fun getAppVersion(): String {
     val stdout = ByteArrayOutputStream()
     exec {
-        commandLine = listOf("git", "describe", "--tags", "--long")
+        commandLine = listOf("git", "describe", "--tags", "--long", "--match=v*")
         standardOutput = stdout
     }
     return stdout.toString().trim().removePrefix("v")


### PR DESCRIPTION
Since the `develop` tag gets moved with every merge to main, it's always the latest tag and during the `v.0.0.9` release, it was used instead of the real version.

This PR fixes that by only considering the `v+` tags.