### PR TITLE
Add scene title to ExoPlayer

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -200,6 +200,16 @@ class PlaybackExoFragment :
         scene = requireActivity().intent.getParcelableExtra(VideoDetailsActivity.MOVIE) as Scene?
             ?: throw RuntimeException()
 
+        val showTitle =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getBoolean("exoShowTitle", true)
+        val titleText = view.findViewById<TextView>(R.id.playback_title)
+        if (showTitle) {
+            titleText.text = scene.title
+        } else {
+            titleText.visibility = View.GONE
+        }
+
         val position = requireActivity().intent.getLongExtra(VideoDetailsFragment.POSITION_ARG, -1)
         Log.d(TAG, "scene=${scene.id}, ${VideoDetailsFragment.POSITION_ARG}=$position")
 

--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -64,6 +64,24 @@
         app:layout_constraintStart_toStartOf="parent"
         tools:text="18:20" />
 
+    <TextView
+        android:id="@+id/playback_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginBottom="3dp"
+        android:textColor="#FFBEBEBE"
+        android:textSize="22sp"
+        android:padding="3dp"
+        android:textAlignment="viewStart"
+        app:layout_constraintBottom_toTopOf="@id/exo_position"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/exo_center_controls"
+        tools:text="This is a sample title"
+        android:maxLines="1"
+        android:singleLine="true"
+        android:ellipsize="end" />
+
     <com.github.rubensousa.previewseekbar.media3.PreviewTimeBar
         android:id="@+id/exo_progress"
         android:layout_width="0dp"
@@ -143,10 +161,10 @@
         android:layout_height="0dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
+        android:layout_marginBottom="6dp"
         android:background="@drawable/video_frame"
         android:visibility="invisible"
-        app:layout_constraintBottom_toTopOf="@+id/exo_progress"
+        app:layout_constraintBottom_toTopOf="@+id/playback_title"
         app:layout_constraintDimensionRatio="16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -148,8 +148,13 @@
             app:defaultValue="@string/playback_finished_do_nothing"
             app:useSimpleSummaryProvider="true"
             app:entries="@array/playback_finished_behavior_options"
-            app:entryValues="@array/playback_finished_behavior_options"
-            />
+            app:entryValues="@array/playback_finished_behavior_options" />
+        <SwitchPreference
+            app:key="exoShowTitle"
+            app:title="Scene title on ExoPlayer"
+            app:summaryOn="Show title"
+            app:summaryOff="Hide title"
+            app:defaultValue="true" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/stashapp_config_tasks_job_queue">


### PR DESCRIPTION
Adds the scene title to the playback controls on ExoPlayer above the progress bar.

This can be turned off in settings.