### PR TITLE
Add default long click listener to cards

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -67,7 +67,7 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
                 PopupOnLongClickListener(
                     listOf("Go to"),
                 ) { _, _, _, _ ->
-                    cardView.callOnClick()
+                    cardView.performClick()
                 },
             )
         }


### PR DESCRIPTION
Closes #151

If a presenter doesn't have a `LongClickCallBack`, a default one is used with a single `Go To` option which, when selected, is the same as clicking the card.

Before this, long clicking a card without a `LongClickCallBack` would do the same as a normal click. So this PR adds an extra step there, but I feel like that's more intuitive. It felt weird to long click something for it to just act like a regular click, except for some cards it doesn't.