### PR TITLE
Fix crash in FilterListActivity & back stack list

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -85,8 +85,8 @@ class FilterListActivity : FragmentActivity() {
         }
         supportFragmentManager.addOnBackStackChangedListener {
             val fragment =
-                supportFragmentManager.findFragmentById(R.id.list_fragment) as StashGridFragment<*, *>
-            titleTextView.text = fragment.name
+                supportFragmentManager.findFragmentById(R.id.list_fragment) as StashGridFragment<*, *>?
+            titleTextView.text = fragment?.name
         }
 
         val exHandler =
@@ -99,7 +99,7 @@ class FilterListActivity : FragmentActivity() {
             val filter = getStartingFilter()
             if (savedInstanceState == null) {
                 if (filter != null) {
-                    setupFragment(filter)
+                    setupFragment(filter, true)
                 } else {
                     Log.e(TAG, "No starting filter found for $dataType was null")
                     finish()
@@ -142,7 +142,7 @@ class FilterListActivity : FragmentActivity() {
                 listPopUp.setOnItemClickListener { parent: AdapterView<*>, view: View, position: Int, id: Long ->
                     val filter = savedFilters[position]
                     listPopUp.dismiss()
-                    setupFragment(filter)
+                    setupFragment(filter, false)
                 }
 
                 filterButton.setOnClickListener {
@@ -214,7 +214,10 @@ class FilterListActivity : FragmentActivity() {
         }
     }
 
-    private fun setupFragment(filter: SavedFilterData) {
+    private fun setupFragment(
+        filter: SavedFilterData,
+        first: Boolean,
+    ) {
         val dataType = DataType.fromFilterMode(filter.mode)!!
         val name =
             if (filter.name.isBlank()) {
@@ -230,7 +233,7 @@ class FilterListActivity : FragmentActivity() {
                     R.id.list_fragment,
                     fragment,
                 )
-        if (transaction.isAddToBackStackAllowed) {
+        if (!first && transaction.isAddToBackStackAllowed) {
             transaction = transaction.addToBackStack(null)
         }
         transaction.commit()
@@ -396,7 +399,7 @@ class FilterListActivity : FragmentActivity() {
                         ui_options = null,
                         __typename = "",
                     )
-                setupFragment(filter)
+                setupFragment(filter, false)
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -127,6 +127,7 @@ class MainFragment : BrowseSupportFragment() {
 
         val newServerHash = computeServerHash()
         if (serverHash != newServerHash) {
+            Log.v(TAG, "server hash changed")
             clearData()
             rowsAdapter.clear()
         }


### PR DESCRIPTION
The fragment found in the back stack listener may be null, so it needs to be cast that way.

Additionally, the first fragment in the activity should not be added to the back stack so that if it's visible, the activity will finish instead of just removing the fragment (and requiring another back button to finish the activity).

Follow up to #146