### PR TITLE
Add popup to go to the scene markers for a tag

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -30,12 +30,14 @@ class StashGridFragment<T : Query.Data, D : Any>(
     private val dataSupplier: StashPagingSource.DataSupplier<T, D>,
     val filter: SavedFilterData?,
     private val cardSize: Int? = null,
+    val name: String?,
 ) : VerticalGridSupportFragment() {
     constructor(
         comparator: DiffUtil.ItemCallback<D>,
         dataSupplier: StashPagingSource.DataSupplier<T, D>,
         cardSize: Int? = null,
-    ) : this(StashPresenter.SELECTOR, comparator, dataSupplier, null, cardSize)
+        name: String? = null,
+    ) : this(StashPresenter.SELECTOR, comparator, dataSupplier, null, cardSize, name)
 
     val mAdapter = PagingDataAdapter(presenter, comparator)
 

--- a/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
@@ -31,6 +31,10 @@ class StashItemViewClickListener(
     private val context: Context,
     private val actionListener: StashActionClickedListener? = null,
 ) : OnItemViewClickedListener {
+    fun onItemClicked(item: Any) {
+        onItemClicked(null, item, null, null)
+    }
+
     override fun onItemClicked(
         itemViewHolder: Presenter.ViewHolder?,
         item: Any,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="fa_circle_play" translatable="false">&#xf144;</string>
 
     <string name="go_to_scene">Go to scene</string>
+    <string name="view_scenes">View scenes</string>
+    <string name="view_markers">View markers</string>
     <string name="failed_o_counter">Failed to update o-counter</string>
 
 </resources>


### PR DESCRIPTION
On the filter page for tags, adds a popup to go to scenes or scene markers with that tag.

A side effect of this change is that the filters are added to the back stack, so pressing back will go to the previous filtered view instead of the main screen.