### PR TITLE
Fixes performers & studios content text being reused

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
@@ -17,10 +17,13 @@ class PerformerPresenter(callback: LongClickCallBack<PerformerData>? = null) :
             item.name + (if (!item.disambiguation.isNullOrBlank()) " (${item.disambiguation})" else "")
         cardView.titleText = title
 
-        if (item.birthdate != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val yearsOldStr = cardView.context.getString(R.string.stashapp_years_old)
-            cardView.contentText = "${item.ageInYears} $yearsOldStr"
-        }
+        cardView.contentText =
+            if (item.birthdate != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val yearsOldStr = cardView.context.getString(R.string.stashapp_years_old)
+                "${item.ageInYears} $yearsOldStr"
+            } else {
+                null
+            }
 
         val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
         dataTypeMap[DataType.SCENE] = item.scene_count

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
@@ -14,10 +14,12 @@ class StudioPresenter(callback: LongClickCallBack<StudioData>? = null) :
         item: StudioData,
     ) {
         cardView.titleText = item.name
-        if (item.parent_studio != null) {
-            cardView.contentText =
+        cardView.contentText =
+            if (item.parent_studio != null) {
                 cardView.context.getString(R.string.stashapp_part_of, item.parent_studio.name)
-        }
+            } else {
+                null
+            }
 
         val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
         dataTypeMap[DataType.SCENE] = item.scene_count


### PR DESCRIPTION
Similar to #172, the content text for performers and studios could be reused.

This PR ensures that the content text is always set to something (or null).