### PR TITLE
Add ability to create a scene marker

### DIFF
--- a/app/src/main/graphql/SceneUpdate.graphql
+++ b/app/src/main/graphql/SceneUpdate.graphql
@@ -9,3 +9,9 @@ mutation SceneUpdate($input: SceneUpdateInput!) {
     }
   }
 }
+
+mutation CreateMarker($input: SceneMarkerCreateInput!) {
+  sceneMarkerCreate(input: $input) {
+    ...MarkerData
+  }
+}

--- a/app/src/main/graphql/SceneUpdate.graphql
+++ b/app/src/main/graphql/SceneUpdate.graphql
@@ -15,3 +15,7 @@ mutation CreateMarker($input: SceneMarkerCreateInput!) {
     ...MarkerData
   }
 }
+
+mutation DeleteMarker($id: ID!) {
+  sceneMarkerDestroy(id: $id)
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
@@ -42,7 +42,6 @@ class SearchForFragment(
     private var taskJob: Job? = null
 
     private val adapter = ArrayObjectAdapter(ListRowPresenter())
-    private val resultsAdapter = ArrayObjectAdapter(StashPresenter.SELECTOR)
 
     private val exceptionHandler =
         CoroutineExceptionHandler { _: CoroutineContext, ex: Throwable ->
@@ -53,7 +52,8 @@ class SearchForFragment(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        title = getString(dataType.pluralStringId)
+        title =
+            requireActivity().intent.getStringExtra(TITLE_KEY) ?: getString(dataType.pluralStringId)
         setSearchResultProvider(this)
         setOnItemViewClickedListener {
                 itemViewHolder: Presenter.ViewHolder,
@@ -76,7 +76,6 @@ class SearchForFragment(
             requireActivity().setResult(Activity.RESULT_OK, result)
             requireActivity().finish()
         }
-        adapter.add(ListRow(HeaderItem("Results"), resultsAdapter))
     }
 
     override fun getResultsAdapter(): ObjectAdapter {
@@ -106,7 +105,7 @@ class SearchForFragment(
     }
 
     private suspend fun search(query: String) {
-        resultsAdapter.clear()
+        adapter.clear()
 
         if (!TextUtils.isEmpty(query)) {
             val perPage =
@@ -119,6 +118,8 @@ class SearchForFragment(
                 )
             val queryEngine = QueryEngine(requireContext(), true)
             viewLifecycleOwner.lifecycleScope.launch(exceptionHandler) {
+                val resultsAdapter = ArrayObjectAdapter(StashPresenter.SELECTOR)
+                adapter.add(ListRow(HeaderItem("Results"), resultsAdapter))
                 resultsAdapter.addAll(0, queryEngine.find(dataType, filter))
             }
         }
@@ -129,5 +130,6 @@ class SearchForFragment(
 
         const val ID_KEY = "id"
         const val RESULT_ID_KEY = "resultId"
+        const val TITLE_KEY = "title"
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/actions/StashAction.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/actions/StashAction.kt
@@ -4,9 +4,10 @@ enum class StashAction(val id: Long, val actionName: String) {
     ADD_TAG(1L, "Add Tag"),
     ADD_PERFORMER(2L, "Add Performer"),
     FORCE_TRANSCODE(3L, "Play with Transcoding"),
+    CREATE_MARKER(4L, "Create Marker from current position"),
     ;
 
     companion object {
-        val SEARCH_FOR_ACTIONS = setOf(ADD_TAG, ADD_PERFORMER)
+        val SEARCH_FOR_ACTIONS = setOf(ADD_TAG, ADD_PERFORMER, CREATE_MARKER)
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
@@ -9,14 +9,17 @@ import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.github.damontecres.stashapp.api.CreateMarkerMutation
 import com.github.damontecres.stashapp.api.MetadataGenerateMutation
 import com.github.damontecres.stashapp.api.MetadataScanMutation
 import com.github.damontecres.stashapp.api.SceneIncrementOMutation
 import com.github.damontecres.stashapp.api.SceneIncrementPlayCountMutation
 import com.github.damontecres.stashapp.api.SceneSaveActivityMutation
 import com.github.damontecres.stashapp.api.SceneUpdateMutation
+import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.type.GenerateMetadataInput
 import com.github.damontecres.stashapp.api.type.ScanMetadataInput
+import com.github.damontecres.stashapp.api.type.SceneMarkerCreateInput
 import com.github.damontecres.stashapp.api.type.SceneUpdateInput
 import com.github.damontecres.stashapp.data.OCounter
 
@@ -198,6 +201,24 @@ class MutationEngine(private val context: Context, private val showToasts: Boole
         val mutation = SceneIncrementOMutation(sceneId.toString())
         val result = executeMutation(mutation)
         return OCounter(sceneId, result.data!!.sceneIncrementO)
+    }
+
+    suspend fun createMarker(
+        sceneId: String,
+        position: Long,
+        primaryTagId: String,
+    ): MarkerData? {
+        val input =
+            SceneMarkerCreateInput(
+                title = "",
+                seconds = position / 1000.0,
+                scene_id = sceneId,
+                primary_tag_id = primaryTagId,
+                tag_ids = Optional.absent(),
+            )
+        val mutation = CreateMarkerMutation(input)
+        val result = executeMutation(mutation)
+        return result.data?.sceneMarkerCreate?.markerData
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
@@ -10,6 +10,7 @@ import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.github.damontecres.stashapp.api.CreateMarkerMutation
+import com.github.damontecres.stashapp.api.DeleteMarkerMutation
 import com.github.damontecres.stashapp.api.MetadataGenerateMutation
 import com.github.damontecres.stashapp.api.MetadataScanMutation
 import com.github.damontecres.stashapp.api.SceneIncrementOMutation
@@ -219,6 +220,12 @@ class MutationEngine(private val context: Context, private val showToasts: Boole
         val mutation = CreateMarkerMutation(input)
         val result = executeMutation(mutation)
         return result.data?.sceneMarkerCreate?.markerData
+    }
+
+    suspend fun deleteMarker(id: String): Boolean {
+        val mutation = DeleteMarkerMutation(id)
+        val result = executeMutation(mutation)
+        return result.data?.sceneMarkerDestroy ?: false
     }
 
     companion object {


### PR DESCRIPTION
Adds an action to the scene details page to create a new scene marker from the scene's current position. It only set a primary tag, no name or secondary tags.

Also a small UI follow up to #98 to remove the row if there the last item was removed.