### PR TITLE
Fix activity tracking for Exo Player

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,7 @@
             android:exported="false"
             android:launchMode="singleTop" />
         <activity
-            android:name=".DetailsActivity"
+            android:name=".VideoDetailsActivity"
             android:exported="false"
             android:theme="@style/NoTitleTheme" />
         <activity

--- a/app/src/main/graphql/SaveSceneActivity.graphql
+++ b/app/src/main/graphql/SaveSceneActivity.graphql
@@ -1,7 +1,11 @@
-mutation SceneSaveActivity($scene_id: ID!, $resume_time: Float!){
-  sceneSaveActivity(id: $scene_id, resume_time: $resume_time)
+mutation SceneSaveActivity($scene_id: ID!, $resume_time: Float!, $play_duration: Float) {
+  sceneSaveActivity(id: $scene_id, resume_time: $resume_time, playDuration: $play_duration)
 }
 
 mutation SceneIncrementO($scene_id: ID!) {
   sceneIncrementO(id: $scene_id)
+}
+
+mutation SceneIncrementPlayCount($id: ID!) {
+  sceneIncrementPlayCount(id: $id)
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -172,7 +172,7 @@ class PlaybackExoFragment :
 
         controlsLayout = view.findViewById(R.id.player_controls)
 
-        scene = requireActivity().intent.getParcelableExtra(DetailsActivity.MOVIE) as Scene?
+        scene = requireActivity().intent.getParcelableExtra(VideoDetailsActivity.MOVIE) as Scene?
             ?: throw RuntimeException()
 
         val position = requireActivity().intent.getLongExtra(VideoDetailsFragment.POSITION_ARG, -1)

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -8,6 +8,7 @@ import androidx.annotation.OptIn
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
@@ -22,9 +23,18 @@ import androidx.media3.ui.PlayerView
 import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.util.Constants
+import com.github.damontecres.stashapp.util.MutationEngine
+import com.github.damontecres.stashapp.util.ServerPreferences
+import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashPreviewLoader
 import com.github.rubensousa.previewseekbar.PreviewBar
 import com.github.rubensousa.previewseekbar.media3.PreviewTimeBar
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @OptIn(UnstableApi::class)
 class PlaybackExoFragment :
@@ -95,6 +105,9 @@ class PlaybackExoFragment :
                 .build()
                 .also { exoPlayer ->
                     videoView.player = exoPlayer
+                    if (ServerPreferences(requireContext()).trackActivity) {
+                        exoPlayer.addListener(PlaybackListener())
+                    }
                 }.also { exoPlayer ->
                     var mediaItem: MediaItem? = null
                     var streamUrl = scene.streams["Direct stream"]
@@ -294,6 +307,78 @@ class PlaybackExoFragment :
         super.onStop()
         if (Util.SDK_INT > 23) {
             releasePlayer()
+        }
+    }
+
+    private inner class PlaybackListener : Player.Listener {
+        private val job: Job
+        private val mutationEngine = MutationEngine(requireContext())
+        private val minimumPlayPercent = ServerPreferences(requireContext()).minimumPlayPercent
+
+        private var totalPlayDuration = 0L
+        private var previousPosition = 0L
+        private var isEnded = AtomicBoolean(false)
+        private var incrementedPlayCount = AtomicBoolean(false)
+
+        init {
+            job =
+                launch {
+                    while (true) {
+                        if (!isEnded.get()) {
+                            delay(10.toDuration(DurationUnit.SECONDS))
+                            Log.v(TAG, "Timer saveSceneActivity")
+                            saveSceneActivity(currentVideoPosition)
+                        }
+                    }
+                }
+        }
+
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            Log.v(TAG, "onIsPlayingChanged isPlaying=$isPlaying")
+            if (isPlaying) {
+                isEnded.set(false)
+            }
+            if (!isEnded.get()) {
+                launch {
+                    saveSceneActivity(currentVideoPosition)
+                }
+            }
+        }
+
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            if (playbackState == Player.STATE_ENDED) {
+                Log.v(TAG, "onPlaybackStateChanged STATE_ENDED")
+                isEnded.set(true)
+                playbackPosition = 0 // Needed?
+                launch {
+                    saveSceneActivity(0)
+                }
+            }
+        }
+
+        private suspend fun saveSceneActivity(position: Long) {
+            mutationEngine.saveSceneActivity(scene.id, position, getDuration())
+            if (scene.duration != null &&
+                totalPlayDuration >= minimumPlayPercent / 100.0 * scene.duration!! &&
+                !incrementedPlayCount.get()
+            ) {
+                mutationEngine.incrementPlayCount(scene.id)
+                incrementedPlayCount.set(true)
+            }
+        }
+
+        private fun getDuration(): Long {
+            val currentPosition = currentVideoPosition
+            val duration = currentPosition - previousPosition
+            previousPosition = currentPosition
+            totalPlayDuration += duration
+            return duration
+        }
+
+        private fun launch(block: suspend () -> Unit): Job {
+            return viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
+                block.invoke()
+            }
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
@@ -48,7 +48,8 @@ class PlaybackVideoFragment : VideoSupportFragment(), PlaybackActivity.StashVide
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        val scene = requireActivity().intent.getParcelableExtra(DetailsActivity.MOVIE) as Scene?
+        val scene =
+            requireActivity().intent.getParcelableExtra(VideoDetailsActivity.MOVIE) as Scene?
         val position = requireActivity().intent.getLongExtra(POSITION_ARG, -1)
         Log.d(TAG, "scene=${scene?.id}")
         Log.d(TAG, "$POSITION_ARG=$position")

--- a/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
@@ -41,7 +41,7 @@ class StashItemViewClickListener(
     ) {
         if (item is SlimSceneData) {
             val intent = Intent(activity, DetailsActivity::class.java)
-            intent.putExtra(DetailsActivity.MOVIE, Scene.fromSlimSceneData(item))
+            intent.putExtra(DetailsActivity.MOVIE, item.id)
 
             val bundle =
                 ActivityOptionsCompat.makeSceneTransitionAnimation(

--- a/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
@@ -40,14 +40,14 @@ class StashItemViewClickListener(
         row: Row?,
     ) {
         if (item is SlimSceneData) {
-            val intent = Intent(activity, DetailsActivity::class.java)
-            intent.putExtra(DetailsActivity.MOVIE, item.id)
+            val intent = Intent(activity, VideoDetailsActivity::class.java)
+            intent.putExtra(VideoDetailsActivity.MOVIE, item.id)
 
             val bundle =
                 ActivityOptionsCompat.makeSceneTransitionAnimation(
                     activity,
                     (itemViewHolder.view as ImageCardView).mainImageView,
-                    DetailsActivity.SHARED_ELEMENT_NAME,
+                    VideoDetailsActivity.SHARED_ELEMENT_NAME,
                 )
                     .toBundle()
             activity.startActivity(intent, bundle)
@@ -58,7 +58,7 @@ class StashItemViewClickListener(
                 ActivityOptionsCompat.makeSceneTransitionAnimation(
                     activity,
                     (itemViewHolder.view as ImageCardView).mainImageView,
-                    DetailsActivity.SHARED_ELEMENT_NAME,
+                    VideoDetailsActivity.SHARED_ELEMENT_NAME,
                 )
                     .toBundle()
             activity.startActivity(intent, bundle)
@@ -69,7 +69,7 @@ class StashItemViewClickListener(
                 ActivityOptionsCompat.makeSceneTransitionAnimation(
                     activity,
                     (itemViewHolder.view as ImageCardView).mainImageView,
-                    DetailsActivity.SHARED_ELEMENT_NAME,
+                    VideoDetailsActivity.SHARED_ELEMENT_NAME,
                 ).toBundle()
             activity.startActivity(intent, bundle)
         } else if (item is StudioData) {
@@ -80,7 +80,7 @@ class StashItemViewClickListener(
                 ActivityOptionsCompat.makeSceneTransitionAnimation(
                     activity,
                     (itemViewHolder.view as ImageCardView).mainImageView,
-                    DetailsActivity.SHARED_ELEMENT_NAME,
+                    VideoDetailsActivity.SHARED_ELEMENT_NAME,
                 ).toBundle()
             activity.startActivity(intent, bundle)
         } else if (item is MovieData) {
@@ -90,7 +90,7 @@ class StashItemViewClickListener(
         } else if (item is MarkerData) {
             val intent = Intent(activity, PlaybackActivity::class.java)
             intent.putExtra(
-                DetailsActivity.MOVIE,
+                VideoDetailsActivity.MOVIE,
                 Scene.fromSlimSceneData(item.scene.slimSceneData),
             )
             intent.putExtra(POSITION_ARG, (item.seconds * 1000).toLong())

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsActivity.kt
@@ -6,7 +6,7 @@ import androidx.fragment.app.FragmentActivity
 /**
  * Details activity class that loads [VideoDetailsFragment] class.
  */
-class DetailsActivity : FragmentActivity() {
+class VideoDetailsActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_details)

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -96,7 +96,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
-        val sceneId = requireActivity().intent.getParcelableExtra<Scene>(DetailsActivity.MOVIE)?.id
+        val sceneId = requireActivity().intent.getStringExtra(DetailsActivity.MOVIE)
         if (sceneId == null) {
             Log.w(TAG, "No scene found in intent")
             val intent = Intent(requireActivity(), MainActivity::class.java)

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -29,7 +29,6 @@ import androidx.leanback.widget.ListRowPresenter
 import androidx.leanback.widget.OnActionClickedListener
 import androidx.leanback.widget.SparseArrayObjectAdapter
 import androidx.lifecycle.lifecycleScope
-import androidx.preference.PreferenceManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
@@ -54,6 +53,7 @@ import com.github.damontecres.stashapp.util.QueryEngine
 import com.github.damontecres.stashapp.util.ServerPreferences
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.createGlideUrl
+import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
@@ -96,7 +96,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
-        val sceneId = requireActivity().intent.getStringExtra(DetailsActivity.MOVIE)
+        val sceneId = requireActivity().intent.getStringExtra(VideoDetailsActivity.MOVIE)
         if (sceneId == null) {
             Log.w(TAG, "No scene found in intent")
             val intent = Intent(requireActivity(), MainActivity::class.java)
@@ -185,12 +185,8 @@ class VideoDetailsFragment : DetailsSupportFragment() {
 
         val screenshotUrl = mSelectedMovie!!.paths.screenshot
 
-        if (!screenshotUrl.isNullOrBlank()) {
-            val apiKey =
-                PreferenceManager.getDefaultSharedPreferences(requireContext())
-                    .getString("stashApiKey", "")
-            val url = createGlideUrl(screenshotUrl, apiKey)
-
+        if (screenshotUrl.isNotNullOrBlank()) {
+            val url = createGlideUrl(screenshotUrl, requireContext())
             Glide.with(requireActivity())
                 .asBitmap()
                 .centerCrop()
@@ -267,7 +263,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         val sharedElementHelper = FullWidthDetailsOverviewSharedElementHelper()
         sharedElementHelper.setSharedElementEnterTransition(
             activity,
-            DetailsActivity.SHARED_ELEMENT_NAME,
+            VideoDetailsActivity.SHARED_ELEMENT_NAME,
         )
         detailsPresenter.setListener(sharedElementHelper)
         detailsPresenter.isParticipatingEntranceTransition = true
@@ -284,7 +280,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     ) {
                         val intent = Intent(requireActivity(), PlaybackActivity::class.java)
                         intent.putExtra(
-                            DetailsActivity.MOVIE,
+                            VideoDetailsActivity.MOVIE,
                             Scene.fromSlimSceneData(mSelectedMovie!!),
                         )
                         if (action.id == ACTION_RESUME_SCENE || action.id == ACTION_TRANSCODE_RESUME_SCENE) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/DetailsDescriptionPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/DetailsDescriptionPresenter.kt
@@ -1,7 +1,7 @@
 package com.github.damontecres.stashapp.presenters
 
 import androidx.leanback.widget.AbstractDetailsDescriptionPresenter
-import com.github.damontecres.stashapp.data.Scene
+import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.util.Constants
 import com.github.damontecres.stashapp.util.concatIfNotBlank
 
@@ -10,31 +10,23 @@ class DetailsDescriptionPresenter : AbstractDetailsDescriptionPresenter() {
         viewHolder: ViewHolder,
         item: Any,
     ) {
-        val scene = item as Scene
+        val scene = item as SlimSceneData
+
         viewHolder.title.text = scene.title
-
-        val resolution =
-            if (scene.videoResolution != null) {
-                scene.videoResolution.toString() + "P"
-            } else {
-                null
-            }
-
-        val duration =
-            if (scene.duration != null) {
-                Constants.durationToString(scene.duration)
-            } else {
-                null
-            }
-
-        viewHolder.subtitle.text =
-            concatIfNotBlank(
-                " - ",
-                scene.studioName,
-                scene.date,
-                duration,
-                resolution,
-            )
         viewHolder.body.text = scene.details
+
+        val file = scene.files.firstOrNull()
+        if (file != null) {
+            val resolution = "${file.videoFileData.height}P"
+            val duration = Constants.durationToString(file.videoFileData.duration)
+            viewHolder.subtitle.text =
+                concatIfNotBlank(
+                    " - ",
+                    scene.studio?.name,
+                    scene.date,
+                    duration,
+                    resolution,
+                )
+        }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -22,6 +22,8 @@ import com.github.damontecres.stashapp.api.ServerInfoQuery
 import com.github.damontecres.stashapp.api.fragment.SavedFilterData
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.data.DataType
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -260,3 +262,11 @@ fun Context.toPx(dp: Int): Float =
         dp.toFloat(),
         resources.displayMetrics,
     )
+
+@OptIn(ExperimentalContracts::class)
+fun CharSequence?.isNotNullOrBlank(): Boolean {
+    contract {
+        returns(true) implies (this@isNotNullOrBlank != null)
+    }
+    return !this.isNullOrBlank()
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.github.damontecres.stashapp.api.MetadataGenerateMutation
 import com.github.damontecres.stashapp.api.MetadataScanMutation
 import com.github.damontecres.stashapp.api.SceneIncrementOMutation
+import com.github.damontecres.stashapp.api.SceneIncrementPlayCountMutation
 import com.github.damontecres.stashapp.api.SceneSaveActivityMutation
 import com.github.damontecres.stashapp.api.SceneUpdateMutation
 import com.github.damontecres.stashapp.api.type.GenerateMetadataInput
@@ -89,13 +90,29 @@ class MutationEngine(private val context: Context, private val showToasts: Boole
     suspend fun saveSceneActivity(
         sceneId: Long,
         position: Long,
+        duration: Long? = null,
     ): Boolean {
-        Log.v(TAG, "SceneSaveActivity sceneId=$sceneId, position=$position")
+        Log.v(
+            TAG,
+            "SceneSaveActivity sceneId=$sceneId, position=$position, playDuration=$duration",
+        )
         val resumeTime = position / 1000.0
+        val playDuration = if (duration != null && duration >= 1000.0) duration / 1000.0 else null
         val mutation =
-            SceneSaveActivityMutation(scene_id = sceneId.toString(), resume_time = resumeTime)
+            SceneSaveActivityMutation(
+                scene_id = sceneId.toString(),
+                resume_time = resumeTime,
+                play_duration = playDuration,
+            )
         val result = executeMutation(mutation)
         return result.data!!.sceneSaveActivity
+    }
+
+    suspend fun incrementPlayCount(sceneId: Long): Int {
+        Log.v(TAG, "incrementPlayCount on $sceneId")
+        val mutation = SceneIncrementPlayCountMutation(sceneId.toString())
+        val result = executeMutation(mutation)
+        return result.data!!.sceneIncrementPlayCount
     }
 
     private fun getServerBoolean(preferenceKey: String): Optional<Boolean> {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
@@ -19,6 +19,8 @@ class ServerPreferences(private val context: Context) {
 
     val trackActivity get() = preferences.getBoolean(PREF_TRACK_ACTIVITY, false)
 
+    val minimumPlayPercent get() = preferences.getInt(PREF_MINIMUM_PLAY_PERCENT, 20)
+
     suspend fun updatePreferences() {
         val queryEngine = QueryEngine(context)
         val query = ConfigurationQuery()
@@ -36,6 +38,10 @@ class ServerPreferences(private val context: Context) {
                 putBoolean(
                     PREF_TRACK_ACTIVITY,
                     (ui.getCaseInsensitive(PREF_TRACK_ACTIVITY) as Boolean?) ?: false,
+                )
+                putInt(
+                    PREF_MINIMUM_PLAY_PERCENT,
+                    (ui.getCaseInsensitive(PREF_MINIMUM_PLAY_PERCENT) as Int?) ?: 20,
                 )
 
                 val scan = config.defaults.scan
@@ -75,6 +81,7 @@ class ServerPreferences(private val context: Context) {
 
     companion object {
         const val PREF_TRACK_ACTIVITY = "trackActivity"
+        const val PREF_MINIMUM_PLAY_PERCENT = "minimumPlayPercent"
 
         // Scan default settings
         const val PREF_SCAN_GENERATE_COVERS = "scanGenerateCovers"

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -4,5 +4,5 @@
     android:id="@+id/details_fragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".DetailsActivity"
+    tools:context=".VideoDetailsActivity"
     tools:deviceIds="tv" />


### PR DESCRIPTION
Closes #80 

I had thought it was just a UI glitch that scene resume times weren't updating, but turns out the new player in #62 did not implement the tracking at all.

This PR adds the tracking to the new player if tracking is enabled server side. Additionally, a rough implementation copy of the [tracking from the server](https://github.com/stashapp/stash/blob/v0.24.3/ui/v2.5/src/components/ScenePlayer/track-activity.ts) is added to increment play count, except the timer runs every 10s instead 1s. This change only applies to the new ExoPlayer, not the old default player.

Also scene details are fetched every time on the video details page instead of using the caller's data (which might be outdated). This ensures the latest resume time is available.