### PR TITLE
Fixes to scene details UI glitches

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -142,8 +142,11 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 
-    override fun onResume() {
-        super.onResume()
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
 
         val sceneId = requireActivity().intent.getStringExtra(VideoDetailsActivity.MOVIE)
         if (sceneId == null) {
@@ -387,6 +390,22 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                         performersAdapter.addAll(0, perfs)
                     }
                 }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
+            if (mSelectedMovie != null) {
+                val queryEngine = QueryEngine(requireContext())
+                mSelectedMovie = queryEngine.getScene(mSelectedMovie!!.id.toInt())
+                // Refresh the o-counter which could have changed
+                sceneActionsAdapter.set(
+                    O_COUNTER_POS,
+                    OCounter(mSelectedMovie!!.id.toInt(), mSelectedMovie!!.o_counter ?: 0),
+                )
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -88,7 +88,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     private val mAdapter = SparseArrayObjectAdapter(mPresenterSelector)
     private lateinit var resultLauncher: ActivityResultLauncher<Intent>
 
-    private val playActionsAdapter = ArrayObjectAdapter()
+    private val playActionsAdapter = SparseArrayObjectAdapter()
     private var position = -1L // The position in the video
     private val detailsPresenter =
         FullWidthDetailsOverviewRowPresenter(
@@ -465,19 +465,20 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 )
         }
 
-        playActionsAdapter.clear()
         val serverPreferences = ServerPreferences(requireContext())
         if (serverPreferences.trackActivity && mSelectedMovie?.resume_time != null && mSelectedMovie?.resume_time!! > 0) {
             position = (mSelectedMovie?.resume_time!! * 1000).toLong()
-            playActionsAdapter.add(Action(ACTION_RESUME_SCENE, "Resume"))
-            playActionsAdapter.add(Action(ACTION_PLAY_SCENE, "Restart"))
+            playActionsAdapter.set(0, Action(ACTION_RESUME_SCENE, "Resume"))
+            playActionsAdapter.set(1, Action(ACTION_PLAY_SCENE, "Restart"))
         } else {
-            playActionsAdapter.add(
+            playActionsAdapter.set(
+                0,
                 Action(
                     ACTION_PLAY_SCENE,
                     resources.getString(R.string.play_scene),
                 ),
             )
+            playActionsAdapter.clear(1)
         }
 
         row.actionsAdapter = playActionsAdapter
@@ -716,9 +717,8 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     if (position > 10_000) {
                         // If some of the video played, reset the available actions
                         // This also causes the focused action to default to resume which is an added bonus
-                        playActionsAdapter.clear()
-                        playActionsAdapter.add(Action(ACTION_RESUME_SCENE, "Resume"))
-                        playActionsAdapter.add(Action(ACTION_PLAY_SCENE, "Restart"))
+                        playActionsAdapter.set(0, Action(ACTION_RESUME_SCENE, "Resume"))
+                        playActionsAdapter.set(1, Action(ACTION_PLAY_SCENE, "Restart"))
 
                         val serverPreferences = ServerPreferences(requireContext())
                         if (serverPreferences.trackActivity) {

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -435,8 +435,6 @@ class VideoDetailsFragment : DetailsSupportFragment() {
 
     private fun setupDetailsOverviewRow() {
         val row = DetailsOverviewRow(mSelectedMovie!!)
-        row.imageDrawable =
-            ContextCompat.getDrawable(requireActivity(), R.drawable.default_background)
         val width = convertDpToPixel(requireActivity(), DETAIL_THUMB_WIDTH)
         val height = convertDpToPixel(requireActivity(), DETAIL_THUMB_HEIGHT)
 

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -138,7 +138,9 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         val actionListener = SceneActionListener()
         onItemViewClickedListener =
             StashItemViewClickListener(requireActivity(), actionListener)
-
+        setupDetailsOverviewRowPresenter()
+        mAdapter.set(ACTIONS_POS, ListRow(HeaderItem("Actions"), sceneActionsAdapter))
+        mPresenterSelector.addClassPresenter(ListRow::class.java, ListRowPresenter())
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 
@@ -155,11 +157,6 @@ class VideoDetailsFragment : DetailsSupportFragment() {
             startActivity(intent)
         } else {
             val queryEngine = QueryEngine(requireContext())
-
-            setupDetailsOverviewRowPresenter()
-            mAdapter.set(ACTIONS_POS, ListRow(HeaderItem("Actions"), sceneActionsAdapter))
-            mPresenterSelector.addClassPresenter(ListRow::class.java, ListRowPresenter())
-
             viewLifecycleOwner.lifecycleScope.launch(
                 StashCoroutineExceptionHandler(
                     Toast.makeText(

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -152,6 +152,11 @@ class VideoDetailsFragment : DetailsSupportFragment() {
             startActivity(intent)
         } else {
             val queryEngine = QueryEngine(requireContext())
+
+            setupDetailsOverviewRowPresenter()
+            mAdapter.set(ACTIONS_POS, ListRow(HeaderItem("Actions"), sceneActionsAdapter))
+            mPresenterSelector.addClassPresenter(ListRow::class.java, ListRowPresenter())
+
             viewLifecycleOwner.lifecycleScope.launch(
                 StashCoroutineExceptionHandler(
                     Toast.makeText(
@@ -166,8 +171,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     position = (mSelectedMovie!!.resume_time!! * 1000).toLong()
                 }
                 setupDetailsOverviewRow()
-                setupDetailsOverviewRowPresenter()
-                setupRelatedMovieListRow()
+
                 adapter = mAdapter
                 initializeBackground()
 
@@ -504,12 +508,6 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 }
             }
         mPresenterSelector.addClassPresenter(DetailsOverviewRow::class.java, detailsPresenter)
-    }
-
-    private fun setupRelatedMovieListRow() {
-        // TODO related scenes
-        mAdapter.set(ACTIONS_POS, ListRow(HeaderItem("Actions"), sceneActionsAdapter))
-        mPresenterSelector.addClassPresenter(ListRow::class.java, ListRowPresenter())
     }
 
     private fun convertDpToPixel(

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
@@ -209,10 +209,10 @@ class StashImageCardView(context: Context) : ImageCardView(context) {
     }
 
     fun showVideo() {
-        mainView.showNext()
+        mainView.displayedChild = 1
     }
 
     fun showImage() {
-        mainView.showPrevious()
+        mainView.displayedChild = 0
     }
 }

--- a/app/src/main/res/drawable/default_background.xml
+++ b/app/src/main/res/drawable/default_background.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <gradient
-        android:angle="-270"
-        android:endColor="@color/background_gradient_end"
-        android:startColor="@color/background_gradient_start" />
-</shape>

--- a/app/src/main/res/layout/lb_image_card_view.xml
+++ b/app/src/main/res/layout/lb_image_card_view.xml
@@ -24,7 +24,6 @@
         lb:layout_viewType="main"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="@android:color/black"
         android:inAnimation="@android:anim/fade_in"
         android:outAnimation="@android:anim/fade_out"
         android:animateFirstView="true">
@@ -43,6 +42,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:adjustViewBounds="true"
+            android:background="@android:color/black"
             app:use_controller="false"
             app:show_buffering="never"
             app:auto_show="false" />


### PR DESCRIPTION
In #81, scene details were updated to fetch during `onResume` which meant that all of the markers, performers, etc would be reset. This meant everything could flash for a second. Also meant that the selected item would revert to the beginning of the list.

So this PR moves the initial fetch of scene data to `onViewCreated` and does a refresh in `onResume` so those UI glitches won't happen.

This PR also moves some of the UI initialization to _before_ fetching the scene data and removes the temporary background image so there isn't a strange color swap.