### PR TITLE
Keep device screen awake during playback

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.WindowManager
 import androidx.annotation.OptIn
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -16,6 +17,7 @@ class PlaybackActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         if (savedInstanceState == null) {
             val useExo =
                 PreferenceManager.getDefaultSharedPreferences(this).getBoolean("playerChoice", true)

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -3,6 +3,7 @@ package com.github.damontecres.stashapp
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.view.WindowManager
 import android.widget.ImageView
 import androidx.annotation.OptIn
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -105,6 +106,7 @@ class PlaybackExoFragment :
                 .build()
                 .also { exoPlayer ->
                     videoView.player = exoPlayer
+                    exoPlayer.addListener(AmbientPlaybackListener())
                     if (ServerPreferences(requireContext()).trackActivity) {
                         exoPlayer.addListener(PlaybackListener())
                     }
@@ -378,6 +380,17 @@ class PlaybackExoFragment :
         private fun launch(block: suspend () -> Unit): Job {
             return viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
                 block.invoke()
+            }
+        }
+    }
+
+    private inner class AmbientPlaybackListener : Player.Listener {
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            Log.v(TAG, "Keep screen on: $isPlaying")
+            if (isPlaying) {
+                requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            } else {
+                requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackVideoFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.KeyEvent
 import android.view.View
+import android.view.WindowManager
 import androidx.leanback.app.VideoSupportFragment
 import androidx.leanback.app.VideoSupportFragmentGlueHost
 import androidx.leanback.media.MediaPlayerAdapter
@@ -106,6 +107,20 @@ class PlaybackVideoFragment : VideoSupportFragment(), PlaybackActivity.StashVide
 
         if (streamUrl != null) {
             playerAdapter.setDataSource(Uri.parse(streamUrl))
+
+            mTransportControlGlue.addPlayerCallback(
+                object : PlayerCallback() {
+                    override fun onPlayStateChanged(glue: PlaybackGlue) {
+                        Log.v(TAG, "Keep screen on: ${glue.isPlaying}")
+                        if (glue.isPlaying) {
+                            requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                        } else {
+                            requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                        }
+                    }
+                },
+            )
+
             if (position > 0) {
                 // If a position was provided, resume playback from there
                 mTransportControlGlue.addPlayerCallback(

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -235,6 +235,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 )
         }
 
+        playActionsAdapter.clear()
         val serverPreferences = ServerPreferences(requireContext())
         if (serverPreferences.trackActivity && mSelectedMovie?.resume_time != null && mSelectedMovie?.resume_time!! > 0) {
             position = (mSelectedMovie?.resume_time!! * 1000).toLong()


### PR DESCRIPTION
Fixes #86 

During playback, the device won't go into ambient mode (aka screen saver or screen off). If playback is paused, the device can go into ambient mode based on [Android's recommendations](https://developer.android.com/docs/quality-guidelines/tv-app-quality#ambient-mode).

Also fixes a minor UI bug where the play actions could be added twice.