### PR TITLE
Define DiffCallbacks instead of shortcut

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -508,7 +508,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                             )
                         val newTags = mutResult?.tags?.map { it.tagData }
                         val newTagName =
-                            newTags?.first { it.id == tagId }?.name
+                            newTags?.firstOrNull { it.id == tagId }?.name
                         tagsAdapter.setItems(newTags, TagDiffCallback)
                         if (mAdapter.lookup(TAG_POS) == null) {
                             mAdapter.set(
@@ -547,7 +547,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                             )
                         val resultPerformers = mutResult?.performers?.map { it.performerData }
                         val newPerformer =
-                            resultPerformers?.first { it.id == performerId }
+                            resultPerformers?.firstOrNull { it.id == performerId }
                         performersAdapter.setItems(resultPerformers, PerformerDiffCallback)
                         if (mAdapter.lookup(PERFORMER_POS) == null) {
                             mAdapter.set(

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Comparators.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Comparators.kt
@@ -1,6 +1,5 @@
 package com.github.damontecres.stashapp.util
 
-import android.annotation.SuppressLint
 import androidx.leanback.widget.DiffCallback
 import androidx.recyclerview.widget.DiffUtil
 import com.github.damontecres.stashapp.api.fragment.GalleryData
@@ -140,29 +139,82 @@ object GalleryComparator : DiffUtil.ItemCallback<GalleryData>() {
     }
 }
 
-open class StashDiffCallback<T>(private val getId: (T) -> String) : DiffCallback<T>() {
+object TagDiffCallback : DiffCallback<TagData>() {
     override fun areItemsTheSame(
-        oldItem: T & Any,
-        newItem: T & Any,
+        oldItem: TagData,
+        newItem: TagData,
     ): Boolean {
-        return getId(oldItem) == getId(newItem)
+        return oldItem.id == newItem.id
     }
 
-    @SuppressLint("DiffUtilEquals")
     override fun areContentsTheSame(
-        oldItem: T & Any,
-        newItem: T & Any,
+        oldItem: TagData,
+        newItem: TagData,
     ): Boolean {
         return oldItem == newItem
     }
 }
 
-object TagDiffCallback : StashDiffCallback<TagData>(getId = { it.id })
+object MarkerDiffCallback : DiffCallback<MarkerData>() {
+    override fun areItemsTheSame(
+        oldItem: MarkerData,
+        newItem: MarkerData,
+    ): Boolean {
+        return oldItem.id == newItem.id
+    }
 
-object MarkerDiffCallback : StashDiffCallback<MarkerData>(getId = { it.id })
+    override fun areContentsTheSame(
+        oldItem: MarkerData,
+        newItem: MarkerData,
+    ): Boolean {
+        return oldItem == newItem
+    }
+}
 
-object PerformerDiffCallback : StashDiffCallback<PerformerData>(getId = { it.id })
+object PerformerDiffCallback : DiffCallback<PerformerData>() {
+    override fun areItemsTheSame(
+        oldItem: PerformerData,
+        newItem: PerformerData,
+    ): Boolean {
+        return oldItem.id == newItem.id
+    }
 
-object MovieDiffCallback : StashDiffCallback<MovieData>(getId = { it.id })
+    override fun areContentsTheSame(
+        oldItem: PerformerData,
+        newItem: PerformerData,
+    ): Boolean {
+        return oldItem == newItem
+    }
+}
 
-object StudioDiffCallback : StashDiffCallback<StudioData>(getId = { it.id })
+object MovieDiffCallback : DiffCallback<MovieData>() {
+    override fun areItemsTheSame(
+        oldItem: MovieData,
+        newItem: MovieData,
+    ): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(
+        oldItem: MovieData,
+        newItem: MovieData,
+    ): Boolean {
+        return oldItem == newItem
+    }
+}
+
+object StudioDiffCallback : DiffCallback<StudioData>() {
+    override fun areItemsTheSame(
+        oldItem: StudioData,
+        newItem: StudioData,
+    ): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(
+        oldItem: StudioData,
+        newItem: StudioData,
+    ): Boolean {
+        return oldItem == newItem
+    }
+}


### PR DESCRIPTION
I think trying to shortcut defining all of the `DiffCallback` objects ended up with weird behavior due to how Kotlin compiles the `==` call.

So explicitly define a `DiffCallback` for each data type.