### PR TITLE
Fade between image & video on cards

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import android.widget.ViewSwitcher
 import androidx.annotation.OptIn
 import androidx.core.content.ContextCompat
 import androidx.leanback.widget.ImageCardView
@@ -30,7 +31,7 @@ class StashImageCardView(context: Context) : ImageCardView(context) {
     var videoUrl: String? = null
     var videoPosition = -1L
     val videoView: PlayerView = findViewById(R.id.main_video)
-    val mainView: View = findViewById(R.id.main_view)
+    val mainView: ViewSwitcher = findViewById(R.id.main_view)
 
     private val dataTypeViews =
         EnumMap<DataType, Pair<TextView, View>>(DataType::class.java)
@@ -46,8 +47,6 @@ class StashImageCardView(context: Context) : ImageCardView(context) {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 if (isPlaying) {
                     showVideo()
-                } else {
-                    showImage()
                 }
             }
         }
@@ -203,12 +202,10 @@ class StashImageCardView(context: Context) : ImageCardView(context) {
     }
 
     fun showVideo() {
-        mainImageView.visibility = View.GONE
-        videoView.visibility = View.VISIBLE
+        mainView.showNext()
     }
 
     fun showImage() {
-        videoView.visibility = View.GONE
-        mainImageView.visibility = View.VISIBLE
+        mainView.showPrevious()
     }
 }

--- a/app/src/main/res/layout/lb_image_card_view.xml
+++ b/app/src/main/res/layout/lb_image_card_view.xml
@@ -19,11 +19,15 @@
     xmlns:lb="http://schemas.android.com/apk/res-auto"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <FrameLayout
+    <ViewSwitcher
         android:id="@+id/main_view"
         lb:layout_viewType="main"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:background="@android:color/black"
+        android:inAnimation="@android:anim/fade_in"
+        android:outAnimation="@android:anim/fade_out"
+        android:animateFirstView="true">
 
         <ImageView
             android:id="@+id/main_image"
@@ -42,7 +46,7 @@
             app:use_controller="false"
             app:show_buffering="never"
             app:auto_show="false" />
-    </FrameLayout>
+    </ViewSwitcher>
     <androidx.leanback.widget.NonOverlappingFrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/video_playback.xml
+++ b/app/src/main/res/layout/video_playback.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/video_playback_frame"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
 
     <com.github.damontecres.stashapp.StashPlayerView
         android:id="@+id/video_view"


### PR DESCRIPTION
Adds a slight fade transition between showing the image & video on a card.

Also sets the background for videos to be black which looks much better when a video doesn't match the device's aspect ratio.