### PR TITLE
Always update the Create Marker action position

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ClassOnItemViewClickedListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ClassOnItemViewClickedListener.kt
@@ -1,0 +1,59 @@
+package com.github.damontecres.stashapp
+
+import androidx.leanback.widget.OnItemViewClickedListener
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.Row
+import androidx.leanback.widget.RowPresenter
+
+/**
+ * An OnItemViewClickedListener which delegates clicks based on the class of the item, falling back to a default implementation if available
+ */
+class ClassOnItemViewClickedListener(private val defaultListener: OnItemViewClickedListener? = null) : OnItemViewClickedListener {
+    private val classMap = mutableMapOf<Class<*>, OnItemViewClickedListener>()
+
+    fun addListenerForClass(
+        klass: Class<*>,
+        listener: OnItemViewClickedListener,
+    ): ClassOnItemViewClickedListener {
+        classMap[klass] = listener
+        return this
+    }
+
+    fun <T> addListenerForClass(
+        klass: Class<T>,
+        listener: SimpleOnItemViewClickedListener<T>,
+    ): ClassOnItemViewClickedListener {
+        classMap[klass] = listener
+        return this
+    }
+
+    override fun onItemClicked(
+        itemViewHolder: Presenter.ViewHolder?,
+        item: Any,
+        rowViewHolder: RowPresenter.ViewHolder?,
+        row: Row?,
+    ) {
+        val listener = classMap[item.javaClass] ?: defaultListener
+        if (listener != null) {
+            listener.onItemClicked(itemViewHolder, item, rowViewHolder, row)
+        } else {
+            throw IllegalStateException("Item is a '${item.javaClass}', but there is no listener for this class nor a default listener")
+        }
+    }
+
+    /**
+     * A simplified, typed OnItemViewClickedListener
+     */
+    fun interface SimpleOnItemViewClickedListener<T> : OnItemViewClickedListener {
+        override fun onItemClicked(
+            itemViewHolder: Presenter.ViewHolder?,
+            item: Any,
+            rowViewHolder: RowPresenter.ViewHolder?,
+            row: Row?,
+        ) {
+            onItemClicked(item as T)
+        }
+
+        fun onItemClicked(item: T)
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -34,6 +34,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import com.github.damontecres.stashapp.PlaybackVideoFragment.Companion.coroutineExceptionHandler
+import com.github.damontecres.stashapp.actions.CreateMarkerAction
 import com.github.damontecres.stashapp.actions.StashAction
 import com.github.damontecres.stashapp.actions.StashActionClickedListener
 import com.github.damontecres.stashapp.api.fragment.MarkerData
@@ -44,16 +45,15 @@ import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.OCounter
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.presenters.ActionPresenter
+import com.github.damontecres.stashapp.presenters.CreateMarkerActionPresenter
 import com.github.damontecres.stashapp.presenters.DetailsDescriptionPresenter
 import com.github.damontecres.stashapp.presenters.MarkerPresenter
 import com.github.damontecres.stashapp.presenters.MoviePresenter
 import com.github.damontecres.stashapp.presenters.OCounterPresenter
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
-import com.github.damontecres.stashapp.presenters.StashImageCardView
 import com.github.damontecres.stashapp.presenters.StashPresenter
 import com.github.damontecres.stashapp.presenters.TagPresenter
-import com.github.damontecres.stashapp.util.Constants
 import com.github.damontecres.stashapp.util.MutationEngine
 import com.github.damontecres.stashapp.util.QueryEngine
 import com.github.damontecres.stashapp.util.ServerPreferences
@@ -79,10 +79,13 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         SparseArrayObjectAdapter(
             ClassPresenterSelector().addClassPresenter(
                 StashAction::class.java,
-                VideoDetailsActionPresenter(),
+                ActionPresenter(),
             ).addClassPresenter(
                 OCounter::class.java,
                 OCounterPresenter(OCounterLongClickCallBack()),
+            ).addClassPresenter(
+                CreateMarkerAction::class.java,
+                CreateMarkerActionPresenter(),
             ),
         )
 
@@ -140,7 +143,15 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     ): View? {
         val actionListener = SceneActionListener()
         onItemViewClickedListener =
-            StashItemViewClickListener(requireActivity(), actionListener)
+            ClassOnItemViewClickedListener(
+                StashItemViewClickListener(
+                    requireActivity(),
+                    actionListener,
+                ),
+            ).addListenerForClass(CreateMarkerAction::class.java) { _ ->
+                actionListener.onClicked(StashAction.CREATE_MARKER)
+            }
+
         setupDetailsOverviewRowPresenter()
         mAdapter.set(ACTIONS_POS, ListRow(HeaderItem("Actions"), sceneActionsAdapter))
         mPresenterSelector.addClassPresenter(ListRow::class.java, ListRowPresenter())
@@ -187,7 +198,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 )
                 sceneActionsAdapter.set(ADD_TAG_POS, StashAction.ADD_TAG)
                 sceneActionsAdapter.set(ADD_PERFORMER_POS, StashAction.ADD_PERFORMER)
-                sceneActionsAdapter.set(CREATE_MARKER_POS, StashAction.CREATE_MARKER)
+                sceneActionsAdapter.set(CREATE_MARKER_POS, CreateMarkerAction(position))
                 sceneActionsAdapter.set(FORCE_TRANSCODE_POS, StashAction.FORCE_TRANSCODE)
 
                 tagsAdapter =
@@ -729,7 +740,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 } else {
                     position = data.getLongExtra(POSITION_ARG, -1)
                     if (position >= 0) {
-                        sceneActionsAdapter.notifyItemRangeChanged(CREATE_MARKER_POS, 1)
+                        sceneActionsAdapter.set(CREATE_MARKER_POS, CreateMarkerAction(position))
                     }
                     if (position > 10_000) {
                         // If some of the video played, reset the available actions
@@ -767,24 +778,6 @@ class VideoDetailsFragment : DetailsSupportFragment() {
             tags = emptyList(),
             __typename = "",
         )
-    }
-
-    private inner class VideoDetailsActionPresenter : StashPresenter<StashAction>() {
-        override fun doOnBindViewHolder(
-            cardView: StashImageCardView,
-            item: StashAction,
-        ) {
-            cardView.titleText = item.actionName
-            if (item == StashAction.CREATE_MARKER) {
-                cardView.contentText =
-                    if (position >= 0) {
-                        Constants.durationToString(position / 1000.0)
-                    } else {
-                        null
-                    }
-            }
-            cardView.setMainImageDimensions(ActionPresenter.CARD_WIDTH, ActionPresenter.CARD_HEIGHT)
-        }
     }
 
     private inner class OCounterLongClickCallBack : StashPresenter.LongClickCallBack<OCounter> {

--- a/app/src/main/java/com/github/damontecres/stashapp/actions/CreateMarkerAction.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/actions/CreateMarkerAction.kt
@@ -1,0 +1,6 @@
+package com.github.damontecres.stashapp.actions
+
+data class CreateMarkerAction(val position: Long) {
+    // This is kind of hacky
+    val id get() = StashAction.CREATE_MARKER.id
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/CreateMarkerActionPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/CreateMarkerActionPresenter.kt
@@ -1,0 +1,18 @@
+package com.github.damontecres.stashapp.presenters
+
+import com.github.damontecres.stashapp.actions.CreateMarkerAction
+import com.github.damontecres.stashapp.util.Constants
+
+class CreateMarkerActionPresenter(callback: LongClickCallBack<CreateMarkerAction>? = null) : StashPresenter<CreateMarkerAction>(callback) {
+    override fun doOnBindViewHolder(
+        cardView: StashImageCardView,
+        item: CreateMarkerAction,
+    ) {
+        cardView.titleText = "Create Marker"
+        cardView.contentText = Constants.durationToString(item.position / 1000.0)
+        cardView.setMainImageDimensions(
+            ActionPresenter.CARD_WIDTH,
+            ActionPresenter.CARD_HEIGHT,
+        )
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -12,6 +12,7 @@ import androidx.leanback.widget.Presenter
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
 import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.actions.CreateMarkerAction
 import com.github.damontecres.stashapp.actions.StashAction
 import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.MovieData
@@ -116,6 +117,7 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
                 .addClassPresenter(StashAction::class.java, ActionPresenter())
                 .addClassPresenter(MarkerData::class.java, MarkerPresenter())
                 .addClassPresenter(OCounter::class.java, OCounterPresenter())
+                .addClassPresenter(CreateMarkerAction::class.java, CreateMarkerActionPresenter())
 
         fun glideError(context: Context): RequestBuilder<PictureDrawable> {
             return Glide.with(context).`as`(PictureDrawable::class.java)


### PR DESCRIPTION
Fixes #168 

Updates the `Create Marker` action to be its own data class so it updates correctly.

Additionally, to support this change, this PR introduces `ClassOnItemViewClickedListener` which is analogous to `ClassPresenterSelector` but for item clicks. I think, eventually, `StashItemViewClickListener` should be refactored into this new class.