### PR TITLE
Fix max popup percentage width

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -660,7 +660,7 @@ fun getMaxMeasuredWidth(
         } else if (maxWidthFraction != null && context is Activity) {
             val displayMetrics = DisplayMetrics()
             context.windowManager.defaultDisplay.getMetrics(displayMetrics)
-            displayMetrics.widthPixels
+            (displayMetrics.widthPixels * maxWidthFraction).toInt()
         } else {
             Log.w(Constants.TAG, "maxWidthFraction is not null, but couldn't get window size")
             Int.MAX_VALUE


### PR DESCRIPTION
#215 added measuring the width of items in a popup list. But using the screen width percentage was not used and would instead always use 100% instead.