### PR TITLE
Add tag/movie icons for performer cards

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerPresenter.kt
@@ -27,6 +27,8 @@ class PerformerPresenter(callback: LongClickCallBack<PerformerData>? = null) :
 
         val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
         dataTypeMap[DataType.SCENE] = item.scene_count
+        dataTypeMap[DataType.TAG] = item.tags.size
+        dataTypeMap[DataType.MOVIE] = item.movie_count
 
         cardView.setUpExtraRow(dataTypeMap, item.o_counter)
 

--- a/app/src/main/res/layout/image_card_icon_row.xml
+++ b/app/src/main/res/layout/image_card_icon_row.xml
@@ -7,17 +7,55 @@
     android:layout_height="18dp"
     android:layout_alignParentStart="true"
     android:layout_below="@+id/content_text"
+    android:layout_marginStart="0dp"
+    android:layout_marginEnd="0dp"
     android:gravity="center">
 
     <LinearLayout style="@style/Widget.Theme.StashAppAndroidTV.ExtraWrapper">
 
         <TextView
+            android:id="@+id/extra_scene_icon"
+            android:text="@string/fa_circle_play"
+            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
+
+        <TextView
+            android:id="@+id/extra_scene_count"
+            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText" />
+    </LinearLayout>
+
+    <LinearLayout style="@style/Widget.Theme.StashAppAndroidTV.ExtraWrapper">
+
+        <TextView
+            android:id="@+id/extra_movie_icon"
+            android:text="@string/fa_film"
+            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
+
+        <TextView
+            android:id="@+id/extra_movie_count"
+            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText" />
+    </LinearLayout>
+
+    <LinearLayout style="@style/Widget.Theme.StashAppAndroidTV.ExtraWrapper">
+
+        <TextView
             android:id="@+id/extra_image_icon"
-            android:text="@string/fa_images"
+            android:text="@string/fa_image"
             style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
 
         <TextView
             android:id="@+id/extra_image_count"
+            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText" />
+    </LinearLayout>
+
+    <LinearLayout style="@style/Widget.Theme.StashAppAndroidTV.ExtraWrapper">
+
+        <TextView
+            android:id="@+id/extra_gallery_icon"
+            android:text="@string/fa_images"
+            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
+
+        <TextView
+            android:id="@+id/extra_gallery_count"
             style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText" />
     </LinearLayout>
 
@@ -48,36 +86,12 @@
     <LinearLayout style="@style/Widget.Theme.StashAppAndroidTV.ExtraWrapper">
 
         <TextView
-            android:id="@+id/extra_movie_icon"
-            android:text="@string/fa_film"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_movie_count"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText" />
-    </LinearLayout>
-
-    <LinearLayout style="@style/Widget.Theme.StashAppAndroidTV.ExtraWrapper">
-
-        <TextView
             android:id="@+id/extra_marker_icon"
             android:text="@string/fa_location_dot"
             style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
 
         <TextView
             android:id="@+id/extra_marker_count"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText" />
-    </LinearLayout>
-
-    <LinearLayout style="@style/Widget.Theme.StashAppAndroidTV.ExtraWrapper">
-
-        <TextView
-            android:id="@+id/extra_scene_icon"
-            android:text="@string/fa_circle_play"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_scene_count"
             style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText" />
     </LinearLayout>
 
@@ -95,18 +109,6 @@
 
         <TextView
             android:id="@+id/extra_ocounter_count"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText" />
-    </LinearLayout>
-
-    <LinearLayout style="@style/Widget.Theme.StashAppAndroidTV.ExtraWrapper">
-
-        <TextView
-            android:id="@+id/extra_gallery_icon"
-            android:text="@string/fa_images"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_gallery_count"
             style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText" />
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="fa_location_dot" translatable="false">&#xf3c5;</string>
     <string name="fa_film" translatable="false">&#xf008;</string>
     <string name="fa_circle_play" translatable="false">&#xf144;</string>
+    <string name="fa_image" translatable="false">&#xf03e;</string>
     <string name="fa_images" translatable="false">&#xf302;</string>
     <string name="fa_rotate_right" translatable="false">&#xf2f9;</string>
     <string name="fa_rotate_left" translatable="false">&#xf2ea;</string>


### PR DESCRIPTION
Adds the tag & movie counts to performer cards. Also some icons are rearranged to match the server UI.

Also switches the icon used for image counts to the correct one.

Performers also have image & gallery counts, but those don't fit yet so I'll open an issue to follow up.