### PR TITLE
Better playback D-Pad non-skipping behavior

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -33,6 +33,7 @@ import com.github.damontecres.stashapp.util.ServerPreferences
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashPreviewLoader
 import com.github.damontecres.stashapp.util.createOkHttpClient
+import com.github.damontecres.stashapp.views.StashPlayerView
 import com.github.rubensousa.previewseekbar.PreviewBar
 import com.github.rubensousa.previewseekbar.media3.PreviewTimeBar
 import kotlinx.coroutines.Dispatchers
@@ -52,8 +53,8 @@ class PlaybackExoFragment :
     private var player: ExoPlayer? = null
     private var trackActivityListener: PlaybackListener? = null
     private lateinit var scene: Scene
-    lateinit var videoView: PlayerView
-    private lateinit var previewTimeBar: PreviewTimeBar
+    lateinit var videoView: StashPlayerView
+    lateinit var previewTimeBar: PreviewTimeBar
     private lateinit var exoCenterControls: View
 
     private var playbackPosition = -1L
@@ -353,6 +354,7 @@ class PlaybackExoFragment :
             object : PreviewBar.OnScrubListener {
                 override fun onScrubStart(previewBar: PreviewBar) {
                     player!!.playWhenReady = false
+                    previewTimeBar.showPreview()
                 }
 
                 override fun onScrubMove(
@@ -527,6 +529,12 @@ class PlaybackExoFragment :
                 requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
             }
         }
+    }
+
+    fun showAndFocusSeekBar() {
+        videoView.showController()
+        previewTimeBar.showPreview()
+        previewTimeBar.requestFocus()
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/StashPreviewLoader.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/StashPreviewLoader.kt
@@ -23,11 +23,8 @@ class StashPreviewLoader(
     ) {
         Log.d(TAG, "loadPreview: currentPosition=$currentPosition")
         StashGlide.with(context, scene.spriteUrl!!)
+            .skipMemoryCache(false)
             .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
-//            .override(
-//                GlideThumbnailTransformation.IMAGE_WIDTH * GlideThumbnailTransformation.MAX_COLUMNS,
-//                GlideThumbnailTransformation.IMAGE_HEIGHT * GlideThumbnailTransformation.MAX_LINES
-//            )
             .transform(
                 GlideThumbnailTransformation(
                     (scene.duration!! * 1000).toLong(),
@@ -63,6 +60,7 @@ class StashPreviewLoader(
         }
 
         override fun updateDiskCacheKey(messageDigest: MessageDigest) {
+            messageDigest.update(KEY)
             val data = ByteBuffer.allocate(8).putInt(x).putInt(y).array()
             messageDigest.update(data)
         }
@@ -81,6 +79,8 @@ class StashPreviewLoader(
         }
 
         companion object {
+            private val KEY =
+                "com.github.damontecres.stashapp.util.StashPreviewLoader.GlideThumbnailTransformation".encodeToByteArray()
             const val MAX_LINES = 9
             const val MAX_COLUMNS = 9
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/views/StashPlayerView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/StashPlayerView.kt
@@ -22,14 +22,23 @@ class StashPlayerView(context: Context, attrs: AttributeSet?, defStyleAttr: Int)
     @OptIn(UnstableApi::class)
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         val keyCode = event.keyCode
-        if (dPadSkipEnabled && player != null && !findFragment<PlaybackExoFragment>().isControllerVisible &&
+        val fragment = findFragment<PlaybackExoFragment>()
+        if (player != null && !fragment.isControllerVisible &&
             (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_DPAD_LEFT)
         ) {
             if (event.action == KeyEvent.ACTION_DOWN) {
                 if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
-                    player!!.seekForward()
+                    if (dPadSkipEnabled) {
+                        player!!.seekForward()
+                    } else {
+                        fragment.showAndFocusSeekBar()
+                    }
                 } else if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
-                    player!!.seekBack()
+                    if (dPadSkipEnabled) {
+                        player!!.seekBack()
+                    } else {
+                        fragment.showAndFocusSeekBar()
+                    }
                 }
             }
             return true


### PR DESCRIPTION
Closes #179 

This PR changes the left/right D-Pad behavior during playback. If D-Pad skipping is _disabled_ in settings, then when left/right is pressed during playback and the controls are _not_ showing, the controls will be shown, focus given to the seek bar, and the video preview (if available) will be shown.

Previously, any D-Pad button would just show the controls and focus on the Play/Pause button. Now, this is the behavior with D-Pad up/down/center/etc only.

If D-Pad skipping is _enabled_, then D-Pad left/right will skip back/forward as before.