### PR TITLE
Fixes using the right value for 'stars'

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/DetailsDescriptionPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/DetailsDescriptionPresenter.kt
@@ -53,8 +53,6 @@ class DetailsDescriptionPresenter(val ratingCallback: RatingCallback) :
                 )
         }
         val serverPreferences = ServerPreferences(viewHolder.view.context)
-        val type =
-            serverPreferences.preferences.getString(ServerPreferences.PREF_RATING_TYPE, "star")
         val precision =
             serverPreferences.preferences.getFloat(ServerPreferences.PREF_RATING_PRECISION, 1.0f)
 
@@ -62,11 +60,11 @@ class DetailsDescriptionPresenter(val ratingCallback: RatingCallback) :
         val ratingBarDecimal = viewHolder.view.findViewById<SeekBar>(R.id.rating_decimal)
         val ratingBarDecimalHolder = viewHolder.view.findViewById<View>(R.id.rating_decimal_holder)
         val ratingBarDecimalText = viewHolder.view.findViewById<TextView>(R.id.rating_decimal_text)
-        if (type == "decimal") {
-            ratingBar.visibility = View.GONE
-        } else {
-            // star
+        if (serverPreferences.ratingsAsStars) {
             ratingBarDecimalHolder.visibility = View.GONE
+        } else {
+            // decimal
+            ratingBar.visibility = View.GONE
         }
 
         var currentRating = scene.rating100 ?: 0

--- a/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
@@ -22,7 +22,7 @@ class ServerPreferences(private val context: Context) {
 
     val minimumPlayPercent get() = preferences.getInt(PREF_MINIMUM_PLAY_PERCENT, 20)
 
-    val ratingsAsStars get() = preferences.getString(PREF_RATING_TYPE, "stars") == "star"
+    val ratingsAsStars get() = preferences.getString(PREF_RATING_TYPE, "stars") == "stars"
 
     suspend fun updatePreferences() {
         val queryEngine = QueryEngine(context)


### PR DESCRIPTION
The rating type for `stars` was being inconsistently used and this PR fixes that.