### PR TITLE
Stop video preview when not selected

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
@@ -98,6 +98,7 @@ class StashImageCardView(context: Context) : ImageCardView(context) {
             } else {
                 showImage()
                 StashExoPlayer.removeListeners()
+                videoView.player?.stop()
                 videoView.player = null
             }
         }


### PR DESCRIPTION
Realized that stopping the video preview playback got lost in the shuffle.

This isn't really noticeable unless the audio is enabled, but this prevents the video/audio from playing the background after navigating off of a card.