### PR TITLE
Ensure new markers appear when none existed before

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -629,6 +629,13 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                             newMarker.scene.slimSceneData.scene_markers.map(::convertMarker)
                         markersAdapter.clear()
                         markersAdapter.addAll(0, markers)
+                        mAdapter.set(
+                            MARKER_POS,
+                            ListRow(
+                                HeaderItem(getString(R.string.stashapp_markers)),
+                                markersAdapter,
+                            ),
+                        )
                         Toast.makeText(
                             requireContext(),
                             "Created a new marker with primary tag '${newMarker.primary_tag.tagData.name}'",


### PR DESCRIPTION
Previously, if a scene had no markers and then you added a new one via the app, the new one wouldn't appear on the details page. This PR fixes that by ensuring the adapter row is always added to the page after creating a new marker.