### PR TITLE
Remove performers or tags from a scene

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -130,16 +130,15 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     ArrayObjectAdapter(
                         TagPresenter(
                             object :
-                                StashPresenter.LongClickCallBack {
+                                StashPresenter.LongClickCallBack<TagData> {
                                 override val popUpItems: List<String>
                                     get() = listOf("Remove")
 
                                 override fun onItemLongClick(
-                                    item: Any?,
+                                    item: TagData,
                                     popUpItemPosition: Int,
                                 ) {
                                     if (popUpItemPosition == 0) {
-                                        val tag = item as TagData
                                         viewLifecycleOwner.lifecycleScope.launch(
                                             CoroutineExceptionHandler { _, ex ->
                                                 Log.e(TAG, "Exception setting tags", ex)
@@ -154,7 +153,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                                                 tagsAdapter.unmodifiableList<TagData>()
                                                     .map { it.id.toInt() }
                                                     .toMutableList()
-                                            tagIds.remove(tag.id.toInt())
+                                            tagIds.remove(item.id.toInt())
                                             val mutResult =
                                                 MutationEngine(requireContext()).setTagsOnScene(
                                                     mSelectedMovie!!.id.toLong(),
@@ -173,7 +172,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
 
                                             Toast.makeText(
                                                 requireContext(),
-                                                "Removed tag '${tag.name}' from scene",
+                                                "Removed tag '${item.name}' from scene",
                                                 Toast.LENGTH_SHORT,
                                             ).show()
                                         }
@@ -221,17 +220,16 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     ArrayObjectAdapter(
                         PerformerPresenter(
                             object :
-                                StashPresenter.LongClickCallBack {
+                                StashPresenter.LongClickCallBack<PerformerData> {
                                 override val popUpItems: List<String>
                                     get() = listOf("Remove")
 
                                 override fun onItemLongClick(
-                                    item: Any?,
+                                    item: PerformerData,
                                     popUpItemPosition: Int,
                                 ) {
                                     if (popUpItemPosition == 0) {
-                                        val performer = item as PerformerData
-                                        val performerId = performer.id
+                                        val performerId = item.id
                                         Log.d(
                                             TAG,
                                             "Removing performer $performerId to scene ${mSelectedMovie?.id}",
@@ -270,7 +268,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
 
                                             Toast.makeText(
                                                 requireContext(),
-                                                "Removed performer '${performer.name}' from scene",
+                                                "Removed performer '${item.name}' from scene",
                                                 Toast.LENGTH_SHORT,
                                             ).show()
                                         }

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -66,7 +66,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     private var mSelectedMovie: SlimSceneData? = null
 
     private lateinit var performersAdapter: ArrayObjectAdapter
-    private val tagsAdapter: ArrayObjectAdapter = ArrayObjectAdapter(TagPresenter())
+    private lateinit var tagsAdapter: ArrayObjectAdapter
     private val markersAdapter: ArrayObjectAdapter = ArrayObjectAdapter(MarkerPresenter())
     private val sceneActionsAdapter = ArrayObjectAdapter(StashPresenter.SELECTOR)
 
@@ -126,6 +126,63 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     ),
                 )
 
+                tagsAdapter =
+                    ArrayObjectAdapter(
+                        TagPresenter(
+                            object :
+                                StashPresenter.LongClickCallBack {
+                                override val popUpItems: List<String>
+                                    get() = listOf("Remove")
+
+                                override fun onItemLongClick(
+                                    item: Any?,
+                                    popUpItemPosition: Int,
+                                ) {
+                                    if (popUpItemPosition == 0) {
+                                        val tag = item as TagData
+                                        viewLifecycleOwner.lifecycleScope.launch(
+                                            CoroutineExceptionHandler { _, ex ->
+                                                Log.e(TAG, "Exception setting tags", ex)
+                                                Toast.makeText(
+                                                    requireContext(),
+                                                    "Failed to add tag: ${ex.message}",
+                                                    Toast.LENGTH_LONG,
+                                                ).show()
+                                            },
+                                        ) {
+                                            val tagIds =
+                                                tagsAdapter.unmodifiableList<TagData>()
+                                                    .map { it.id.toInt() }
+                                                    .toMutableList()
+                                            tagIds.remove(tag.id.toInt())
+                                            val mutResult =
+                                                MutationEngine(requireContext()).setTagsOnScene(
+                                                    mSelectedMovie!!.id.toLong(),
+                                                    tagIds,
+                                                )
+                                            val newTags = mutResult?.tags?.map { it.tagData }
+                                            tagsAdapter.clear()
+                                            tagsAdapter.addAll(0, newTags)
+                                            mAdapter.set(
+                                                TAG_POS,
+                                                ListRow(
+                                                    HeaderItem(getString(R.string.stashapp_tags)),
+                                                    tagsAdapter,
+                                                ),
+                                            )
+
+                                            Toast.makeText(
+                                                requireContext(),
+                                                "Removed tag '${tag.name}' from scene",
+                                                Toast.LENGTH_SHORT,
+                                            ).show()
+                                        }
+                                    }
+                                }
+                            },
+                        ),
+                    )
+
                 if (mSelectedMovie!!.tags.isNotEmpty()) {
                     mAdapter.set(
                         TAG_POS,
@@ -172,44 +229,51 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                                     item: Any?,
                                     popUpItemPosition: Int,
                                 ) {
-                                    val performer = item as PerformerData
-                                    val performerId = performer.id
-                                    Log.d(TAG, "Removing performer $performerId to scene ${mSelectedMovie?.id}")
-                                    viewLifecycleOwner.lifecycleScope.launch(
-                                        CoroutineExceptionHandler { _, ex ->
-                                            Log.e(TAG, "Exception setting performers", ex)
+                                    if (popUpItemPosition == 0) {
+                                        val performer = item as PerformerData
+                                        val performerId = performer.id
+                                        Log.d(
+                                            TAG,
+                                            "Removing performer $performerId to scene ${mSelectedMovie?.id}",
+                                        )
+                                        viewLifecycleOwner.lifecycleScope.launch(
+                                            CoroutineExceptionHandler { _, ex ->
+                                                Log.e(TAG, "Exception setting performers", ex)
+                                                Toast.makeText(
+                                                    requireContext(),
+                                                    "Failed to add performer: ${ex.message}",
+                                                    Toast.LENGTH_LONG,
+                                                ).show()
+                                            },
+                                        ) {
+                                            val performerIds =
+                                                performersAdapter.unmodifiableList<PerformerData>()
+                                                    .map { it.id }
+                                                    .toMutableList()
+                                            performerIds.remove(performerId)
+                                            val mutResult =
+                                                MutationEngine(requireContext()).setPerformersOnScene(
+                                                    mSelectedMovie!!.id.toLong(),
+                                                    performerIds.map { it.toInt() },
+                                                )
+                                            val resultPerformers =
+                                                mutResult?.performers?.map { it.performerData }
+                                            performersAdapter.clear()
+                                            performersAdapter.addAll(0, resultPerformers)
+                                            mAdapter.set(
+                                                PERFORMER_POS,
+                                                ListRow(
+                                                    HeaderItem(getString(R.string.stashapp_performers)),
+                                                    performersAdapter,
+                                                ),
+                                            )
+
                                             Toast.makeText(
                                                 requireContext(),
-                                                "Failed to add performer: ${ex.message}",
-                                                Toast.LENGTH_LONG,
+                                                "Removed performer '${performer.name}' from scene",
+                                                Toast.LENGTH_SHORT,
                                             ).show()
-                                        },
-                                    ) {
-                                        val performerIds =
-                                            performersAdapter.unmodifiableList<PerformerData>().map { it.id }
-                                                .toMutableList()
-                                        performerIds.remove(performerId)
-                                        val mutResult =
-                                            MutationEngine(requireContext()).setPerformersOnScene(
-                                                mSelectedMovie!!.id.toLong(),
-                                                performerIds.map { it.toInt() },
-                                            )
-                                        val resultPerformers = mutResult?.performers?.map { it.performerData }
-                                        performersAdapter.clear()
-                                        performersAdapter.addAll(0, resultPerformers)
-                                        mAdapter.set(
-                                            PERFORMER_POS,
-                                            ListRow(
-                                                HeaderItem(getString(R.string.stashapp_performers)),
-                                                performersAdapter,
-                                            ),
-                                        )
-
-                                        Toast.makeText(
-                                            requireContext(),
-                                            "Removed performer '${performer.name}' from scene",
-                                            Toast.LENGTH_SHORT,
-                                        ).show()
+                                        }
                                     }
                                 }
                             },

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ActionPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ActionPresenter.kt
@@ -3,14 +3,14 @@ package com.github.damontecres.stashapp.presenters
 import androidx.leanback.widget.ImageCardView
 import com.github.damontecres.stashapp.actions.StashAction
 
-class ActionPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+class ActionPresenter(callback: LongClickCallBack<StashAction>? = null) :
+    StashPresenter<StashAction>(callback) {
     override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: StashAction,
     ) {
-        val action = item as StashAction
         val cardView = viewHolder.view as ImageCardView
-        cardView.titleText = action.actionName
+        cardView.titleText = item.actionName
         cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ActionPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ActionPresenter.kt
@@ -3,10 +3,10 @@ package com.github.damontecres.stashapp.presenters
 import androidx.leanback.widget.ImageCardView
 import com.github.damontecres.stashapp.actions.StashAction
 
-class ActionPresenter : StashPresenter() {
-    override fun onBindViewHolder(
+class ActionPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+    override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any,
+        item: Any?,
     ) {
         val action = item as StashAction
         val cardView = viewHolder.view as ImageCardView

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ActionPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ActionPresenter.kt
@@ -6,10 +6,9 @@ import com.github.damontecres.stashapp.actions.StashAction
 class ActionPresenter(callback: LongClickCallBack<StashAction>? = null) :
     StashPresenter<StashAction>(callback) {
     override fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: StashAction,
     ) {
-        val cardView = viewHolder.view as ImageCardView
         cardView.titleText = item.actionName
         cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
@@ -11,10 +11,9 @@ import kotlin.time.toDuration
 class MarkerPresenter(callback: LongClickCallBack<MarkerData>? = null) :
     StashPresenter<MarkerData>(callback) {
     override fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: MarkerData,
     ) {
-        val cardView = viewHolder.view as ImageCardView
         val title =
             item.title.ifBlank {
                 item.primary_tag.tagData.name
@@ -24,8 +23,8 @@ class MarkerPresenter(callback: LongClickCallBack<MarkerData>? = null) :
             if (item.title.isNotBlank()) item.primary_tag.tagData.name else null
 
         cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
-        val url = createGlideUrl(item.screenshot, viewHolder.view.context)
-        Glide.with(viewHolder.view.context)
+        val url = createGlideUrl(item.screenshot, cardView.context)
+        Glide.with(cardView.context)
             .load(url)
             .transform(CenterCrop())
             .error(mDefaultCardImage)

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
@@ -8,8 +8,8 @@ import com.github.damontecres.stashapp.util.createGlideUrl
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
-class MarkerPresenter : StashPresenter() {
-    override fun onBindViewHolder(
+class MarkerPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+    override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
         item: Any?,
     ) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
@@ -8,23 +8,23 @@ import com.github.damontecres.stashapp.util.createGlideUrl
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
-class MarkerPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+class MarkerPresenter(callback: LongClickCallBack<MarkerData>? = null) :
+    StashPresenter<MarkerData>(callback) {
     override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: MarkerData,
     ) {
-        val marker = item as MarkerData
         val cardView = viewHolder.view as ImageCardView
         val title =
-            marker.title.ifBlank {
-                marker.primary_tag.tagData.name
+            item.title.ifBlank {
+                item.primary_tag.tagData.name
             }
-        cardView.titleText = "$title - ${marker.seconds.toInt().toDuration(DurationUnit.SECONDS)}"
+        cardView.titleText = "$title - ${item.seconds.toInt().toDuration(DurationUnit.SECONDS)}"
         cardView.contentText =
-            if (marker.title.isNotBlank()) marker.primary_tag.tagData.name else null
+            if (item.title.isNotBlank()) item.primary_tag.tagData.name else null
 
         cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
-        val url = createGlideUrl(marker.screenshot, viewHolder.view.context)
+        val url = createGlideUrl(item.screenshot, viewHolder.view.context)
         Glide.with(viewHolder.view.context)
             .load(url)
             .transform(CenterCrop())

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MoviePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MoviePresenter.kt
@@ -7,8 +7,8 @@ import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.util.createGlideUrl
 import java.util.EnumMap
 
-class MoviePresenter : StashPresenter() {
-    override fun onBindViewHolder(
+class MoviePresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+    override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
         item: Any?,
     ) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MoviePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MoviePresenter.kt
@@ -7,24 +7,24 @@ import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.util.createGlideUrl
 import java.util.EnumMap
 
-class MoviePresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+class MoviePresenter(callback: LongClickCallBack<MovieData>? = null) :
+    StashPresenter<MovieData>(callback) {
     override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: MovieData,
     ) {
-        val movie = item as MovieData
         val cardView = viewHolder.view as ImageCardView
 
-        if (movie.front_image_path != null) {
-            cardView.titleText = movie.name
-            cardView.contentText = movie.date
+        if (item.front_image_path != null) {
+            cardView.titleText = item.name
+            cardView.contentText = item.date
 
             val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-            dataTypeMap[DataType.SCENE] = movie.scene_count
+            dataTypeMap[DataType.SCENE] = item.scene_count
             setUpExtraRow(cardView, dataTypeMap, null)
 
             cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
-            val url = createGlideUrl(movie.front_image_path, cardView.context)
+            val url = createGlideUrl(item.front_image_path, cardView.context)
             Glide.with(viewHolder.view.context)
                 .load(url)
                 .centerCrop()

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MoviePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MoviePresenter.kt
@@ -10,11 +10,9 @@ import java.util.EnumMap
 class MoviePresenter(callback: LongClickCallBack<MovieData>? = null) :
     StashPresenter<MovieData>(callback) {
     override fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: MovieData,
     ) {
-        val cardView = viewHolder.view as ImageCardView
-
         if (item.front_image_path != null) {
             cardView.titleText = item.name
             cardView.contentText = item.date
@@ -25,7 +23,7 @@ class MoviePresenter(callback: LongClickCallBack<MovieData>? = null) :
 
             cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
             val url = createGlideUrl(item.front_image_path, cardView.context)
-            Glide.with(viewHolder.view.context)
+            Glide.with(cardView.context)
                 .load(url)
                 .centerCrop()
                 .error(mDefaultCardImage)

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/OCounterPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/OCounterPresenter.kt
@@ -5,18 +5,18 @@ import androidx.leanback.widget.ImageCardView
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.data.OCounter
 
-class OCounterPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+class OCounterPresenter(callback: LongClickCallBack<OCounter>? = null) :
+    StashPresenter<OCounter>(callback) {
     override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: OCounter,
     ) {
-        val counter = item as OCounter
         val cardView = viewHolder.view as ImageCardView
 
         val context = viewHolder.view.context
 
         val text = context.getString(R.string.stashapp_o_counter)
-        cardView.titleText = "$text (${counter.count})"
+        cardView.titleText = "$text (${item.count})"
         cardView.setMainImageDimensions(ActionPresenter.CARD_WIDTH, ActionPresenter.CARD_HEIGHT)
         cardView.mainImageView.setImageDrawable(
             AppCompatResources.getDrawable(

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/OCounterPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/OCounterPresenter.kt
@@ -5,10 +5,10 @@ import androidx.leanback.widget.ImageCardView
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.data.OCounter
 
-class OCounterPresenter : StashPresenter() {
-    override fun onBindViewHolder(
+class OCounterPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+    override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any,
+        item: Any?,
     ) {
         val counter = item as OCounter
         val cardView = viewHolder.view as ImageCardView

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/OCounterPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/OCounterPresenter.kt
@@ -8,19 +8,15 @@ import com.github.damontecres.stashapp.data.OCounter
 class OCounterPresenter(callback: LongClickCallBack<OCounter>? = null) :
     StashPresenter<OCounter>(callback) {
     override fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: OCounter,
     ) {
-        val cardView = viewHolder.view as ImageCardView
-
-        val context = viewHolder.view.context
-
-        val text = context.getString(R.string.stashapp_o_counter)
+        val text = cardView.context.getString(R.string.stashapp_o_counter)
         cardView.titleText = "$text (${item.count})"
         cardView.setMainImageDimensions(ActionPresenter.CARD_WIDTH, ActionPresenter.CARD_HEIGHT)
         cardView.mainImageView.setImageDrawable(
             AppCompatResources.getDrawable(
-                context,
+                cardView.context,
                 R.drawable.sweat_drops,
             ),
         )

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
@@ -10,8 +10,8 @@ import com.github.damontecres.stashapp.util.ageInYears
 import com.github.damontecres.stashapp.util.createGlideUrl
 import java.util.EnumMap
 
-class PerformerPresenter : StashPresenter() {
-    override fun onBindViewHolder(
+class PerformerPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+    override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
         item: Any?,
     ) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
@@ -13,11 +13,9 @@ import java.util.EnumMap
 class PerformerPresenter(callback: LongClickCallBack<PerformerData>? = null) :
     StashPresenter<PerformerData>(callback) {
     override fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: PerformerData,
     ) {
-        val cardView = viewHolder.view as ImageCardView
-
         if (item.image_path != null) {
             val title =
                 item.name + (if (!item.disambiguation.isNullOrBlank()) " (${item.disambiguation})" else "")
@@ -35,7 +33,7 @@ class PerformerPresenter(callback: LongClickCallBack<PerformerData>? = null) :
 
             cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
             val url = createGlideUrl(item.image_path, cardView.context)
-            Glide.with(viewHolder.view.context)
+            Glide.with(cardView.context)
                 .load(url)
                 .centerCrop()
                 .error(mDefaultCardImage)

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
@@ -10,31 +10,31 @@ import com.github.damontecres.stashapp.util.ageInYears
 import com.github.damontecres.stashapp.util.createGlideUrl
 import java.util.EnumMap
 
-class PerformerPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+class PerformerPresenter(callback: LongClickCallBack<PerformerData>? = null) :
+    StashPresenter<PerformerData>(callback) {
     override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: PerformerData,
     ) {
-        val performer = item as PerformerData
         val cardView = viewHolder.view as ImageCardView
 
-        if (performer.image_path != null) {
+        if (item.image_path != null) {
             val title =
-                performer.name + (if (!performer.disambiguation.isNullOrBlank()) " (${performer.disambiguation})" else "")
+                item.name + (if (!item.disambiguation.isNullOrBlank()) " (${item.disambiguation})" else "")
             cardView.titleText = title
 
-            if (performer.birthdate != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (item.birthdate != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val yearsOldStr = cardView.context.getString(R.string.stashapp_years_old)
-                cardView.contentText = "${performer.ageInYears} $yearsOldStr"
+                cardView.contentText = "${item.ageInYears} $yearsOldStr"
             }
 
             val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-            dataTypeMap[DataType.SCENE] = performer.scene_count
+            dataTypeMap[DataType.SCENE] = item.scene_count
 
-            setUpExtraRow(cardView, dataTypeMap, performer.o_counter)
+            setUpExtraRow(cardView, dataTypeMap, item.o_counter)
 
             cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
-            val url = createGlideUrl(performer.image_path, cardView.context)
+            val url = createGlideUrl(item.image_path, cardView.context)
             Glide.with(viewHolder.view.context)
                 .load(url)
                 .centerCrop()

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/PopupOnLongClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/PopupOnLongClickListener.kt
@@ -1,0 +1,62 @@
+package com.github.damontecres.stashapp.presenters
+
+import android.view.View
+import android.view.View.OnLongClickListener
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.appcompat.widget.ListPopupWindow
+import com.github.damontecres.stashapp.StashOnFocusChangeListener
+
+/**
+ * An OnLongClickListener which shows a popup of predefined options
+ */
+class PopupOnLongClickListener(
+    private val popupOptions: List<String>,
+    private val popupItemClickListener: AdapterView.OnItemClickListener,
+) : OnLongClickListener {
+    override fun onLongClick(view: View): Boolean {
+        val listPopUp =
+            ListPopupWindow(
+                view.context,
+                null,
+                android.R.attr.listPopupWindowStyle,
+            )
+        listPopUp.inputMethodMode = ListPopupWindow.INPUT_METHOD_NEEDED
+        listPopUp.anchorView = view
+        // listPopUp.width = ViewGroup.LayoutParams.MATCH_PARENT
+        // TODO: Better width calculation
+        listPopUp.width = 200
+        listPopUp.isModal = true
+
+        val focusChangeListener = StashOnFocusChangeListener(view.context)
+
+        val adapter =
+            object : ArrayAdapter<String>(
+                view.context,
+                android.R.layout.simple_list_item_1,
+                popupOptions,
+            ) {
+                override fun getView(
+                    position: Int,
+                    convertView: View?,
+                    parent: ViewGroup,
+                ): View {
+                    val itemView = super.getView(position, convertView, parent)
+                    // TODO: this doesn't seem to work?
+                    itemView.onFocusChangeListener = focusChangeListener
+                    return itemView
+                }
+            }
+        listPopUp.setAdapter(adapter)
+
+        listPopUp.setOnItemClickListener { parent: AdapterView<*>, v: View, position: Int, id: Long ->
+            popupItemClickListener.onItemClick(parent, v, position, id)
+            listPopUp.dismiss()
+        }
+
+        listPopUp.show()
+
+        return true
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
@@ -19,8 +19,8 @@ import com.github.damontecres.stashapp.util.titleOrFilename
 import java.security.MessageDigest
 import java.util.EnumMap
 
-class ScenePresenter : StashPresenter() {
-    override fun onBindViewHolder(
+class ScenePresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+    override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
         item: Any?,
     ) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
@@ -22,11 +22,9 @@ import java.util.EnumMap
 class ScenePresenter(callback: LongClickCallBack<SlimSceneData>? = null) :
     StashPresenter<SlimSceneData>(callback) {
     override fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: SlimSceneData,
     ) {
-        val cardView = viewHolder.view as ImageCardView
-
         cardView.titleText = item.titleOrFilename
 
         val details = mutableListOf<String?>()
@@ -45,9 +43,9 @@ class ScenePresenter(callback: LongClickCallBack<SlimSceneData>? = null) :
         if (!item.paths.screenshot.isNullOrBlank()) {
             cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
             val url = createGlideUrl(item.paths.screenshot, vParent.context)
-            Glide.with(viewHolder.view.context)
+            Glide.with(cardView.context)
                 .load(url)
-                .transform(CenterCrop(), TextOverlay(viewHolder.view.context, item))
+                .transform(CenterCrop(), TextOverlay(cardView.context, item))
                 .error(mDefaultCardImage)
                 .into(cardView.mainImageView!!)
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
@@ -19,35 +19,35 @@ import com.github.damontecres.stashapp.util.titleOrFilename
 import java.security.MessageDigest
 import java.util.EnumMap
 
-class ScenePresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+class ScenePresenter(callback: LongClickCallBack<SlimSceneData>? = null) :
+    StashPresenter<SlimSceneData>(callback) {
     override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: SlimSceneData,
     ) {
-        val scene = item as SlimSceneData
         val cardView = viewHolder.view as ImageCardView
 
-        cardView.titleText = scene.titleOrFilename
+        cardView.titleText = item.titleOrFilename
 
         val details = mutableListOf<String?>()
-        details.add(scene.studio?.name)
-        details.add(scene.date)
+        details.add(item.studio?.name)
+        details.add(item.date)
         cardView.contentText = concatIfNotBlank(" - ", details)
 
         val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-        dataTypeMap[DataType.TAG] = scene.tags.size
-        dataTypeMap[DataType.PERFORMER] = scene.performers.size
-        dataTypeMap[DataType.MOVIE] = scene.movies.size
-        dataTypeMap[DataType.MARKER] = scene.scene_markers.size
+        dataTypeMap[DataType.TAG] = item.tags.size
+        dataTypeMap[DataType.PERFORMER] = item.performers.size
+        dataTypeMap[DataType.MOVIE] = item.movies.size
+        dataTypeMap[DataType.MARKER] = item.scene_markers.size
 
-        setUpExtraRow(cardView, dataTypeMap, scene.o_counter)
+        setUpExtraRow(cardView, dataTypeMap, item.o_counter)
 
-        if (!scene.paths.screenshot.isNullOrBlank()) {
+        if (!item.paths.screenshot.isNullOrBlank()) {
             cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
-            val url = createGlideUrl(scene.paths.screenshot, vParent.context)
+            val url = createGlideUrl(item.paths.screenshot, vParent.context)
             Glide.with(viewHolder.view.context)
                 .load(url)
-                .transform(CenterCrop(), TextOverlay(viewHolder.view.context, scene))
+                .transform(CenterCrop(), TextOverlay(viewHolder.view.context, item))
                 .error(mDefaultCardImage)
                 .into(cardView.mainImageView!!)
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashFilterPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashFilterPresenter.kt
@@ -7,10 +7,11 @@ import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.data.StashCustomFilter
 import com.github.damontecres.stashapp.data.StashSavedFilter
 
-class StashFilterPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+class StashFilterPresenter(callback: LongClickCallBack<Any>? = null) :
+    StashPresenter<Any>(callback) {
     override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: Any,
     ) {
         val cardView = viewHolder.view as ImageCardView
         cardView.titleText = "View All"

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashFilterPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashFilterPresenter.kt
@@ -7,8 +7,8 @@ import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.data.StashCustomFilter
 import com.github.damontecres.stashapp.data.StashSavedFilter
 
-class StashFilterPresenter : StashPresenter() {
-    override fun onBindViewHolder(
+class StashFilterPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+    override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
         item: Any?,
     ) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashFilterPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashFilterPresenter.kt
@@ -10,10 +10,9 @@ import com.github.damontecres.stashapp.data.StashSavedFilter
 class StashFilterPresenter(callback: LongClickCallBack<Any>? = null) :
     StashPresenter<Any>(callback) {
     override fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: Any,
     ) {
-        val cardView = viewHolder.view as ImageCardView
         cardView.titleText = "View All"
 
         val mode: FilterMode =
@@ -68,7 +67,7 @@ class StashFilterPresenter(callback: LongClickCallBack<Any>? = null) :
 
         cardView.mainImageView.setImageDrawable(
             AppCompatResources.getDrawable(
-                viewHolder.view.context,
+                cardView.context,
                 R.drawable.baseline_camera_indoor_48,
             ),
         )

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -67,7 +67,7 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
 
     final override fun onBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: Any,
     ) {
         val cardView = viewHolder.view as ImageCardView
         if (callback != null) {
@@ -79,11 +79,11 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
                 },
             )
         }
-        doOnBindViewHolder(viewHolder, item as T)
+        doOnBindViewHolder(viewHolder.view as ImageCardView, item as T)
     }
 
     abstract fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: T,
     )
 

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -25,7 +25,7 @@ import com.github.damontecres.stashapp.util.enableMarquee
 import java.util.EnumMap
 import kotlin.properties.Delegates
 
-abstract class StashPresenter(private val callback: LongClickCallBack? = null) : Presenter() {
+abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = null) : Presenter() {
     protected var vParent: ViewGroup by Delegates.notNull()
     protected var mDefaultCardImage: Drawable? = null
     private var sSelectedBackgroundColor: Int by Delegates.notNull()
@@ -75,16 +75,16 @@ abstract class StashPresenter(private val callback: LongClickCallBack? = null) :
                 PopupOnLongClickListener(
                     callback.popUpItems,
                 ) { _, _, pos, _ ->
-                    callback.onItemLongClick(item, pos)
+                    callback.onItemLongClick(item as T, pos)
                 },
             )
         }
-        doOnBindViewHolder(viewHolder, item)
+        doOnBindViewHolder(viewHolder, item as T)
     }
 
     abstract fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: T,
     )
 
     final override fun onUnbindViewHolder(viewHolder: ViewHolder) {
@@ -177,11 +177,11 @@ abstract class StashPresenter(private val callback: LongClickCallBack? = null) :
         }
     }
 
-    interface LongClickCallBack {
+    interface LongClickCallBack<T> {
         val popUpItems: List<String>
 
         fun onItemLongClick(
-            item: Any?,
+            item: T,
             popUpItemPosition: Int,
         )
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -25,13 +25,13 @@ import com.github.damontecres.stashapp.util.enableMarquee
 import java.util.EnumMap
 import kotlin.properties.Delegates
 
-abstract class StashPresenter : Presenter() {
+abstract class StashPresenter(private val callback: LongClickCallBack? = null) : Presenter() {
     protected var vParent: ViewGroup by Delegates.notNull()
     protected var mDefaultCardImage: Drawable? = null
     private var sSelectedBackgroundColor: Int by Delegates.notNull()
     private var sDefaultBackgroundColor: Int by Delegates.notNull()
 
-    override fun onCreateViewHolder(parent: ViewGroup): ViewHolder {
+    final override fun onCreateViewHolder(parent: ViewGroup): ViewHolder {
         vParent = parent
 
         sDefaultBackgroundColor =
@@ -65,7 +65,29 @@ abstract class StashPresenter : Presenter() {
         return ViewHolder(cardView)
     }
 
-    override fun onUnbindViewHolder(viewHolder: ViewHolder) {
+    final override fun onBindViewHolder(
+        viewHolder: ViewHolder,
+        item: Any?,
+    ) {
+        val cardView = viewHolder.view as ImageCardView
+        if (callback != null) {
+            cardView.setOnLongClickListener(
+                PopupOnLongClickListener(
+                    callback.popUpItems,
+                ) { _, _, pos, _ ->
+                    callback.onItemLongClick(item, pos)
+                },
+            )
+        }
+        doOnBindViewHolder(viewHolder, item)
+    }
+
+    abstract fun doOnBindViewHolder(
+        viewHolder: ViewHolder,
+        item: Any?,
+    )
+
+    final override fun onUnbindViewHolder(viewHolder: ViewHolder) {
         val cardView = viewHolder.view as ImageCardView
         // Remove references to images so that the garbage collector can free up memory
         cardView.badgeImage = null
@@ -153,6 +175,15 @@ abstract class StashPresenter : Presenter() {
             iconView.visibility = View.GONE
             (textView.parent as ViewGroup).visibility = View.GONE
         }
+    }
+
+    interface LongClickCallBack {
+        val popUpItems: List<String>
+
+        fun onItemLongClick(
+            item: Any?,
+            popUpItemPosition: Int,
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
@@ -10,33 +10,33 @@ import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.util.createGlideUrl
 import java.util.EnumMap
 
-class StudioPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+class StudioPresenter(callback: LongClickCallBack<StudioData>? = null) :
+    StashPresenter<StudioData>(callback) {
     override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: StudioData,
     ) {
-        val studio = item as StudioData
         val cardView = viewHolder.view as ImageCardView
 
-        cardView.titleText = studio.name
-        if (studio.parent_studio != null) {
+        cardView.titleText = item.name
+        if (item.parent_studio != null) {
             cardView.contentText =
-                cardView.context.getString(R.string.stashapp_part_of, studio.parent_studio.name)
+                cardView.context.getString(R.string.stashapp_part_of, item.parent_studio.name)
         }
 
         val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-        dataTypeMap[DataType.SCENE] = studio.scene_count
-        dataTypeMap[DataType.PERFORMER] = studio.performer_count
-        dataTypeMap[DataType.MOVIE] = studio.movie_count
+        dataTypeMap[DataType.SCENE] = item.scene_count
+        dataTypeMap[DataType.PERFORMER] = item.performer_count
+        dataTypeMap[DataType.MOVIE] = item.movie_count
         setUpExtraRow(cardView, dataTypeMap, null)
 
-        if (!studio.image_path.isNullOrBlank()) {
+        if (!item.image_path.isNullOrBlank()) {
             cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
             cardView.setMainImageScaleType(ImageView.ScaleType.FIT_CENTER)
             val apiKey =
                 PreferenceManager.getDefaultSharedPreferences(vParent.context)
                     .getString("stashApiKey", "")
-            val url = createGlideUrl(studio.image_path, apiKey)
+            val url = createGlideUrl(item.image_path, apiKey)
             Glide.with(viewHolder.view.context)
                 .load(url)
                 .fitCenter()

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
@@ -10,8 +10,8 @@ import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.util.createGlideUrl
 import java.util.EnumMap
 
-class StudioPresenter : StashPresenter() {
-    override fun onBindViewHolder(
+class StudioPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+    override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
         item: Any?,
     ) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
@@ -13,11 +13,9 @@ import java.util.EnumMap
 class StudioPresenter(callback: LongClickCallBack<StudioData>? = null) :
     StashPresenter<StudioData>(callback) {
     override fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: StudioData,
     ) {
-        val cardView = viewHolder.view as ImageCardView
-
         cardView.titleText = item.name
         if (item.parent_studio != null) {
             cardView.contentText =
@@ -37,7 +35,7 @@ class StudioPresenter(callback: LongClickCallBack<StudioData>? = null) :
                 PreferenceManager.getDefaultSharedPreferences(vParent.context)
                     .getString("stashApiKey", "")
             val url = createGlideUrl(item.image_path, apiKey)
-            Glide.with(viewHolder.view.context)
+            Glide.with(cardView.context)
                 .load(url)
                 .fitCenter()
                 .error(mDefaultCardImage)

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
@@ -5,8 +5,8 @@ import com.github.damontecres.stashapp.api.fragment.TagData
 import com.github.damontecres.stashapp.data.DataType
 import java.util.EnumMap
 
-class TagPresenter : StashPresenter() {
-    override fun onBindViewHolder(
+class TagPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+    override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
         item: Any?,
     ) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
@@ -8,11 +8,9 @@ import java.util.EnumMap
 class TagPresenter(callback: LongClickCallBack<TagData>? = null) :
     StashPresenter<TagData>(callback) {
     override fun doOnBindViewHolder(
-        viewHolder: ViewHolder,
+        cardView: ImageCardView,
         item: TagData,
     ) {
-        val cardView = viewHolder.view as ImageCardView
-
         val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
         dataTypeMap[DataType.SCENE] = item.scene_count
         dataTypeMap[DataType.PERFORMER] = item.performer_count

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
@@ -5,22 +5,22 @@ import com.github.damontecres.stashapp.api.fragment.TagData
 import com.github.damontecres.stashapp.data.DataType
 import java.util.EnumMap
 
-class TagPresenter(callback: LongClickCallBack? = null) : StashPresenter(callback) {
+class TagPresenter(callback: LongClickCallBack<TagData>? = null) :
+    StashPresenter<TagData>(callback) {
     override fun doOnBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any?,
+        item: TagData,
     ) {
-        val tag = item as TagData
         val cardView = viewHolder.view as ImageCardView
 
         val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-        dataTypeMap[DataType.SCENE] = tag.scene_count
-        dataTypeMap[DataType.PERFORMER] = tag.performer_count
-        dataTypeMap[DataType.MARKER] = tag.scene_marker_count
+        dataTypeMap[DataType.SCENE] = item.scene_count
+        dataTypeMap[DataType.PERFORMER] = item.performer_count
+        dataTypeMap[DataType.MARKER] = item.scene_marker_count
         setUpExtraRow(cardView, dataTypeMap, null)
 
-        cardView.titleText = tag.name
-        cardView.contentText = tag.description
+        cardView.titleText = item.name
+        cardView.contentText = item.description
         cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
 
         // TODO: fetch image


### PR DESCRIPTION
Closes #52 

Long click on a performer or tag on the scene view and select `Remove` to remove it from the scene.

This PR also refactors `StashPresenter` to be more strongly typed so there's less casting.