### PR TITLE
Add image scrolling for galleries

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/GalleryActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/GalleryActivity.kt
@@ -1,14 +1,15 @@
 package com.github.damontecres.stashapp
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
 import com.apollographql.apollo3.api.Optional
+import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.api.type.CriterionModifier
-import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.ImageFilterType
 import com.github.damontecres.stashapp.api.type.MultiCriterionInput
-import com.github.damontecres.stashapp.api.type.SortDirectionEnum
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.suppliers.ImageDataSupplier
 import com.github.damontecres.stashapp.util.ImageComparator
 
@@ -20,28 +21,43 @@ class GalleryActivity : FragmentActivity() {
             val galleryId = intent.getStringExtra(INTENT_GALLERY_ID)!!
             val galleryName = intent.getStringExtra(INTENT_GALLERY_NAME)
             findViewById<TextView>(R.id.grid_title).text = galleryName
-            supportFragmentManager.beginTransaction()
-                .replace(
-                    R.id.grid_fragment,
-                    StashGridFragment(
-                        ImageComparator,
-                        ImageDataSupplier(
-                            FindFilterType(
-                                sort = Optional.present("path"),
-                                direction = Optional.present(SortDirectionEnum.ASC),
-                            ),
-                            ImageFilterType(
-                                galleries =
-                                    Optional.present(
-                                        MultiCriterionInput(
-                                            value = Optional.present(listOf(galleryId)),
-                                            modifier = CriterionModifier.INCLUDES,
-                                        ),
+
+            val fragment =
+                StashGridFragment(
+                    ImageComparator,
+                    ImageDataSupplier(
+                        DataType.IMAGE.asDefaultFindFilterType,
+                        ImageFilterType(
+                            galleries =
+                                Optional.present(
+                                    MultiCriterionInput(
+                                        value = Optional.present(listOf(galleryId)),
+                                        modifier = CriterionModifier.INCLUDES,
                                     ),
-                            ),
+                                ),
                         ),
                     ),
-                ).commitNow()
+                )
+            fragment.onItemViewClickedListener =
+                ClassOnItemViewClickedListener.SimpleOnItemViewClickedListener<ImageData> { image ->
+                    val snapshot = fragment.pagingAdapter.snapshot()
+                    val position = snapshot.indexOf(image)
+                    val intent = Intent(this@GalleryActivity, ImageActivity::class.java)
+                    intent.putExtra(ImageActivity.INTENT_IMAGE_ID, image.id)
+                    intent.putExtra(ImageActivity.INTENT_IMAGE_URL, image.paths.image)
+                    intent.putExtra(
+                        ImageActivity.INTENT_IMAGE_SIZE,
+                        image.visual_files.maxOfOrNull {
+                            it.onBaseFile?.size?.toString()?.toInt() ?: -1
+                        } ?: -1,
+                    )
+                    intent.putExtra(ImageActivity.INTENT_POSITION, position)
+                    intent.putExtra(ImageActivity.INTENT_GALLERY_ID, galleryId)
+                    startActivity(intent)
+                }
+
+            supportFragmentManager.beginTransaction().replace(R.id.grid_fragment, fragment)
+                .commitNow()
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/ImageActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ImageActivity.kt
@@ -101,14 +101,12 @@ class ImageActivity : FragmentActivity() {
                     return true
                 }
             } else if (isDpadKey(event.keyCode) && !imageFragment.isOverlayVisible()) {
-                lifecycleScope.launch(StashCoroutineExceptionHandler()) {
-                    if (isLeft(event.keyCode)) {
-                        switchImage(currentPosition - 1)
-                    } else if (isRight(event.keyCode)) {
-                        switchImage(currentPosition + 1)
-                    } else {
-                        imageFragment.showOverlay()
-                    }
+                if (isLeft(event.keyCode)) {
+                    switchImage(currentPosition - 1)
+                } else if (isRight(event.keyCode)) {
+                    switchImage(currentPosition + 1)
+                } else {
+                    imageFragment.showOverlay()
                 }
                 return true
             }
@@ -147,17 +145,27 @@ class ImageActivity : FragmentActivity() {
             )
     }
 
-    private suspend fun switchImage(newPosition: Int) {
+    private fun switchImage(newPosition: Int) {
         Log.v(TAG, "switchImage to $newPosition")
-        if (canScrollImages && newPosition >= 0) {
-            val image = fetchImageData(newPosition)
-            if (image != null && image.paths.image != null) {
-                currentPosition = newPosition
-                imageFragment = ImageFragment(image.id, image.paths.image, image.maxFileSize)
-                imageFragment.image = image
-                supportFragmentManager.beginTransaction()
-                    .replace(R.id.image_fragment, imageFragment)
-                    .commitNow()
+        if (canScrollImages) {
+            if (newPosition >= 0) {
+                lifecycleScope.launch(StashCoroutineExceptionHandler()) {
+                    val image = fetchImageData(newPosition)
+                    if (image != null && image.paths.image != null) {
+                        currentPosition = newPosition
+                        imageFragment =
+                            ImageFragment(image.id, image.paths.image, image.maxFileSize)
+                        imageFragment.image = image
+                        supportFragmentManager.beginTransaction()
+                            .replace(R.id.image_fragment, imageFragment)
+                            .commitNow()
+                    } else if (image == null) {
+                        Toast.makeText(this@ImageActivity, "No more images", Toast.LENGTH_SHORT)
+                            .show()
+                    }
+                }
+            } else {
+                Toast.makeText(this, "Already at beginning", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -63,7 +63,9 @@ class StashGridFragment<T : Query.Data, D : Any>(
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        onItemViewClickedListener = StashItemViewClickListener(requireActivity())
+        if (onItemViewClickedListener == null) {
+            onItemViewClickedListener = StashItemViewClickListener(requireActivity())
+        }
 
         val pageSize =
             PreferenceManager.getDefaultSharedPreferences(requireContext())

--- a/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashItemViewClickListener.kt
@@ -25,6 +25,7 @@ import com.github.damontecres.stashapp.data.Performer
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.data.StashCustomFilter
 import com.github.damontecres.stashapp.data.StashSavedFilter
+import com.github.damontecres.stashapp.util.maxFileSize
 import com.github.damontecres.stashapp.util.name
 
 /**
@@ -78,12 +79,7 @@ class StashItemViewClickListener(
             val intent = Intent(context, ImageActivity::class.java)
             intent.putExtra(ImageActivity.INTENT_IMAGE_ID, item.id)
             intent.putExtra(ImageActivity.INTENT_IMAGE_URL, item.paths.image)
-            intent.putExtra(
-                ImageActivity.INTENT_IMAGE_SIZE,
-                item.visual_files.maxOfOrNull {
-                    it.onBaseFile?.size?.toString()?.toInt() ?: -1
-                } ?: -1,
-            )
+            intent.putExtra(ImageActivity.INTENT_IMAGE_SIZE, item.maxFileSize)
             context.startActivity(intent)
         } else if (item is GalleryData) {
             val intent = Intent(context, GalleryActivity::class.java)

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
@@ -54,7 +54,7 @@ class StashPagingSource<T : Query.Data, D : Any>(
         fun getDefaultFilter(): FindFilterType
     }
 
-    private suspend fun fetchPage(
+    suspend fun fetchPage(
         page: Int,
         loadSize: Int,
     ): CountAndList<D> {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -29,6 +29,7 @@ import com.bumptech.glide.load.model.LazyHeaders
 import com.github.damontecres.stashapp.StashApplication
 import com.github.damontecres.stashapp.api.ServerInfoQuery
 import com.github.damontecres.stashapp.api.fragment.GalleryData
+import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SavedFilterData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
@@ -518,3 +519,9 @@ fun SharedPreferences.getInt(
 fun ArrayObjectAdapter.isEmpty(): Boolean = size() == 0
 
 fun ArrayObjectAdapter.isNotEmpty(): Boolean = !isEmpty()
+
+val ImageData.maxFileSize: Int
+    get() =
+        visual_files.maxOfOrNull {
+            it.onBaseFile?.size?.toString()?.toInt() ?: -1
+        } ?: -1

--- a/app/src/main/res/layout/image_layout.xml
+++ b/app/src/main/res/layout/image_layout.xml
@@ -7,6 +7,7 @@
         android:id="@+id/image_view_image"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@android:color/black"
         android:adjustViewBounds="true"
         android:contentDescription="@string/stashapp_image" />
 


### PR DESCRIPTION
Part of #182

When viewing a gallery's images, it's now possible to scroll/move between images with left/right on the D-Pad if the image details overlay is not showing.

For now, this is only possible when viewing the images from the gallery's page.