### PR TITLE
Fix navigation buttons not working on some images

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ImageActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ImageActivity.kt
@@ -645,7 +645,7 @@ class ImageActivity : FragmentActivity() {
         }
 
         fun isImageZoomedIn(): Boolean {
-            return mainImage.zoom > 1.0f
+            return (mainImage.zoom * 100).toInt() > 100
         }
 
         fun resetImageZoom() {


### PR DESCRIPTION
See #214 

Fixes how determining if an image is zoomed in. The zoom value is a float and so may be a minuscule amount over exactly 1.0f (e.g. 1.0000001) and the previous comparison would count that as zoomed in. 

Sine direct comparisons won't work well, the comparison is updated to essentially check if the image is <1% zoomed in or out from default. Since the zoom in/out controls do ~30%, this 1% margin is fine.

This is comp sci 101, doh! 🤦