### PR TITLE
Add a default long click for markers to go to its scene

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -1,7 +1,5 @@
 package com.github.damontecres.stashapp
 
-import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -18,7 +16,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.Query
-import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.SavedFilterData
 import com.github.damontecres.stashapp.api.fragment.TagData
 import com.github.damontecres.stashapp.api.type.CriterionModifier
@@ -35,7 +32,6 @@ import com.github.damontecres.stashapp.data.FilterType
 import com.github.damontecres.stashapp.data.StashCustomFilter
 import com.github.damontecres.stashapp.data.StashFilter
 import com.github.damontecres.stashapp.data.StashSavedFilter
-import com.github.damontecres.stashapp.presenters.MarkerPresenter
 import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
 import com.github.damontecres.stashapp.presenters.StashPresenter
@@ -403,13 +399,7 @@ class FilterListActivity : FragmentActivity() {
                     } else {
                         filterParser.convertMarkerObjectFilter(objectFilter)
                     }
-                val selectorPresenter =
-                    ClassPresenterSelector().addClassPresenter(
-                        MarkerData::class.java,
-                        MarkerPresenter(MarkerLongClickCallBack(this)),
-                    )
                 StashGridFragment(
-                    selectorPresenter,
                     MarkerComparator,
                     MarkerDataSupplier(findFilter, markerFilter),
                     null,
@@ -454,21 +444,6 @@ class FilterListActivity : FragmentActivity() {
                     name,
                 )
             }
-        }
-    }
-
-    class MarkerLongClickCallBack(private val context: Context) :
-        StashPresenter.LongClickCallBack<MarkerData> {
-        override val popUpItems: List<String>
-            get() = listOf(context.getString(R.string.go_to_scene))
-
-        override fun onItemLongClick(
-            item: MarkerData,
-            popUpItemPosition: Int,
-        ) {
-            val intent = Intent(context, VideoDetailsActivity::class.java)
-            intent.putExtra(VideoDetailsActivity.MOVIE, item.scene.slimSceneData.id)
-            context.startActivity(intent)
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
@@ -185,7 +185,7 @@ class SearchForFragment(
     class GoToLongClick<T : Any>(private val context: Context) :
         StashPresenter.LongClickCallBack<T> {
         override val popUpItems: List<String>
-            get() = listOf("Go to")
+            get() = listOf(context.getString(R.string.go_to))
 
         override fun onItemLongClick(
             item: T,

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
@@ -1,5 +1,8 @@
 package com.github.damontecres.stashapp.presenters
 
+import android.content.Intent
+import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.VideoDetailsActivity
 import com.github.damontecres.stashapp.api.fragment.MarkerData
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -21,6 +24,32 @@ class MarkerPresenter(callback: LongClickCallBack<MarkerData>? = null) :
         cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
         loadImage(cardView, item.screenshot)
         cardView.videoUrl = item.stream
+    }
+
+    override fun getDefaultLongClickCallBack(cardView: StashImageCardView): LongClickCallBack<MarkerData> {
+        return object : LongClickCallBack<MarkerData> {
+            override val popUpItems: List<String>
+                get() =
+                    listOf(
+                        cardView.context.getString(R.string.go_to),
+                        cardView.context.getString(R.string.go_to_scene),
+                    )
+
+            override fun onItemLongClick(
+                item: MarkerData,
+                popUpItemPosition: Int,
+            ) {
+                if (popUpItemPosition == 0) {
+                    cardView.performClick()
+                } else if (popUpItemPosition == 1) {
+                    val intent = Intent(cardView.context, VideoDetailsActivity::class.java)
+                    intent.putExtra(VideoDetailsActivity.MOVIE, item.scene.slimSceneData.id)
+                    cardView.context.startActivity(intent)
+                } else {
+                    throw IllegalStateException()
+                }
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -63,11 +63,12 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
                 },
             )
         } else {
+            val callback = getDefaultLongClickCallBack(cardView)
             cardView.setOnLongClickListener(
                 PopupOnLongClickListener(
-                    listOf("Go to"),
-                ) { _, _, _, _ ->
-                    cardView.performClick()
+                    callback.popUpItems,
+                ) { _, _, pos, _ ->
+                    callback.onItemLongClick(item as T, pos)
                 },
             )
         }
@@ -96,6 +97,20 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
     open override fun onUnbindViewHolder(viewHolder: ViewHolder) {
         val cardView = viewHolder.view as StashImageCardView
         cardView.onUnbindViewHolder()
+    }
+
+    open fun getDefaultLongClickCallBack(cardView: StashImageCardView): LongClickCallBack<T> {
+        return object : LongClickCallBack<T> {
+            override val popUpItems: List<String>
+                get() = listOf(cardView.context.getString(R.string.go_to))
+
+            override fun onItemLongClick(
+                item: T,
+                popUpItemPosition: Int,
+            ) {
+                cardView.performClick()
+            }
+        }
     }
 
     interface LongClickCallBack<T> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="fa_magnifying_glass_minus" translatable="false">&#xf010;</string>
 
 
+    <string name="go_to">Go to</string>
     <string name="go_to_scene">Go to scene</string>
     <string name="view_scenes">View scenes</string>
     <string name="view_markers">View markers</string>


### PR DESCRIPTION
A `StashPresenter` can now dynamically provide a default `LongClickCallback`. This allows for markers to have a default long click to go to its scene from any page in the app.