### PR TITLE
Add option to scroll long scene details text

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
@@ -21,6 +21,7 @@ import com.github.damontecres.stashapp.presenters.StashPresenter
 import com.github.damontecres.stashapp.util.QueryEngine
 import com.github.damontecres.stashapp.util.ageInYears
 import com.github.damontecres.stashapp.util.createGlideUrl
+import com.github.damontecres.stashapp.util.onlyScrollIfNeeded
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
 import kotlin.math.floor
@@ -130,14 +131,7 @@ class PerformerFragment : Fragment(R.layout.performer_view) {
     override fun onResume() {
         super.onResume()
         val scrollView = requireView().findViewById<ScrollView>(R.id.performer_scrollview)
-
-        scrollView.viewTreeObserver.addOnGlobalLayoutListener {
-            val childHeight = scrollView.getChildAt(0).height
-            val isScrollable =
-                scrollView.height < childHeight + scrollView.paddingTop + scrollView.paddingBottom
-            Log.v(TAG, "isScrollable=$isScrollable")
-            scrollView.isFocusable = isScrollable
-        }
+        scrollView.onlyScrollIfNeeded()
     }
 
     private fun addRow(

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/DetailsDescriptionPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/DetailsDescriptionPresenter.kt
@@ -5,13 +5,16 @@ import android.view.View
 import android.widget.RatingBar
 import android.widget.SeekBar
 import android.widget.TextView
+import androidx.core.widget.NestedScrollView
 import androidx.leanback.widget.AbstractDetailsDescriptionPresenter
+import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.StashOnFocusChangeListener
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.util.Constants
 import com.github.damontecres.stashapp.util.ServerPreferences
 import com.github.damontecres.stashapp.util.concatIfNotBlank
+import com.github.damontecres.stashapp.util.onlyScrollIfNeeded
 import com.github.damontecres.stashapp.util.titleOrFilename
 
 class DetailsDescriptionPresenter(val ratingCallback: RatingCallback) :
@@ -24,6 +27,17 @@ class DetailsDescriptionPresenter(val ratingCallback: RatingCallback) :
 
         viewHolder.title.text = scene.titleOrFilename
         viewHolder.body.text = scene.details
+
+        val scrollView = viewHolder.view.findViewById<NestedScrollView>(R.id.description_scrollview)
+        val useScrollbar =
+            PreferenceManager.getDefaultSharedPreferences(viewHolder.view.context)
+                .getBoolean("scrollSceneDetails", true)
+        if (useScrollbar) {
+            scrollView.onlyScrollIfNeeded()
+        } else {
+            scrollView.isFocusable = false
+            scrollView.isVerticalScrollBarEnabled = false
+        }
 
         val file = scene.files.firstOrNull()
         if (file != null) {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -7,9 +7,11 @@ import android.os.Build
 import android.text.TextUtils
 import android.util.Log
 import android.util.TypedValue
+import android.widget.ScrollView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.RequiresApi
+import androidx.core.widget.NestedScrollView
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.Optional
@@ -394,3 +396,21 @@ val PerformerData.ageInYears: Int?
         } else {
             null
         }
+
+fun ScrollView.onlyScrollIfNeeded() {
+    viewTreeObserver.addOnGlobalLayoutListener {
+        val childHeight = getChildAt(0).height
+        val isScrollable =
+            height < childHeight + paddingTop + paddingBottom
+        isFocusable = isScrollable
+    }
+}
+
+fun NestedScrollView.onlyScrollIfNeeded() {
+    viewTreeObserver.addOnGlobalLayoutListener {
+        val childHeight = getChildAt(0).height
+        val isScrollable =
+            height < childHeight + paddingTop + paddingBottom
+        isFocusable = isScrollable
+    }
+}

--- a/app/src/main/res/layout/lb_details_description.xml
+++ b/app/src/main/res/layout/lb_details_description.xml
@@ -1,7 +1,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     >
 
@@ -45,13 +45,22 @@
         android:id="@+id/lb_details_description_subtitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        style="?attr/detailsDescriptionSubtitleStyle"
-        />
+        style="?attr/detailsDescriptionSubtitleStyle" />
 
-    <TextView
-        android:id="@+id/lb_details_description_body"
-        android:layout_width="wrap_content"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/description_scrollview"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        style="?attr/detailsDescriptionBodyStyle"
-        />
+        android:paddingBottom="25dp"
+        android:fadeScrollbars="false"
+        android:scrollbars="vertical"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:scrollbarThumbVertical="@color/focus_color">
+
+        <TextView
+            android:id="@+id/lb_details_description_body"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="?attr/detailsDescriptionBodyStyle" />
+    </androidx.core.widget.NestedScrollView>
 </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <integer tools:override="true" name="lb_details_description_body_max_lines">18</integer>
+    <integer tools:override="true" name="lb_details_description_body_max_lines">1000</integer>
     <dimen name="title_bar_height">60dp</dimen>
     <dimen name="title_bar_margin">10dp</dimen>
     <dimen name="table_text_size">13sp</dimen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -81,8 +81,13 @@
             app:key="scrollToNextResult"
             app:title="Scroll to next on View All"
             app:summary="Automatically scroll down to the 'next' results when clicking View All on main page"
-            app:defaultValue="true"
-            />
+            app:defaultValue="true" />
+        <SwitchPreference
+            app:key="scrollSceneDetails"
+            app:title="Long scene details behavior"
+            app:summaryOn="Scroll if needed"
+            app:summaryOff="Truncate details"
+            app:defaultValue="true" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Playback">


### PR DESCRIPTION
Adds a preference (enabled by default) which adds scrolling to scenes with long details. Long details are about ~18 lines or longer.

When enabled, the entire details section is scrollable and must be scrolled to the bottom to move to the rows below. If no scrolling is needed, then it acts as if disabled.

When disabled, the details section is truncated to whatever fits in the view.