### PR TITLE
Fix some cases where the media controls don't appear

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackActivity.kt
@@ -1,9 +1,11 @@
 package com.github.damontecres.stashapp
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.KeyEvent
 import android.view.WindowManager
 import androidx.annotation.OptIn
 import androidx.fragment.app.Fragment
@@ -40,6 +42,18 @@ class PlaybackActivity : FragmentActivity() {
         if (!(fragment as StashVideoPlayer).hideControlsIfVisible()) {
             returnPosition()
             super.onBackPressed()
+        }
+    }
+
+    @SuppressLint("RestrictedApi")
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        return if (fragment is PlaybackExoFragment) {
+            (fragment as PlaybackExoFragment).videoView.dispatchKeyEvent(event) ||
+                super.dispatchKeyEvent(
+                    event,
+                )
+        } else {
+            super.dispatchKeyEvent(event)
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -49,7 +49,7 @@ class PlaybackExoFragment :
     PlaybackActivity.StashVideoPlayer {
     private var player: ExoPlayer? = null
     private lateinit var scene: Scene
-    private lateinit var videoView: PlayerView
+    lateinit var videoView: PlayerView
     private lateinit var previewTimeBar: PreviewTimeBar
     private lateinit var exoCenterControls: View
 


### PR DESCRIPTION
On some devices, button presses aren't dispatched the same way, so this PR adds `dispatchKeyEvent` to playback activity which delegates to the ExoPlayer.

I think this will fix #97.