### PR TITLE
Fix a crash when a video finishes and return to scene is enabled

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -1,5 +1,7 @@
 package com.github.damontecres.stashapp
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -123,6 +125,13 @@ class PlaybackExoFragment :
                                     override fun onPlaybackStateChanged(playbackState: Int) {
                                         if (playbackState == Player.STATE_ENDED) {
                                             Log.v(TAG, "Finishing activity")
+                                            val result = Intent()
+                                            result.putExtra(
+                                                SearchForFragment.ID_KEY,
+                                                -1,
+                                            )
+                                            result.putExtra(VideoDetailsFragment.POSITION_ARG, 0L)
+                                            requireActivity().setResult(Activity.RESULT_OK, result)
                                             requireActivity().finish()
                                         }
                                     }

--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -128,7 +128,7 @@ class PlaybackExoFragment :
                                             val result = Intent()
                                             result.putExtra(
                                                 SearchForFragment.ID_KEY,
-                                                -1,
+                                                -1L,
                                             )
                                             result.putExtra(VideoDetailsFragment.POSITION_ARG, 0L)
                                             requireActivity().setResult(Activity.RESULT_OK, result)

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -607,6 +607,8 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     private fun setupPlayActionsAdapter() {
         if (position > 0) {
             playActionsAdapter.set(0, Action(ACTION_RESUME_SCENE, "Resume"))
+            // Force focus to move to Resume
+            playActionsAdapter.clear(1)
             playActionsAdapter.set(1, Action(ACTION_PLAY_SCENE, "Restart"))
         } else {
             playActionsAdapter.set(

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -496,18 +496,8 @@ class VideoDetailsFragment : DetailsSupportFragment() {
         val serverPreferences = ServerPreferences(requireContext())
         if (serverPreferences.trackActivity && mSelectedMovie?.resume_time != null && mSelectedMovie?.resume_time!! > 0) {
             position = (mSelectedMovie?.resume_time!! * 1000).toLong()
-            playActionsAdapter.set(0, Action(ACTION_RESUME_SCENE, "Resume"))
-            playActionsAdapter.set(1, Action(ACTION_PLAY_SCENE, "Restart"))
-        } else {
-            playActionsAdapter.set(
-                0,
-                Action(
-                    ACTION_PLAY_SCENE,
-                    resources.getString(R.string.play_scene),
-                ),
-            )
-            playActionsAdapter.clear(1)
         }
+        setupPlayActionsAdapter()
 
         row.actionsAdapter = playActionsAdapter
 
@@ -611,6 +601,19 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                 mSelectedMovie = mSelectedMovie!!.copy(o_counter = newCounter.count)
                 sceneActionsAdapter.set(O_COUNTER_POS, newCounter)
             }
+        }
+    }
+
+    private fun setupPlayActionsAdapter() {
+        if (position > 0) {
+            playActionsAdapter.set(0, Action(ACTION_RESUME_SCENE, "Resume"))
+            playActionsAdapter.set(1, Action(ACTION_PLAY_SCENE, "Restart"))
+        } else {
+            playActionsAdapter.set(
+                0,
+                Action(ACTION_PLAY_SCENE, resources.getString(R.string.play_scene)),
+            )
+            playActionsAdapter.clear(1)
         }
     }
 
@@ -742,20 +745,15 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     if (position >= 0) {
                         sceneActionsAdapter.set(CREATE_MARKER_POS, CreateMarkerAction(position))
                     }
-                    if (position > 10_000) {
-                        // If some of the video played, reset the available actions
-                        // This also causes the focused action to default to resume which is an added bonus
-                        playActionsAdapter.set(0, Action(ACTION_RESUME_SCENE, "Resume"))
-                        playActionsAdapter.set(1, Action(ACTION_PLAY_SCENE, "Restart"))
-
-                        val serverPreferences = ServerPreferences(requireContext())
-                        if (serverPreferences.trackActivity) {
-                            viewLifecycleOwner.lifecycleScope.launch(coroutineExceptionHandler) {
-                                MutationEngine(requireContext(), false).saveSceneActivity(
-                                    mSelectedMovie!!.id.toLong(),
-                                    position,
-                                )
-                            }
+                    setupPlayActionsAdapter()
+                    val serverPreferences = ServerPreferences(requireContext())
+                    if (serverPreferences.trackActivity) {
+                        viewLifecycleOwner.lifecycleScope.launch(coroutineExceptionHandler) {
+                            Log.v(TAG, "ResultCallback saveSceneActivity start")
+                            MutationEngine(requireContext(), false).saveSceneActivity(
+                                mSelectedMovie!!.id.toLong(),
+                                position,
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
When the "Return to scene" is enabled when a video finishes, it wasn't returning a result. Sometimes it would cause a hang on the UI thread and then crash.