### PR TITLE
Only scroll to next page on first filter load

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerActivity.kt
@@ -58,11 +58,11 @@ class PerformerActivity : FragmentActivity() {
                 .replace(R.id.performer_list_fragment, sceneFragment)
                 .commitNow()
 
-            sceneFragment.mAdapter.registerObserver(
+            sceneFragment.pagingAdapter.registerObserver(
                 object : ObjectAdapter.DataObserver() {
                     override fun onChanged() {
                         sceneFragment.view!!.requestFocus()
-                        sceneFragment.mAdapter.unregisterObserver(this)
+                        sceneFragment.pagingAdapter.unregisterObserver(this)
                     }
                 },
             )

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -7,7 +7,6 @@ import androidx.leanback.app.VerticalGridSupportFragment
 import androidx.leanback.paging.PagingDataAdapter
 import androidx.leanback.widget.BrowseFrameLayout
 import androidx.leanback.widget.FocusHighlight
-import androidx.leanback.widget.ObjectAdapter
 import androidx.leanback.widget.PresenterSelector
 import androidx.leanback.widget.VerticalGridPresenter
 import androidx.lifecycle.lifecycleScope
@@ -39,7 +38,7 @@ class StashGridFragment<T : Query.Data, D : Any>(
         name: String? = null,
     ) : this(StashPresenter.SELECTOR, comparator, dataSupplier, null, cardSize, name)
 
-    val mAdapter = PagingDataAdapter(presenter, comparator)
+    val pagingAdapter = PagingDataAdapter(presenter, comparator)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,27 +50,7 @@ class StashGridFragment<T : Query.Data, D : Any>(
 
         gridPresenter.numberOfColumns = columns
         setGridPresenter(gridPresenter)
-
-        adapter = mAdapter
-
-        val pageSize =
-            PreferenceManager.getDefaultSharedPreferences(requireContext())
-                .getInt("maxSearchResults", 50)
-        val scrollToNextResult =
-            PreferenceManager.getDefaultSharedPreferences(requireContext())
-                .getBoolean("scrollToNextResult", true)
-        val moveOnePage = requireActivity().intent.getBooleanExtra("moveOnePage", false)
-        if (moveOnePage && scrollToNextResult) {
-            adapter.registerObserver(
-                object : ObjectAdapter.DataObserver() {
-                    override fun onChanged() {
-                        Log.v(TAG, "Skipping one page")
-                        setSelectedPosition(pageSize)
-                        adapter.unregisterObserver(this)
-                    }
-                },
-            )
-        }
+        adapter = pagingAdapter
     }
 
     override fun onViewCreated(
@@ -111,7 +90,7 @@ class StashGridFragment<T : Query.Data, D : Any>(
 
         viewLifecycleOwner.lifecycleScope.launch {
             flow.collectLatest {
-                mAdapter.submitData(it)
+                pagingAdapter.submitData(it)
             }
         }
     }


### PR DESCRIPTION
Fixes #150 

If the caller (`View All` button) requests to scroll to the next page and the user has the preference enabled, only scroll if it's the first filter fragment loaded. Switching to another filter will always start at the beginning now.