### PR TITLE
Add option to trust self signed certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Hardcoded crentials
 StashCredentials.kt
 stash_strings.xml
+test-server/
 
 # Gradle files
 .gradle/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("kotlin-parcelize")
     id("com.apollographql.apollo3") version "3.8.2"
+    id("kotlin-kapt")
 }
 
 fun getVersionCode(): Int {
@@ -124,13 +125,16 @@ tasks.create("generateStrings", Exec::class.java) {
 tasks.preBuild.dependsOn("generateStrings")
 
 val mediaVersion = "1.2.1"
+val glideVersion = "4.16.0"
 
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.leanback:leanback:1.1.0-rc02")
     implementation("androidx.leanback:leanback-preference:1.1.0-rc01")
     implementation("androidx.leanback:leanback-paging:1.1.0-alpha11")
-    implementation("com.github.bumptech.glide:glide:4.11.0")
+    implementation("com.github.bumptech.glide:glide:$glideVersion")
+    implementation("com.github.bumptech.glide:okhttp3-integration:$glideVersion")
+    kapt("com.github.bumptech.glide:compiler:$glideVersion")
 
     implementation("androidx.preference:preference-ktx:1.2.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,17 +23,17 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.StashAppAndroidTV"
         android:usesCleartextTraffic="true">
-        <activity
-            android:name=".PinActivity"
-            android:banner="@mipmap/stash_logo"
-            android:exported="true"
-            android:icon="@mipmap/stash_logo"
-            android:logo="@mipmap/stash_logo"
-            android:screenOrientation="landscape"
-            android:theme="@style/NoTitleTheme"
-            android:noHistory="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+    <activity
+        android:name=".PinActivity"
+        android:banner="@mipmap/stash_logo"
+        android:exported="true"
+        android:icon="@mipmap/stash_logo"
+        android:logo="@mipmap/stash_logo"
+        android:screenOrientation="landscape"
+        android:theme="@style/NoTitleTheme"
+        android:noHistory="true">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,17 +23,17 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.StashAppAndroidTV"
         android:usesCleartextTraffic="true">
-    <activity
-        android:name=".PinActivity"
-        android:banner="@mipmap/stash_logo"
-        android:exported="true"
-        android:icon="@mipmap/stash_logo"
-        android:logo="@mipmap/stash_logo"
-        android:screenOrientation="landscape"
-        android:theme="@style/NoTitleTheme"
-        android:noHistory="true">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
+        <activity
+            android:name=".PinActivity"
+            android:banner="@mipmap/stash_logo"
+            android:exported="true"
+            android:icon="@mipmap/stash_logo"
+            android:logo="@mipmap/stash_logo"
+            android:noHistory="true"
+            android:screenOrientation="landscape"
+            android:theme="@style/NoTitleTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>

--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
@@ -25,6 +25,7 @@ import androidx.preference.PreferenceManager
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreference
 import com.github.damontecres.stashapp.util.MutationEngine
+import com.github.damontecres.stashapp.util.configureHttpsTrust
 import com.github.damontecres.stashapp.util.testStashConnection
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
@@ -293,6 +294,12 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
 
             findPreference<Preference>("license")?.setOnPreferenceClickListener {
                 startActivity(Intent(requireContext(), LicenseActivity::class.java))
+                true
+            }
+
+            findPreference<Preference>("trustAllCerts")?.setOnPreferenceChangeListener { _, newValue ->
+                val app = requireActivity().application as StashApplication
+                configureHttpsTrust(app, newValue as Boolean)
                 true
             }
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/StashApplication.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashApplication.kt
@@ -11,11 +11,16 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.preference.PreferenceManager
+import com.github.damontecres.stashapp.util.configureHttpsTrust
+import javax.net.ssl.HttpsURLConnection
 
 class StashApplication : Application() {
     private var wasEnterBackground = false
     private var mainDestroyed = false
     var hasAskedForPin = false
+
+    val defaultSSLSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory()
+    val defaultHostnameVerifier = HttpsURLConnection.getDefaultHostnameVerifier()
 
     override fun onCreate() {
         super.onCreate()
@@ -42,6 +47,8 @@ class StashApplication : Application() {
                 putLong(VERSION_CODE_CURRENT_KEY, pkgInfo.versionCode.toLong())
             }
         }
+
+        configureHttpsTrust(this)
     }
 
     fun showPinActivity() {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/UnsafeOkHttpGlideModule.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/UnsafeOkHttpGlideModule.kt
@@ -1,0 +1,35 @@
+package com.github.damontecres.stashapp.util
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
+import com.bumptech.glide.load.model.GlideUrl
+import com.bumptech.glide.module.AppGlideModule
+import java.io.InputStream
+
+@GlideModule
+class UnsafeOkHttpGlideModule : AppGlideModule() {
+    override fun isManifestParsingEnabled(): Boolean {
+        return false
+    }
+
+    override fun registerComponents(
+        context: Context,
+        glide: Glide,
+        registry: Registry,
+    ) {
+        val trustAll =
+            PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean("trustAllCerts", false)
+        if (trustAll) {
+            registry.replace<GlideUrl, InputStream>(
+                GlideUrl::class.java,
+                InputStream::class.java,
+                OkHttpUrlLoader.Factory(createUnsafeOkHttpClient()),
+            )
+        }
+    }
+}

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -33,6 +33,12 @@
             app:title="Remove a Stash Server"
             app:summary="" />
 
+        <SwitchPreference
+            app:key="trustAllCerts"
+            app:title="Trust self-signed certificates"
+            app:summary="Restart may be required after changing this"
+            app:defaultValue="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Search">


### PR DESCRIPTION
Closes #2 

Adds a settings to allow trusting self-signed (technically all) certificates.

Sometimes restarting the app is required to ensure the setting is used properly since it involves modifying some static classes.