### PR TITLE
Calculate version code from git tag

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,22 +13,24 @@ plugins {
     id("kotlin-kapt")
 }
 
-fun getVersionCode(): Int {
-    val stdout = ByteArrayOutputStream()
-    exec {
-        commandLine = listOf("git", "tag", "--list", "v*")
-        standardOutput = stdout
-    }
-    return stdout.toString().trim().lines().size
-}
-
-fun getAppVersion(): String {
+fun getAppVersionFromGit(): String {
     val stdout = ByteArrayOutputStream()
     exec {
         commandLine = listOf("git", "describe", "--tags", "--long", "--match=v*")
         standardOutput = stdout
     }
     return stdout.toString().trim().removePrefix("v")
+}
+
+val appVersion = getAppVersionFromGit()
+
+fun getVersionCode(): Int {
+    val splits = appVersion.split(".", "-")
+    val major = splits[0].toInt() * 1_000_000_000
+    val minor = splits[1].toInt() * 1_000_000
+    val patch = splits[2].toInt() * 1_000
+    val commits = splits[3].toInt()
+    return major + minor + patch + commits
 }
 
 android {
@@ -40,7 +42,7 @@ android {
         minSdk = 23
         targetSdk = 34
         versionCode = getVersionCode()
-        versionName = getAppVersion()
+        versionName = appVersion
         vectorDrawables.useSupportLibrary = true
     }
     signingConfigs {


### PR DESCRIPTION
This is not a user faced change.

Update the version code to be based on the git tag. This ensures that both release and develop builds increase the version code together and can be compared.

Example: `git describe` returns `v0.1.6-7-gaf1dc67` which turns into `1_006_007`. And then if commit `af1dc67` is tagged to `v0.1.7`, then `git describe` returns `v0.1.7-0-faf1dc67` or `1_007_000` which is greater than the previous version. 

This does impose a limit of 999 minor versions, patches, and commits. And in lower Android API levels, the version code is an Int which maxes out at 2147483647 or `v2.147.483-647-gXXXXXXX`.