### PR TITLE
Add option to skip back/forward with D-Pad left/right on ExoPlayer

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -59,8 +59,10 @@ class PlaybackExoFragment :
 
     override val currentVideoPosition get() = player?.currentPosition ?: playbackPosition
 
+    val isControllerVisible get() = videoView.isControllerFullyVisible || previewTimeBar.isShown
+
     override fun hideControlsIfVisible(): Boolean {
-        if (videoView.isControllerFullyVisible || previewTimeBar.isShown) {
+        if (isControllerVisible) {
             videoView.hideController()
             previewTimeBar.hidePreview()
             previewTimeBar.hideScrubber(250L)

--- a/app/src/main/java/com/github/damontecres/stashapp/StashPlayerView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashPlayerView.kt
@@ -1,0 +1,37 @@
+package com.github.damontecres.stashapp
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.KeyEvent
+import androidx.annotation.OptIn
+import androidx.fragment.app.findFragment
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.PlayerView
+
+class StashPlayerView(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : PlayerView(context, attrs, defStyleAttr) {
+    constructor(context: Context, attrs: AttributeSet? = null) : this(context, attrs, 0)
+
+    constructor(context: Context) : this(context, null)
+
+    @OptIn(UnstableApi::class)
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        val keyCode = event.keyCode
+        if (player != null && !findFragment<PlaybackExoFragment>().isControllerVisible &&
+            (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_DPAD_LEFT)
+        ) {
+            if (event.action == KeyEvent.ACTION_DOWN) {
+                if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                    player!!.seekForward()
+                } else if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
+                    player!!.seekBack()
+                }
+            }
+            return true
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+    companion object {
+        const val TAG = "StashPlayerView"
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/StashPlayerView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashPlayerView.kt
@@ -7,16 +7,20 @@ import androidx.annotation.OptIn
 import androidx.fragment.app.findFragment
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
+import androidx.preference.PreferenceManager
 
 class StashPlayerView(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : PlayerView(context, attrs, defStyleAttr) {
     constructor(context: Context, attrs: AttributeSet? = null) : this(context, attrs, 0)
 
     constructor(context: Context) : this(context, null)
 
+    private val dPadSkipEnabled: Boolean =
+        PreferenceManager.getDefaultSharedPreferences(context).getBoolean("skipWithDpad", true)
+
     @OptIn(UnstableApi::class)
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         val keyCode = event.keyCode
-        if (player != null && !findFragment<PlaybackExoFragment>().isControllerVisible &&
+        if (dPadSkipEnabled && player != null && !findFragment<PlaybackExoFragment>().isControllerVisible &&
             (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_DPAD_LEFT)
         ) {
             if (event.action == KeyEvent.ACTION_DOWN) {

--- a/app/src/main/res/layout/video_playback.xml
+++ b/app/src/main/res/layout/video_playback.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.media3.ui.PlayerView
+    <com.github.damontecres.stashapp.StashPlayerView
         android:id="@+id/video_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -100,6 +100,13 @@
             app:showSeekBarValue="true"
             android:max="300"
             app:defaultValue="10" />
+        <SwitchPreference
+            app:key="skipWithDpad"
+            app:title="D-Pad skipping"
+            app:summaryOn="Skip back/forward with D-Pad left/right on ExoPlayer"
+            app:summaryOff="Don't skip back/forward with D-Pad left/right on ExoPlayer"
+            app:defaultValue="true"
+            />
         <ListPreference
             app:key="stream_choice"
             app:title="Stream Choice"


### PR DESCRIPTION
Adds a preference (enabled by default) to skip back or skip forward when pressing the D-Pad left button or right button respectively.

This only works for ExoPlayer.