### PR TITLE
Use utf-8 encoding for python script

### DIFF
--- a/app/convert_strings.py
+++ b/app/convert_strings.py
@@ -34,10 +34,10 @@ def convert_file(source_file, dest_file, allowed_keys):
     if DEBUG:
         print(f"Converting {source_file} to {dest_file}")
     collected_keys = []
-    with open(source_file, "r") as f:
+    with open(source_file, "r", encoding="utf-8") as f:
         data = json.load(f)
     dest_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(dest_file, "w") as f:
+    with open(dest_file, "w", encoding="utf-8") as f:
         f.write('<?xml version="1.0" encoding="utf-8"?>\n')
         f.write("<resources>\n")
         for key, value in parse_dict(data, ["stashapp"]):


### PR DESCRIPTION
Specify explicitly to use utf-8 in the string converter script.

Some platforms may default to a different encoding which may not parse all of the translations.