### PR TITLE
Better popup width caclulation

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -60,7 +60,7 @@ import com.github.damontecres.stashapp.util.StudioComparator
 import com.github.damontecres.stashapp.util.TagComparator
 import com.github.damontecres.stashapp.util.convertFilter
 import com.github.damontecres.stashapp.util.getInt
-import com.github.damontecres.stashapp.util.toPx
+import com.github.damontecres.stashapp.util.getMaxMeasuredWidth
 import com.github.damontecres.stashapp.views.ImageGridClickedListener
 import com.github.damontecres.stashapp.views.StashItemViewClickListener
 import com.github.damontecres.stashapp.views.StashOnFocusChangeListener
@@ -162,12 +162,6 @@ class FilterListActivity : FragmentActivity() {
                         null,
                         android.R.attr.listPopupWindowStyle,
                     )
-                listPopUp.inputMethodMode = ListPopupWindow.INPUT_METHOD_NEEDED
-                listPopUp.anchorView = filterButton
-                // TODO: Better width calculation
-                listPopUp.width = this@FilterListActivity.toPx(250).toInt()
-                listPopUp.isModal = true
-
                 val adapter =
                     ArrayAdapter(
                         this@FilterListActivity,
@@ -175,6 +169,11 @@ class FilterListActivity : FragmentActivity() {
                         savedFilters.map { it.name },
                     )
                 listPopUp.setAdapter(adapter)
+                listPopUp.inputMethodMode = ListPopupWindow.INPUT_METHOD_NEEDED
+                listPopUp.anchorView = filterButton
+
+                listPopUp.width = getMaxMeasuredWidth(this@FilterListActivity, adapter)
+                listPopUp.isModal = true
 
                 listPopUp.setOnItemClickListener { parent: AdapterView<*>, view: View, position: Int, id: Long ->
                     val savedFilter = savedFilters[position]

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/PopupOnLongClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/PopupOnLongClickListener.kt
@@ -1,15 +1,12 @@
 package com.github.damontecres.stashapp.presenters
 
-import android.content.Context
 import android.view.View
-import android.view.View.MeasureSpec
 import android.view.View.OnLongClickListener
-import android.widget.Adapter
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
-import android.widget.FrameLayout
 import androidx.appcompat.widget.ListPopupWindow
 import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.util.getMaxMeasuredWidth
 
 /**
  * An OnLongClickListener which shows a popup of predefined options
@@ -37,7 +34,7 @@ class PopupOnLongClickListener(
         listPopUp.anchorView = view
         listPopUp.width =
             if (popUpWidth == ListPopupWindow.WRAP_CONTENT) {
-                getMaxWidth(view.context, adapter)
+                getMaxMeasuredWidth(view.context, adapter)
             } else {
                 popUpWidth
             }
@@ -53,30 +50,5 @@ class PopupOnLongClickListener(
         listPopUp.show()
 
         return true
-    }
-
-    private fun getMaxWidth(
-        context: Context,
-        adapter: ArrayAdapter<String>,
-    ): Int {
-        if (adapter.viewTypeCount != 1) {
-            throw IllegalStateException("Adapter creates more than 1 type of view")
-        }
-
-        val tempParent = FrameLayout(context)
-        var maxWidth = 0
-        var itemView: View? = null
-        val measureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
-
-        for (i in 0 until adapter.count) {
-            if (adapter.getItemViewType(i) != Adapter.IGNORE_ITEM_VIEW_TYPE) {
-                itemView = adapter.getView(i, itemView, tempParent)
-                itemView.measure(measureSpec, measureSpec)
-                if (itemView.measuredWidth > maxWidth) {
-                    maxWidth = itemView.measuredWidth
-                }
-            }
-        }
-        return maxWidth
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -1,15 +1,20 @@
 package com.github.damontecres.stashapp.util
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Build
 import android.text.TextUtils
+import android.util.DisplayMetrics
 import android.util.Log
 import android.util.TypedValue
 import android.view.View
+import android.widget.Adapter
+import android.widget.ArrayAdapter
+import android.widget.FrameLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import android.widget.Toast
@@ -626,4 +631,45 @@ fun View.animateToInvisible(
             alpha = 1f
             visibility = targetVisibility
         }
+}
+
+/**
+ * Gets the max measured width size for the views produced by an ArrayAdapter
+ */
+fun getMaxMeasuredWidth(
+    context: Context,
+    adapter: ArrayAdapter<String>,
+    maxWidth: Int? = null,
+    maxWidthFraction: Double? = 0.4,
+): Int {
+    val widest =
+        if (maxWidth != null) {
+            maxWidth
+        } else if (maxWidthFraction != null && context is Activity) {
+            val displayMetrics = DisplayMetrics()
+            context.windowManager.defaultDisplay.getMetrics(displayMetrics)
+            displayMetrics.widthPixels
+        } else {
+            Log.w(Constants.TAG, "maxWidthFraction is not null, but couldn't get window size")
+            Int.MAX_VALUE
+        }
+    if (adapter.viewTypeCount != 1) {
+        throw IllegalStateException("Adapter creates more than 1 type of view")
+    }
+
+    val tempParent = FrameLayout(context)
+    var maxMeasuredWidth = 0
+    var itemView: View? = null
+    val measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+
+    for (i in 0 until adapter.count) {
+        if (adapter.getItemViewType(i) != Adapter.IGNORE_ITEM_VIEW_TYPE) {
+            itemView = adapter.getView(i, itemView, tempParent)
+            itemView.measure(measureSpec, measureSpec)
+            if (itemView.measuredWidth > maxMeasuredWidth) {
+                maxMeasuredWidth = itemView.measuredWidth
+            }
+        }
+    }
+    return Math.min(widest, maxMeasuredWidth)
 }


### PR DESCRIPTION
A popup's width is tied to the anchor view which can be pretty small. So this PR adds a function to measure the width of the text for each item in the popup so the popup can be sized better.

The function can also calculate the max width based on the window size.