### PR TITLE
Use a drawable instead of color for scrollbars to support older devices

### DIFF
--- a/app/src/main/res/drawable/scrollbar_thumb.xml
+++ b/app/src/main/res/drawable/scrollbar_thumb.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/selected_background"/>
-</shape>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="@color/selected_background">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/selected_background" />
+        </shape>
+    </item>
+    <item android:color="@android:color/darker_gray">
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/darker_gray" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/scrollbar_thumb.xml
+++ b/app/src/main/res/drawable/scrollbar_thumb.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/selected_background"/>
+</shape>

--- a/app/src/main/res/layout/lb_details_description.xml
+++ b/app/src/main/res/layout/lb_details_description.xml
@@ -55,7 +55,7 @@
         android:fadeScrollbars="false"
         android:scrollbars="vertical"
         android:scrollbarAlwaysDrawVerticalTrack="true"
-        android:scrollbarThumbVertical="@color/focus_color">
+        android:scrollbarThumbVertical="@drawable/scrollbar_thumb">
 
         <TextView
             android:id="@+id/lb_details_description_body"

--- a/app/src/main/res/layout/performer_view.xml
+++ b/app/src/main/res/layout/performer_view.xml
@@ -16,7 +16,7 @@
         android:layout_weight="3"
         android:layout_margin="5dp"
         android:fadeScrollbars="false"
-        android:scrollbarThumbVertical="@color/focus_color">
+        android:scrollbarThumbVertical="@drawable/scrollbar_thumb">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #160 

`scrollbarThumbVertical` is technically a drawable, but it seems that newer devices happily accept a color to use, but some devices (such as Fire TV devices running Fire OS 6 or 7) will crash.

So this PR updates the scrollviews to use a drawable.