### PR TITLE
Add rating to scene details and allow updating the rating

### DIFF
--- a/app/src/main/graphql/SceneUpdate.graphql
+++ b/app/src/main/graphql/SceneUpdate.graphql
@@ -7,6 +7,7 @@ mutation SceneUpdate($input: SceneUpdateInput!) {
     performers {
       ...PerformerData
     }
+    rating100
   }
 }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/StashOnFocusChangeListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashOnFocusChangeListener.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.view.View
 import androidx.core.content.ContextCompat
 
-class StashOnFocusChangeListener(val context: Context) : View.OnFocusChangeListener {
+open class StashOnFocusChangeListener(val context: Context) : View.OnFocusChangeListener {
     private val mFocusedZoom =
         context.resources.getFraction(
             androidx.leanback.R.fraction.lb_search_orb_focused_zoom,

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -91,7 +91,14 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     private val playActionsAdapter = ArrayObjectAdapter()
     private var position = -1L // The position in the video
     private val detailsPresenter =
-        FullWidthDetailsOverviewRowPresenter(DetailsDescriptionPresenter())
+        FullWidthDetailsOverviewRowPresenter(
+            DetailsDescriptionPresenter { sceneId: Int, rating100: Int ->
+                viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
+                    MutationEngine(requireContext()).setRating(sceneId, rating100)
+                    Toast.makeText(requireContext(), "Set a new rating!", Toast.LENGTH_SHORT).show()
+                }
+            },
+        )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d(TAG, "onCreate DetailsFragment")

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/DetailsDescriptionPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/DetailsDescriptionPresenter.kt
@@ -1,12 +1,21 @@
 package com.github.damontecres.stashapp.presenters
 
+import android.annotation.SuppressLint
+import android.view.View
+import android.widget.RatingBar
+import android.widget.SeekBar
+import android.widget.TextView
 import androidx.leanback.widget.AbstractDetailsDescriptionPresenter
+import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.StashOnFocusChangeListener
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.util.Constants
+import com.github.damontecres.stashapp.util.ServerPreferences
 import com.github.damontecres.stashapp.util.concatIfNotBlank
 import com.github.damontecres.stashapp.util.titleOrFilename
 
-class DetailsDescriptionPresenter : AbstractDetailsDescriptionPresenter() {
+class DetailsDescriptionPresenter(val ratingCallback: RatingCallback) :
+    AbstractDetailsDescriptionPresenter() {
     override fun onBindDescription(
         viewHolder: ViewHolder,
         item: Any,
@@ -29,5 +38,83 @@ class DetailsDescriptionPresenter : AbstractDetailsDescriptionPresenter() {
                     resolution,
                 )
         }
+        val serverPreferences = ServerPreferences(viewHolder.view.context)
+        val type =
+            serverPreferences.preferences.getString(ServerPreferences.PREF_RATING_TYPE, "star")
+        val precision =
+            serverPreferences.preferences.getFloat(ServerPreferences.PREF_RATING_PRECISION, 1.0f)
+
+        val ratingBar = viewHolder.view.findViewById<RatingBar>(R.id.rating)
+        val ratingBarDecimal = viewHolder.view.findViewById<SeekBar>(R.id.rating_decimal)
+        val ratingBarDecimalHolder = viewHolder.view.findViewById<View>(R.id.rating_decimal_holder)
+        val ratingBarDecimalText = viewHolder.view.findViewById<TextView>(R.id.rating_decimal_text)
+        if (type == "decimal") {
+            ratingBar.visibility = View.GONE
+        } else {
+            // star
+            ratingBarDecimalHolder.visibility = View.GONE
+        }
+
+        var currentRating = scene.rating100 ?: 0
+
+        ratingBar.rating = (scene.rating100?.div(20.0))?.toFloat() ?: 0.0f
+        ratingBar.stepSize = precision
+
+        ratingBarDecimal.setOnSeekBarChangeListener(
+            object : SeekBar.OnSeekBarChangeListener {
+                @SuppressLint("SetTextI18n")
+                override fun onProgressChanged(
+                    seekBar: SeekBar?,
+                    progress: Int,
+                    fromUser: Boolean,
+                ) {
+                    ratingBarDecimalText.text =
+                        viewHolder.view.context.getString(R.string.stashapp_rating) + " (${progress / 10.0}):"
+                }
+
+                override fun onStartTrackingTouch(seekBar: SeekBar?) {
+                    // no-op
+                }
+
+                override fun onStopTrackingTouch(seekBar: SeekBar?) {
+                    // no-op
+                }
+            },
+        )
+        ratingBarDecimal.progress = scene.rating100 ?: 0
+        ratingBarDecimalText.text =
+            viewHolder.view.context.getString(R.string.stashapp_rating) + " (${currentRating / 10.0}):"
+
+        ratingBar.setOnClickListener {
+            currentRating = (ratingBar.rating * 20).toInt()
+            ratingCallback.setRating(scene.id.toInt(), currentRating)
+        }
+        ratingBarDecimal.setOnClickListener {
+            currentRating = ratingBarDecimal.progress
+            ratingCallback.setRating(scene.id.toInt(), currentRating)
+        }
+
+        val focusChangeListener =
+            object : StashOnFocusChangeListener(ratingBar.context) {
+                override fun onFocusChange(
+                    v: View,
+                    hasFocus: Boolean,
+                ) {
+                    super.onFocusChange(v, hasFocus)
+                    if (!hasFocus) {
+                        ratingBar.rating = currentRating / 20.0f
+                        ratingBarDecimal.progress = currentRating
+                    }
+                }
+            }
+        ratingBar.onFocusChangeListener = focusChangeListener
+        ratingBarDecimal.onFocusChangeListener = focusChangeListener
+    }
+
+    fun interface RatingCallback {
+        fun setRating(
+            sceneId: Int,
+            rating100: Int,
+        )
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
@@ -242,6 +242,22 @@ class MutationEngine(private val context: Context, private val showToasts: Boole
         return result.data?.sceneMarkerDestroy ?: false
     }
 
+    suspend fun setRating(
+        sceneId: Int,
+        rating100: Int,
+    ) {
+        Log.v(TAG, "setRating sceneId=$sceneId, rating=$rating100")
+        val mutation =
+            SceneUpdateMutation(
+                input =
+                    SceneUpdateInput(
+                        id = sceneId.toString(),
+                        rating100 = Optional.present(rating100),
+                    ),
+            )
+        executeMutation(mutation)
+    }
+
     companion object {
         const val TAG = "MutationEngine"
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
@@ -47,6 +47,30 @@ class ServerPreferences(private val context: Context) {
                         Log.w(TAG, "$PREF_MINIMUM_PLAY_PERCENT is not an integer: '$it'")
                     }
                 }
+                val ratingSystemOptionsRaw = ui.getCaseInsensitive("ratingSystemOptions")
+                if (ratingSystemOptionsRaw != null) {
+                    try {
+                        val ratingSystemOptions = ratingSystemOptionsRaw as Map<String, String>
+                        val type = ratingSystemOptions["type"] ?: "star"
+                        val starPrecision =
+                            when (ratingSystemOptions["starPrecision"]?.lowercase()) {
+                                "full" -> 1.0f
+                                "half" -> 0.5f
+                                "quarter" -> 0.25f
+                                "tenth" -> 0.1f
+                                else -> null
+                            }
+                        putString(PREF_RATING_TYPE, type)
+                        if (starPrecision != null) {
+                            putFloat(PREF_RATING_PRECISION, starPrecision)
+                        }
+                    } catch (ex: Exception) {
+                        Log.e(
+                            TAG,
+                            "Exception parsing ratingSystemOptions: $ratingSystemOptionsRaw",
+                        )
+                    }
+                }
 
                 val scan = config.defaults.scan
                 if (scan != null) {
@@ -88,6 +112,8 @@ class ServerPreferences(private val context: Context) {
 
         const val PREF_TRACK_ACTIVITY = "trackActivity"
         const val PREF_MINIMUM_PLAY_PERCENT = "minimumPlayPercent"
+        const val PREF_RATING_TYPE = "ratingSystemOptions.type"
+        const val PREF_RATING_PRECISION = "ratingSystemOptions.starPrecision"
 
         // Scan default settings
         const val PREF_SCAN_GENERATE_COVERS = "scanGenerateCovers"

--- a/app/src/main/res/layout/lb_details_description.xml
+++ b/app/src/main/res/layout/lb_details_description.xml
@@ -1,0 +1,57 @@
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    >
+
+    <TextView
+        android:id="@+id/lb_details_description_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="?attr/detailsDescriptionTitleStyle"
+        />
+
+    <RatingBar
+        android:id="@+id/rating"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:numStars="5"
+        android:stepSize=".5"
+        android:isIndicator="false"
+        android:theme="@style/RatingBar"
+        />
+
+    <LinearLayout
+        android:id="@+id/rating_decimal_holder"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <TextView
+            android:id="@+id/rating_decimal_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/stashapp_rating"
+            style="?attr/detailsDescriptionSubtitleStyle"/>
+        <SeekBar
+            android:id="@+id/rating_decimal"
+            android:layout_width="250dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="45dp"
+            android:max="100" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/lb_details_description_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="?attr/detailsDescriptionSubtitleStyle"
+        />
+
+    <TextView
+        android:id="@+id/lb_details_description_body"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="?attr/detailsDescriptionBodyStyle"
+        />
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,4 +6,5 @@
     <color name="selected_background">#4785b5</color>
     <color name="default_background">#202b33</color>
     <color name="default_card_background">#30404d</color>
+    <color name="gold">#FFD700</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,4 +12,9 @@
         <item name="android:colorBackground">@color/default_background</item>
     </style>
 
+    <style name="RatingBar" parent="Theme.AppCompat">
+        <item name="colorControlNormal">@android:color/darker_gray</item>
+        <item name="colorControlActivated">@color/gold</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Adds the scene's rating to the scene details page. If the type is `start`, a `RatingBar` (five stars) is used, otherwise for `decimal` a `SeekBar` is used.

You can highlight the rating and move it left/right and then press enter/OK to set the new rating.

Like usual, the UI is a bit rough, but it's a great feature to add I think and work on refining later.