### PR TITLE
Add preference to control behavior when playback finishes

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -126,16 +126,19 @@ class PlaybackExoFragment :
                         PreferenceManager.getDefaultSharedPreferences(requireContext())
                             .getString(
                                 "playbackFinishedBehavior",
-                                R.integer.playback_finished_do_nothing.toString(),
-                            )!!.toInt()
+                                getString(R.string.playback_finished_do_nothing),
+                            )
                     when (finishedBehavior) {
-                        resources.getInteger(R.integer.playback_finished_repeat) -> {
+                        getString(R.string.playback_finished_repeat) -> {
                             exoPlayer.addListener(
                                 object :
                                     Player.Listener {
                                     override fun onAvailableCommandsChanged(availableCommands: Player.Commands) {
                                         if (Player.COMMAND_SET_REPEAT_MODE in availableCommands) {
-                                            Log.v(TAG, "Listener setting repeatMode to REPEAT_MODE_ONE")
+                                            Log.v(
+                                                TAG,
+                                                "Listener setting repeatMode to REPEAT_MODE_ONE",
+                                            )
                                             exoPlayer.repeatMode = Player.REPEAT_MODE_ONE
                                             exoPlayer.removeListener(this)
                                         }
@@ -144,7 +147,7 @@ class PlaybackExoFragment :
                             )
                         }
 
-                        resources.getInteger(R.integer.playback_finished_return) ->
+                        getString(R.string.playback_finished_return) ->
                             exoPlayer.addListener(
                                 object :
                                     Player.Listener {
@@ -156,7 +159,7 @@ class PlaybackExoFragment :
                                     }
                                 })
 
-                        resources.getInteger(R.integer.playback_finished_do_nothing) -> {
+                        getString(R.string.playback_finished_do_nothing) -> {
                             // no-op
                         }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -122,6 +122,47 @@ class PlaybackExoFragment :
                         exoPlayer.addListener(PlaybackListener())
                     }
                 }.also { exoPlayer ->
+                    val finishedBehavior =
+                        PreferenceManager.getDefaultSharedPreferences(requireContext())
+                            .getString(
+                                "playbackFinishedBehavior",
+                                R.integer.playback_finished_do_nothing.toString(),
+                            )!!.toInt()
+                    when (finishedBehavior) {
+                        resources.getInteger(R.integer.playback_finished_repeat) -> {
+                            exoPlayer.addListener(
+                                object :
+                                    Player.Listener {
+                                    override fun onAvailableCommandsChanged(availableCommands: Player.Commands) {
+                                        if (Player.COMMAND_SET_REPEAT_MODE in availableCommands) {
+                                            Log.v(TAG, "Listener setting repeatMode to REPEAT_MODE_ONE")
+                                            exoPlayer.repeatMode = Player.REPEAT_MODE_ONE
+                                            exoPlayer.removeListener(this)
+                                        }
+                                    }
+                                },
+                            )
+                        }
+
+                        resources.getInteger(R.integer.playback_finished_return) ->
+                            exoPlayer.addListener(
+                                object :
+                                    Player.Listener {
+                                    override fun onPlaybackStateChanged(playbackState: Int) {
+                                        if (playbackState == Player.STATE_ENDED) {
+                                            Log.v(TAG, "Finishing activity")
+                                            requireActivity().finish()
+                                        }
+                                    }
+                                })
+
+                        resources.getInteger(R.integer.playback_finished_do_nothing) -> {
+                            // no-op
+                        }
+
+                        else -> Log.w(TAG, "Unknown playbackFinishedBehavior: $finishedBehavior")
+                    }
+                }.also { exoPlayer ->
                     var mediaItem: MediaItem? = null
                     var streamUrl = scene.streams["Direct stream"]
                     if (streamUrl != null && scene.videoCodec != "av1" && !forceTranscode) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -6,19 +6,13 @@
         <item>WEBM</item>
     </string-array>
 
+    <string name="playback_finished_do_nothing">Do nothing</string>
+    <string name="playback_finished_repeat">Repeat scene</string>
+    <string name="playback_finished_return">Return to scene details</string>
     <string-array name="playback_finished_behavior_options">
-        <item>Do nothing</item>
-        <item>Repeat scene</item>
-        <item>Return to scene details</item>
-    </string-array>
-
-    <integer name="playback_finished_do_nothing">0</integer>
-    <integer name="playback_finished_repeat">1</integer>
-    <integer name="playback_finished_return">2</integer>
-    <string-array name="playback_finished_behavior_options_values">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
+        <item>@string/playback_finished_do_nothing</item>
+        <item>@string/playback_finished_repeat</item>
+        <item>@string/playback_finished_return</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -5,4 +5,20 @@
         <item>MP4</item>
         <item>WEBM</item>
     </string-array>
+
+    <string-array name="playback_finished_behavior_options">
+        <item>Do nothing</item>
+        <item>Repeat scene</item>
+        <item>Return to scene details</item>
+    </string-array>
+
+    <integer name="playback_finished_do_nothing">0</integer>
+    <integer name="playback_finished_repeat">1</integer>
+    <integer name="playback_finished_return">2</integer>
+    <string-array name="playback_finished_behavior_options_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -125,6 +125,14 @@
             app:showSeekBarValue="true"
             android:max="15000"
             app:defaultValue="5000" />
+        <ListPreference
+            app:key="playbackFinishedBehavior"
+            app:title="Playback finished behavior"
+            app:defaultValue="0"
+            app:useSimpleSummaryProvider="true"
+            app:entries="@array/playback_finished_behavior_options"
+            app:entryValues="@array/playback_finished_behavior_options_values"
+            />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/stashapp_config_tasks_job_queue">

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -128,10 +128,10 @@
         <ListPreference
             app:key="playbackFinishedBehavior"
             app:title="Playback finished behavior"
-            app:defaultValue="0"
+            app:defaultValue="@string/playback_finished_do_nothing"
             app:useSimpleSummaryProvider="true"
             app:entries="@array/playback_finished_behavior_options"
-            app:entryValues="@array/playback_finished_behavior_options_values"
+            app:entryValues="@array/playback_finished_behavior_options"
             />
     </PreferenceCategory>
 


### PR DESCRIPTION
Adds a new preference to control what happens when playback of a scene finished:
1. `Do nothing` - Default & current behavior where the last frame remains in view
2. `Repeat scene` - Restart playback from the beginning
3. `Return to scene details` - Close the player and return the scene details page (markers will return the previous page)