### PR TITLE
Better "View All" handling for random filters & scroll to next

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -461,12 +461,10 @@ class MainFragment : BrowseSupportFragment() {
 
             if (result?.mode in supportedFilterModes) {
                 // TODO doing it this way will result it adding an unsupported row then removing it which looks weird, in practice though it happens pretty fast
-                rowsAdapter.add(
-                    index,
-                    ListRow(HeaderItem(result?.name ?: ""), adapter),
-                )
+                rowsAdapter.add(index, ListRow(HeaderItem(result?.name ?: ""), adapter))
 
-                val filter = convertFilter(result?.find_filter)
+                val filter =
+                    queryEngine.updateFilter(convertFilter(result?.find_filter), useRandom = true)
                 val objectFilter =
                     result?.object_filter as Map<String, Map<String, *>>?
 
@@ -476,7 +474,7 @@ class MainFragment : BrowseSupportFragment() {
                             FilterParser.instance.convertSceneObjectFilter(objectFilter)
                         adapter.addAll(
                             0,
-                            queryEngine.findScenes(filter, sceneFilter),
+                            queryEngine.findScenes(filter, sceneFilter, useRandom = false),
                         )
                     }
 
@@ -488,6 +486,7 @@ class MainFragment : BrowseSupportFragment() {
                             queryEngine.findStudios(
                                 filter,
                                 studioFilter,
+                                useRandom = false,
                             ),
                         )
                     }
@@ -500,6 +499,7 @@ class MainFragment : BrowseSupportFragment() {
                             queryEngine.findPerformers(
                                 filter,
                                 performerFilter,
+                                useRandom = false,
                             ),
                         )
                     }
@@ -509,7 +509,7 @@ class MainFragment : BrowseSupportFragment() {
                             FilterParser.instance.convertTagObjectFilter(objectFilter)
                         adapter.addAll(
                             0,
-                            queryEngine.findTags(filter, tagFilter),
+                            queryEngine.findTags(filter, tagFilter, useRandom = false),
                         )
                     }
 
@@ -520,7 +520,13 @@ class MainFragment : BrowseSupportFragment() {
                         )
                     }
                 }
-                adapter.add(StashSavedFilter(filterId.toString(), result!!.mode))
+                adapter.add(
+                    StashSavedFilter(
+                        filterId.toString(),
+                        result!!.mode,
+                        filter?.sort?.getOrNull(),
+                    ),
+                )
             } else {
                 Log.w(TAG, "SavedFilter mode is ${result?.mode} which is not supported yet")
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -394,12 +394,14 @@ class MainFragment : BrowseSupportFragment() {
                     } else {
                         SortDirectionEnum.DESC
                     }
-
+                val pageSize =
+                    PreferenceManager.getDefaultSharedPreferences(requireContext())
+                        .getInt("maxSearchResults", 25)
                 val filter =
                     FindFilterType(
                         direction = Optional.presentIfNotNull(directionEnum),
                         sort = Optional.presentIfNotNull(sortBy),
-                        per_page = Optional.present(25),
+                        per_page = Optional.present(pageSize),
                     )
 
                 when (mode) {
@@ -463,8 +465,13 @@ class MainFragment : BrowseSupportFragment() {
                 // TODO doing it this way will result it adding an unsupported row then removing it which looks weird, in practice though it happens pretty fast
                 rowsAdapter.add(index, ListRow(HeaderItem(result?.name ?: ""), adapter))
 
+                val pageSize =
+                    PreferenceManager.getDefaultSharedPreferences(requireContext())
+                        .getInt("maxSearchResults", 25)
+
                 val filter =
                     queryEngine.updateFilter(convertFilter(result?.find_filter), useRandom = true)
+                        ?.copy(per_page = Optional.present(pageSize))
                 val objectFilter =
                     result?.object_filter as Map<String, Map<String, *>>?
 

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -57,6 +57,25 @@ class StashGridFragment<T : Query.Data, D : Any>(
         setGridPresenter(gridPresenter)
 
         adapter = mAdapter
+
+        val pageSize =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getInt("maxSearchResults", 50)
+        val scrollToNextResult =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getBoolean("scrollToNextResult", true)
+        val moveOnePage = requireActivity().intent.getBooleanExtra("moveOnePage", false)
+        if (moveOnePage && scrollToNextResult) {
+            adapter.registerObserver(
+                object : ObjectAdapter.DataObserver() {
+                    override fun onChanged() {
+                        Log.v(TAG, "Skipping one page")
+                        setSelectedPosition(pageSize)
+                        adapter.unregisterObserver(this)
+                    }
+                },
+            )
+        }
     }
 
     override fun onViewCreated(
@@ -117,21 +136,6 @@ class StashGridFragment<T : Query.Data, D : Any>(
                 }
             }
         browseFrameLayout.requestFocus()
-        val pageSize =
-            PreferenceManager.getDefaultSharedPreferences(requireContext())
-                .getInt("maxSearchResults", 50)
-        val moveOnePage = requireActivity().intent.getBooleanExtra("moveOnePage", false)
-        if (moveOnePage) {
-            adapter.registerObserver(
-                object : ObjectAdapter.DataObserver() {
-                    override fun onChanged() {
-                        Log.v(TAG, "Skipping one page")
-                        setSelectedPosition(pageSize)
-                        adapter.unregisterObserver(this)
-                    }
-                },
-            )
-        }
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -73,6 +73,11 @@ class StashGridFragment<T : Query.Data, D : Any>(
             PreferenceManager.getDefaultSharedPreferences(requireContext())
                 .getInt("maxSearchResults", 50)
 
+        val useRandom = requireActivity().intent.getBooleanExtra("useRandom", true)
+        val sortBy = requireActivity().intent.getStringExtra("sortBy")
+
+        Log.v(TAG, "useRandom=$useRandom, sortBy=$sortBy")
+
         val flow =
             Pager(
                 PagingConfig(pageSize = pageSize, prefetchDistance = pageSize * 2),
@@ -81,6 +86,8 @@ class StashGridFragment<T : Query.Data, D : Any>(
                     requireContext(),
                     pageSize,
                     dataSupplier = dataSupplier,
+                    useRandom = useRandom,
+                    sortByOverride = sortBy,
                 )
             }.flow
                 .cachedIn(viewLifecycleOwner.lifecycleScope)

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -78,7 +78,11 @@ class StashGridFragment<T : Query.Data, D : Any>(
 
         val flow =
             Pager(
-                PagingConfig(pageSize = pageSize, prefetchDistance = pageSize * 2),
+                PagingConfig(
+                    pageSize = pageSize,
+                    prefetchDistance = pageSize * 2,
+                    initialLoadSize = pageSize * 2,
+                ),
             ) {
                 StashPagingSource(
                     requireContext(),
@@ -120,11 +124,9 @@ class StashGridFragment<T : Query.Data, D : Any>(
         if (moveOnePage) {
             adapter.registerObserver(
                 object : ObjectAdapter.DataObserver() {
-                    private var first = true
-
                     override fun onChanged() {
                         Log.v(TAG, "Skipping one page")
-                        setSelectedPosition(pageSize + 1)
+                        setSelectedPosition(pageSize)
                         adapter.unregisterObserver(this)
                     }
                 },

--- a/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
@@ -101,6 +101,7 @@ class StashItemViewClickListener(
             intent.putExtra("dataType", DataType.fromFilterMode(item.mode)!!.name)
             intent.putExtra("useRandom", false)
             intent.putExtra("sortBy", item.sortBy)
+            intent.putExtra("moveOnePage", true)
             activity.startActivity(intent)
         } else if (item is StashCustomFilter) {
             val intent = Intent(activity, FilterListActivity::class.java)
@@ -109,6 +110,7 @@ class StashItemViewClickListener(
             intent.putExtra("dataType", DataType.fromFilterMode(item.mode)!!.name)
             intent.putExtra("description", item.description)
             intent.putExtra("useRandom", false)
+            intent.putExtra("moveOnePage", true)
             activity.startActivity(intent)
         } else if (item is StashAction) {
             if (actionListener != null) {

--- a/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
@@ -99,6 +99,8 @@ class StashItemViewClickListener(
             val intent = Intent(activity, FilterListActivity::class.java)
             intent.putExtra("savedFilterId", item.savedFilterId)
             intent.putExtra("dataType", DataType.fromFilterMode(item.mode)!!.name)
+            intent.putExtra("useRandom", false)
+            intent.putExtra("sortBy", item.sortBy)
             activity.startActivity(intent)
         } else if (item is StashCustomFilter) {
             val intent = Intent(activity, FilterListActivity::class.java)
@@ -106,6 +108,7 @@ class StashItemViewClickListener(
             intent.putExtra("sortBy", item.sortBy)
             intent.putExtra("dataType", DataType.fromFilterMode(item.mode)!!.name)
             intent.putExtra("description", item.description)
+            intent.putExtra("useRandom", false)
             activity.startActivity(intent)
         } else if (item is StashAction) {
             if (actionListener != null) {

--- a/app/src/main/java/com/github/damontecres/stashapp/data/StashSavedFilter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/StashSavedFilter.kt
@@ -8,4 +8,5 @@ import kotlinx.parcelize.Parcelize
 data class StashSavedFilter(
     val savedFilterId: String,
     val mode: FilterMode,
+    val sortBy: String? = null,
 ) : Parcelable

--- a/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
@@ -107,11 +107,12 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
         findFilter: FindFilterType? = null,
         sceneFilter: SceneFilterType? = null,
         sceneIds: List<Int>? = null,
+        useRandom: Boolean = true,
     ): List<SlimSceneData> {
         val query =
             client.query(
                 FindScenesQuery(
-                    filter = updateFilter(findFilter),
+                    filter = updateFilter(findFilter, useRandom),
                     scene_filter = sceneFilter,
                     scene_ids = sceneIds,
                 ),
@@ -131,11 +132,12 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
         findFilter: FindFilterType? = null,
         performerFilter: PerformerFilterType? = null,
         performerIds: List<Int>? = null,
+        useRandom: Boolean = true,
     ): List<PerformerData> {
         val query =
             client.query(
                 FindPerformersQuery(
-                    filter = updateFilter(findFilter),
+                    filter = updateFilter(findFilter, useRandom),
                     performer_filter = performerFilter,
                     performer_ids = performerIds,
                 ),
@@ -151,11 +153,12 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
     suspend fun findStudios(
         findFilter: FindFilterType? = null,
         studioFilter: StudioFilterType? = null,
+        useRandom: Boolean = true,
     ): List<StudioData> {
         val query =
             client.query(
                 FindStudiosQuery(
-                    filter = updateFilter(findFilter),
+                    filter = updateFilter(findFilter, useRandom),
                     studio_filter = studioFilter,
                 ),
             )
@@ -169,11 +172,12 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
     suspend fun findTags(
         findFilter: FindFilterType? = null,
         tagFilter: TagFilterType? = null,
+        useRandom: Boolean = true,
     ): List<Tag> {
         val query =
             client.query(
                 FindTagsQuery(
-                    filter = updateFilter(findFilter),
+                    filter = updateFilter(findFilter, useRandom),
                     tag_filter = tagFilter,
                 ),
             )
@@ -185,11 +189,12 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
     suspend fun findMovies(
         findFilter: FindFilterType? = null,
         movieFilter: MovieFilterType? = null,
+        useRandom: Boolean = true,
     ): List<MovieData> {
         val query =
             client.query(
                 FindMoviesQuery(
-                    filter = updateFilter(findFilter),
+                    filter = updateFilter(findFilter, useRandom),
                     movie_filter = movieFilter,
                 ),
             )
@@ -200,11 +205,12 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
     suspend fun findMarkers(
         findFilter: FindFilterType? = null,
         markerFilter: SceneMarkerFilterType? = null,
+        useRandom: Boolean = true,
     ): List<MarkerData> {
         val query =
             client.query(
                 FindMarkersQuery(
-                    filter = updateFilter(findFilter),
+                    filter = updateFilter(findFilter, useRandom),
                     scene_marker_filter = markerFilter,
                 ),
             )
@@ -249,9 +255,12 @@ class QueryEngine(private val context: Context, private val showToasts: Boolean 
      *
      * Handles updating the random sort if requested
      */
-    fun updateFilter(filter: FindFilterType?): FindFilterType? {
+    fun updateFilter(
+        filter: FindFilterType?,
+        useRandom: Boolean = true,
+    ): FindFilterType? {
         return if (filter != null) {
-            if (filter.sort.getOrNull()?.startsWith("random_") == true) {
+            if (useRandom && filter.sort.getOrNull()?.startsWith("random_") == true) {
                 Log.v(TAG, "Updating random filter")
                 filter.copy(sort = Optional.present("random_" + Random.nextInt(1e8.toInt())))
             } else {

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -73,6 +73,13 @@
             android:min="1"
             android:max="12"
             app:defaultValue="5" />
+
+        <SwitchPreference
+            app:key="scrollToNextResult"
+            app:title="Scroll to next on View All"
+            app:summary="Automatically scroll down to the 'next' results when clicking View All on main page"
+            app:defaultValue="true"
+            />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Playback">


### PR DESCRIPTION
Updates the `View All` button at the end of rows on the main page so that if they are random, the same random sort is used on the grid view.

Additionally, after loading data on the grid, it will scroll to the "next" result. In other words, if 25 scenes are showing in a row, when clicking `View All`, the grid will scroll down to the 26th item so you can continue. This scrolling is enabled by default, but can be disabled in settings.