### PR TITLE
Scale the number of cards shown in a row for all data types

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -32,7 +32,6 @@ import com.github.damontecres.stashapp.data.FilterType
 import com.github.damontecres.stashapp.data.StashCustomFilter
 import com.github.damontecres.stashapp.data.StashFilter
 import com.github.damontecres.stashapp.data.StashSavedFilter
-import com.github.damontecres.stashapp.presenters.PerformerPresenter
 import com.github.damontecres.stashapp.presenters.ScenePresenter
 import com.github.damontecres.stashapp.presenters.StashPresenter
 import com.github.damontecres.stashapp.presenters.TagPresenter
@@ -330,8 +329,8 @@ class FilterListActivity : FragmentActivity() {
         val cardSize =
             PreferenceManager.getDefaultSharedPreferences(this)
                 .getInt("cardSize", getString(R.string.card_size_default))
-        val performerCardSize =
-            (cardSize * (ScenePresenter.CARD_WIDTH.toDouble() / PerformerPresenter.CARD_WIDTH)).toInt()
+        val calculatedCardSize =
+            (cardSize * (ScenePresenter.CARD_WIDTH.toDouble() / dataType.defaultCardWidth)).toInt()
         // TODO other sizes
         val filterParser = FilterParser(ServerPreferences(this).serverVersion)
         return when (dataType) {
@@ -340,7 +339,7 @@ class FilterListActivity : FragmentActivity() {
                 StashGridFragment(
                     SceneComparator,
                     SceneDataSupplier(findFilter, sceneFilter),
-                    null,
+                    calculatedCardSize,
                     name,
                 )
             }
@@ -350,7 +349,7 @@ class FilterListActivity : FragmentActivity() {
                 StashGridFragment(
                     StudioComparator,
                     StudioDataSupplier(findFilter, studioFilter),
-                    null,
+                    calculatedCardSize,
                     name,
                 )
             }
@@ -361,7 +360,7 @@ class FilterListActivity : FragmentActivity() {
                 StashGridFragment(
                     PerformerComparator,
                     PerformerDataSupplier(findFilter, performerFilter),
-                    performerCardSize,
+                    calculatedCardSize,
                     name,
                 )
             }
@@ -377,7 +376,7 @@ class FilterListActivity : FragmentActivity() {
                     selectorPresenter,
                     TagComparator,
                     TagDataSupplier(findFilter, tagFilter),
-                    null,
+                    calculatedCardSize,
                     name,
                 )
             }
@@ -387,7 +386,7 @@ class FilterListActivity : FragmentActivity() {
                 StashGridFragment(
                     MovieComparator,
                     MovieDataSupplier(findFilter, movieFilter),
-                    null,
+                    calculatedCardSize,
                     name,
                 )
             }
@@ -402,7 +401,7 @@ class FilterListActivity : FragmentActivity() {
                 StashGridFragment(
                     MarkerComparator,
                     MarkerDataSupplier(findFilter, markerFilter),
-                    null,
+                    calculatedCardSize,
                     name,
                 )
             }
@@ -418,7 +417,7 @@ class FilterListActivity : FragmentActivity() {
                     StashGridFragment(
                         ImageComparator,
                         ImageDataSupplier(findFilter, imageFilter),
-                        null,
+                        calculatedCardSize,
                         name,
                     )
                 fragment.onItemViewClickedListener =
@@ -440,7 +439,7 @@ class FilterListActivity : FragmentActivity() {
                 StashGridFragment(
                     GalleryComparator,
                     GalleryDataSupplier(findFilter, galleryFilter),
-                    null,
+                    calculatedCardSize,
                     name,
                 )
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
@@ -3,6 +3,14 @@ package com.github.damontecres.stashapp.data
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
+import com.github.damontecres.stashapp.presenters.GalleryPresenter
+import com.github.damontecres.stashapp.presenters.ImagePresenter
+import com.github.damontecres.stashapp.presenters.MarkerPresenter
+import com.github.damontecres.stashapp.presenters.MoviePresenter
+import com.github.damontecres.stashapp.presenters.PerformerPresenter
+import com.github.damontecres.stashapp.presenters.ScenePresenter
+import com.github.damontecres.stashapp.presenters.StudioPresenter
+import com.github.damontecres.stashapp.presenters.TagPresenter
 
 enum class DataType(
     val filterMode: FilterMode,
@@ -56,6 +64,19 @@ enum class DataType(
     ;
 
     val asDefaultFindFilterType get() = defaultSort.asFindFilterType
+
+    val defaultCardWidth
+        get() =
+            when (this) {
+                SCENE -> ScenePresenter.CARD_WIDTH
+                MOVIE -> MoviePresenter.CARD_WIDTH
+                MARKER -> MarkerPresenter.CARD_WIDTH
+                PERFORMER -> PerformerPresenter.CARD_WIDTH
+                STUDIO -> StudioPresenter.CARD_WIDTH
+                TAG -> TagPresenter.CARD_WIDTH
+                IMAGE -> ImagePresenter.CARD_WIDTH
+                GALLERY -> GalleryPresenter.CARD_WIDTH
+            }
 
     companion object {
         fun fromFilterMode(mode: FilterMode): DataType? {


### PR DESCRIPTION
When viewing data in a filter, all data types will scale up/down the number of cards shown in each row.

This means for cards which have a narrower width will now have more in a row instead of large blank spaces on the left & right sides.

Previously, just performer cards scaled this way, but now all data types will.