### PR TITLE
Set some minimums in settings

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
@@ -23,8 +23,11 @@ import androidx.preference.PreferenceDialogFragmentCompat
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import androidx.preference.PreferenceScreen
+import androidx.preference.SeekBarPreference
 import androidx.preference.SwitchPreference
 import com.github.damontecres.stashapp.util.MutationEngine
+import com.github.damontecres.stashapp.util.ServerPreferences
+import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.configureHttpsTrust
 import com.github.damontecres.stashapp.util.testStashConnection
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -225,10 +228,6 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
                 val apiKey = manager.getString(apiKeyKey, null)
                 urlPref?.text = server
                 apiKayPref?.text = apiKey
-//                manager.edit(true) {
-//                    putString("stashUrl", server)
-//                    putString("stashApiKey", apiKey)
-//                }
 
                 false
             }
@@ -301,6 +300,19 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
                 val app = requireActivity().application as StashApplication
                 configureHttpsTrust(app, newValue as Boolean)
                 true
+            }
+
+            findPreference<SeekBarPreference>("maxSearchResults")?.min = 5
+            findPreference<SeekBarPreference>("skip_back_time")?.min = 5
+            findPreference<SeekBarPreference>("skip_forward_time")?.min = 5
+            findPreference<SeekBarPreference>("numberOfColumns")?.min = 1
+            findPreference<SeekBarPreference>("searchDelay")?.min = 50
+        }
+
+        override fun onResume() {
+            super.onResume()
+            viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
+                ServerPreferences(requireContext()).updatePreferences()
             }
         }
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -47,7 +47,6 @@
             app:title="Maximum number of search results"
             app:seekBarIncrement="1"
             app:showSeekBarValue="true"
-            android:min="1"
             android:max="100"
             app:defaultValue="25" />
         <SeekBarPreference
@@ -55,7 +54,6 @@
             app:title="Wait for searching (ms)"
             app:seekBarIncrement="50"
             app:showSeekBarValue="true"
-            android:min="50"
             android:max="2000"
             app:defaultValue="500" />
     </PreferenceCategory>
@@ -76,7 +74,6 @@
             app:title="Number of Columns"
             app:seekBarIncrement="1"
             app:showSeekBarValue="true"
-            android:min="1"
             android:max="12"
             app:defaultValue="5" />
 
@@ -94,7 +91,6 @@
             app:title="Skip forward (seconds)"
             app:seekBarIncrement="5"
             app:showSeekBarValue="true"
-            android:min="5"
             android:max="300"
             app:defaultValue="30" />
         <SeekBarPreference
@@ -102,7 +98,6 @@
             app:title="Skip back (seconds)"
             app:seekBarIncrement="5"
             app:showSeekBarValue="true"
-            android:min="5"
             android:max="300"
             app:defaultValue="10" />
         <ListPreference
@@ -121,7 +116,6 @@
             app:title="Hide controls after (milliseconds)"
             app:seekBarIncrement="100"
             app:showSeekBarValue="true"
-            android:min="0"
             android:max="15000"
             app:defaultValue="5000" />
     </PreferenceCategory>


### PR DESCRIPTION
Specifying the minimums for a `SeekBarPreference` in XML require API>=26, but settings it code does not, so move that configuration to code.

Also, refresh the server preferences on resume which will occurs after switching servers.