### PR TITLE
Move network calls to IO dispatcher

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -90,7 +90,7 @@ class MainFragment : BrowseSupportFragment() {
         browseFrameLayout.onFocusSearchListener =
             OnFocusSearchListener { focused: View?, direction: Int ->
                 if (direction == View.FOCUS_UP) {
-                    requireActivity().findViewById(androidx.leanback.R.id.search_orb)
+                    requireActivity().findViewById(R.id.search_button)
                 } else {
                     null
                 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -32,6 +32,8 @@ import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.util.Constants.STASH_API_HEADER
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import java.io.File
 import java.security.SecureRandom
@@ -241,50 +243,61 @@ suspend fun testStashConnection(
     context: Context,
     showToast: Boolean,
 ): ServerInfoQuery.Data? {
-    val client = createApolloClient(context)
-    if (client == null) {
-        if (showToast) {
-            Toast.makeText(
-                context,
-                "Stash server URL is not set.",
-                Toast.LENGTH_LONG,
-            ).show()
-        }
-    } else {
-        try {
-            val info = client.query(ServerInfoQuery()).execute()
-            if (info.hasErrors()) {
-                if (showToast) {
-                    Toast.makeText(
-                        context,
-                        "Failed to connect to Stash. Check URL or API Key.",
-                        Toast.LENGTH_LONG,
-                    ).show()
-                }
-                Log.w(Constants.TAG, "Errors in ServerInfoQuery: ${info.errors}")
-            } else {
-                if (showToast) {
-                    val version = info.data?.version?.version
-                    val sceneCount = info.data?.stats?.scene_count
-                    Toast.makeText(
-                        context,
-                        "Connected to Stash ($version) with $sceneCount scenes!",
-                        Toast.LENGTH_SHORT,
-                    ).show()
-                }
-                return info.data
+    return withContext(Dispatchers.IO) {
+        val client = createApolloClient(context)
+        if (client == null) {
+            if (showToast) {
+                Toast.makeText(
+                    context,
+                    "Stash server URL is not set.",
+                    Toast.LENGTH_LONG,
+                ).show()
             }
-        } catch (ex: ApolloHttpException) {
-            Log.e(Constants.TAG, "ApolloHttpException", ex)
-            if (ex.statusCode == 401 || ex.statusCode == 403) {
-                if (showToast) {
-                    Toast.makeText(
-                        context,
-                        "Failed to connect to Stash. API Key was not valid.",
-                        Toast.LENGTH_LONG,
-                    ).show()
+        } else {
+            try {
+                val info = client.query(ServerInfoQuery()).execute()
+                if (info.hasErrors()) {
+                    if (showToast) {
+                        Toast.makeText(
+                            context,
+                            "Failed to connect to Stash. Check URL or API Key.",
+                            Toast.LENGTH_LONG,
+                        ).show()
+                    }
+                    Log.w(Constants.TAG, "Errors in ServerInfoQuery: ${info.errors}")
+                } else {
+                    if (showToast) {
+                        val version = info.data?.version?.version
+                        val sceneCount = info.data?.stats?.scene_count
+                        Toast.makeText(
+                            context,
+                            "Connected to Stash ($version) with $sceneCount scenes!",
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    }
+                    return@withContext info.data
                 }
-            } else {
+            } catch (ex: ApolloHttpException) {
+                Log.e(Constants.TAG, "ApolloHttpException", ex)
+                if (ex.statusCode == 401 || ex.statusCode == 403) {
+                    if (showToast) {
+                        Toast.makeText(
+                            context,
+                            "Failed to connect to Stash. API Key was not valid.",
+                            Toast.LENGTH_LONG,
+                        ).show()
+                    }
+                } else {
+                    if (showToast) {
+                        Toast.makeText(
+                            context,
+                            "Failed to connect to Stash. Error was '${ex.message}'",
+                            Toast.LENGTH_LONG,
+                        ).show()
+                    }
+                }
+            } catch (ex: ApolloException) {
+                Log.e(Constants.TAG, "ApolloException", ex)
                 if (showToast) {
                     Toast.makeText(
                         context,
@@ -293,18 +306,9 @@ suspend fun testStashConnection(
                     ).show()
                 }
             }
-        } catch (ex: ApolloException) {
-            Log.e(Constants.TAG, "ApolloException", ex)
-            if (showToast) {
-                Toast.makeText(
-                    context,
-                    "Failed to connect to Stash. Error was '${ex.message}'",
-                    Toast.LENGTH_LONG,
-                ).show()
-            }
         }
+        return@withContext null
     }
-    return null
 }
 
 fun convertFilter(filter: SavedFilterData.Find_filter?): FindFilterType? {


### PR DESCRIPTION
The networks calls should happen with `Dispatchers.IO` so that UI updates are not blocked. The UI blocking is probably not signifcant on a fast LAN connection, but just in case.