### PR TITLE
Keep selected tab & grid position for Studio/Tag screens

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/StudioActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StudioActivity.kt
@@ -1,12 +1,8 @@
 package com.github.damontecres.stashapp
 
-import android.os.Bundle
-import android.util.Log
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import androidx.leanback.tab.LeanbackTabLayout
-import androidx.leanback.tab.LeanbackViewPager
+import androidx.viewpager.widget.PagerAdapter
 import com.apollographql.apollo3.api.Optional
 import com.github.damontecres.stashapp.api.type.CriterionModifier
 import com.github.damontecres.stashapp.api.type.GalleryFilterType
@@ -33,44 +29,29 @@ import com.github.damontecres.stashapp.util.SceneComparator
 import com.github.damontecres.stashapp.util.StudioComparator
 
 class StudioActivity : TabbedGridFragmentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        if (savedInstanceState == null) {
-            val studioId = this.intent.getIntExtra("studioId", -1)
-            val studioName = this.intent.getStringExtra("studioName")
-            findViewById<TextView>(R.id.grid_title).text = "$studioName"
-
-            val viewPager = findViewById<LeanbackViewPager>(R.id.view_pager)
-            val tabLayout = findViewById<LeanbackTabLayout>(R.id.tab_layout)
-
-            val tabTitles =
-                listOf(
-                    getString(DataType.SCENE.pluralStringId),
-                    getString(DataType.GALLERY.pluralStringId),
-                    getString(DataType.IMAGE.pluralStringId),
-                    getString(DataType.PERFORMER.pluralStringId),
-                    getString(DataType.MOVIE.pluralStringId),
-                    getString(R.string.stashapp_subsidiary_studios),
-                )
-
-            val tagAdapter = PagerAdapter(tabTitles, studioId.toString(), supportFragmentManager)
-            viewPager.adapter = tagAdapter
-            tabLayout.setupWithViewPager(viewPager)
-        }
+    override fun getTitleText(): CharSequence? {
+        return intent.getStringExtra("studioName")
     }
 
-    override fun onStart() {
-        super.onStart()
-        val layout = findViewById<LeanbackTabLayout>(R.id.tab_layout)
-
-        Log.v("StudioActivity", "currentFocus=$currentFocus, ${currentFocus?.id}")
-        layout.getChildAt(0).requestFocus()
-//        val tab = layout.getTabAt(0)
-//        tab?.view
-        Log.v("StudioActivity", "currentFocus=$currentFocus, ${currentFocus?.id}")
+    override fun getPagerAdapter(): PagerAdapter {
+        val studioId = this.intent.getIntExtra("studioId", -1)
+        val tabTitles =
+            listOf(
+                getString(DataType.SCENE.pluralStringId),
+                getString(DataType.GALLERY.pluralStringId),
+                getString(DataType.IMAGE.pluralStringId),
+                getString(DataType.PERFORMER.pluralStringId),
+                getString(DataType.MOVIE.pluralStringId),
+                getString(R.string.stashapp_subsidiary_studios),
+            )
+        return StudioPagerAdapter(tabTitles, studioId.toString(), supportFragmentManager)
     }
 
-    class PagerAdapter(tabTitles: List<String>, private val studioId: String, fm: FragmentManager) :
+    class StudioPagerAdapter(
+        tabTitles: List<String>,
+        private val studioId: String,
+        fm: FragmentManager,
+    ) :
         ListFragmentPagerAdapter(tabTitles, fm) {
         override fun getItem(position: Int): Fragment {
             return if (position == 0) {

--- a/app/src/main/java/com/github/damontecres/stashapp/TabbedGridFragmentActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/TabbedGridFragmentActivity.kt
@@ -1,15 +1,35 @@
 package com.github.damontecres.stashapp
 
+import android.os.Bundle
+import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
 import androidx.leanback.tab.LeanbackTabLayout
+import androidx.leanback.tab.LeanbackViewPager
+import androidx.viewpager.widget.PagerAdapter
 
-open class TabbedGridFragmentActivity : FragmentActivity(R.layout.tabbed_grid_view) {
-    override fun onStart() {
-        super.onStart()
+abstract class TabbedGridFragmentActivity : FragmentActivity(R.layout.tabbed_grid_view) {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null) {
+            findViewById<TextView>(R.id.grid_title).text = getTitleText()
+            val viewPager = findViewById<LeanbackViewPager>(R.id.view_pager)
+            val tabLayout = findViewById<LeanbackTabLayout>(R.id.tab_layout)
 
-        val layout = findViewById<LeanbackTabLayout>(R.id.tab_layout)
-        if (layout.childCount > 0) {
-            layout.getChildAt(0).requestFocus()
+            viewPager.adapter = getPagerAdapter()
+            tabLayout.setupWithViewPager(viewPager)
+            if (tabLayout.childCount > 0) {
+                tabLayout.getChildAt(0).requestFocus()
+            }
         }
     }
+
+    /**
+     * Get an optional text to set on the grid title
+     */
+    abstract fun getTitleText(): CharSequence?
+
+    /**
+     * Get the tab pager adapter, typical a ListFragmentPagerAdapter
+     */
+    abstract fun getPagerAdapter(): PagerAdapter
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/TagActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/TagActivity.kt
@@ -1,11 +1,8 @@
 package com.github.damontecres.stashapp
 
-import android.os.Bundle
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import androidx.leanback.tab.LeanbackTabLayout
-import androidx.leanback.tab.LeanbackViewPager
+import androidx.viewpager.widget.PagerAdapter
 import com.apollographql.apollo3.api.Optional
 import com.github.damontecres.stashapp.api.type.CriterionModifier
 import com.github.damontecres.stashapp.api.type.GalleryFilterType
@@ -28,31 +25,22 @@ import com.github.damontecres.stashapp.util.PerformerComparator
 import com.github.damontecres.stashapp.util.SceneComparator
 
 class TagActivity : TabbedGridFragmentActivity() {
-    private lateinit var tagId: String
+    override fun getTitleText(): CharSequence? {
+        return intent.getStringExtra("tagName")
+    }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        if (savedInstanceState == null) {
-            tagId = intent.getStringExtra("tagId")!!
-            val tagName = intent.getStringExtra("tagName")
-            findViewById<TextView>(R.id.grid_title).text = tagName
+    override fun getPagerAdapter(): PagerAdapter {
+        val tagId = intent.getStringExtra("tagId")!!
+        val tabs =
+            listOf(
+                getString(DataType.SCENE.pluralStringId),
+                getString(DataType.GALLERY.pluralStringId),
+                getString(DataType.IMAGE.pluralStringId),
+                getString(DataType.MARKER.pluralStringId),
+                getString(DataType.PERFORMER.pluralStringId),
+            )
 
-            val viewPager = findViewById<LeanbackViewPager>(R.id.view_pager)
-            val tabLayout = findViewById<LeanbackTabLayout>(R.id.tab_layout)
-
-            val tabs =
-                listOf(
-                    getString(DataType.SCENE.pluralStringId),
-                    getString(DataType.GALLERY.pluralStringId),
-                    getString(DataType.IMAGE.pluralStringId),
-                    getString(DataType.MARKER.pluralStringId),
-                    getString(DataType.PERFORMER.pluralStringId),
-                )
-
-            val tagAdapter = TabPageAdapter(tabs, tagId, supportFragmentManager)
-            viewPager.adapter = tagAdapter
-            tabLayout.setupWithViewPager(viewPager)
-        }
+        return TabPageAdapter(tabs, tagId, supportFragmentManager)
     }
 
     class TabPageAdapter(tabs: List<String>, private val tagId: String, fm: FragmentManager) :


### PR DESCRIPTION
Refactors `TabbedGridFragmentActivity` to be abstract and request focus during `onCreate` instead of `onStart` which means the selected tab and grid position will be retained when navigating back from a new screen.