### PR TITLE
Ensure video previews aren't reused

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -89,6 +89,7 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
         // Remove references to images so that the garbage collector can free up memory
         cardView.badgeImage = null
         cardView.mainImage = null
+        cardView.videoUrl = null
         cardView.videoView.player?.release()
         cardView.videoView.player = null
     }


### PR DESCRIPTION
If there's a lot of cards to scroll through and some do not have a video preview, the card view is reused with a previous card's video URL and the card shows a different card's video preview.

This PR ensures that the video URL is cleared before reusing the card view to prevent this.