### PR TITLE
Don't automatically force av1 to transcode

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PlaybackExoFragment.kt
@@ -163,7 +163,7 @@ class PlaybackExoFragment :
                 }.also { exoPlayer ->
                     var mediaItem: MediaItem? = null
                     var streamUrl = scene.streams["Direct stream"]
-                    if (streamUrl != null && scene.videoCodec != "av1" && !forceTranscode) {
+                    if (streamUrl != null && !forceTranscode) {
                         mediaItem = MediaItem.fromUri(streamUrl)
                     } else {
                         val streamChoice =


### PR DESCRIPTION
Closes #232
Closes #59 

Don't always forced AV1 files to transcode. This allows devices that do support AV1 to direct stream and devices that do not support AV1, can trigger a manual transcode (see #61) via the action button at the bottom of scene details.