### PR TITLE
Only initialize a DateTimeFormatter for API >=26

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -80,9 +80,6 @@ object Constants {
     const val OK_HTTP_TAG = "$TAG.OkHttpClient"
     const val OK_HTTP_CACHE_DIR = "okhttpcache"
 
-    @RequiresApi(Build.VERSION_CODES.O)
-    val dateTimeFormatter = DateTimeFormatter.ofPattern("eee, MMMM d, yyyy h:mm a")
-
     /**
      * Converts seconds into a Duration string where fractional seconds are removed
      */
@@ -118,6 +115,7 @@ object Constants {
             null
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             try {
+                val dateTimeFormatter = DateTimeFormatter.ofPattern("eee, MMMM d, yyyy h:mm a")
                 val dateTime =
                     ZonedDateTime.parse(
                         ts.toString(),


### PR DESCRIPTION
Fixes #244 

I believe this will fix the issue, but need to double check on a lower API level device.