### PR TITLE
Add network timeout setting for large servers

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
@@ -454,6 +454,24 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
                 startActivity(Intent(requireContext(), LicenseActivity::class.java))
                 true
             }
+
+            val networkTimeoutPref = findPreference<Preference>("networkTimeout")!!
+            networkTimeoutPref.setOnPreferenceClickListener {
+                viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
+                    testStashConnection(requireContext(), true)
+                }
+                true
+            }
+            networkTimeoutPref.setOnPreferenceChangeListener { _, newValue ->
+                if (newValue == 0) {
+                    Toast.makeText(
+                        requireContext(),
+                        "Warning! A zero network timeout will wait forever!",
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+                true
+            }
         }
 
         private fun setCacheDurationSummary(

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -159,8 +159,13 @@ fun createOkHttpClient(context: Context): OkHttpClient {
     val apiKey = manager.getString("stashApiKey", null)
     val cacheDuration = cacheDurationPrefToDuration(manager.getInt("networkCacheDuration", 3))
     val cacheLogging = manager.getBoolean("networkCacheLogging", false)
+    val networkTimeout = manager.getInt("networkTimeout", 15).toLong()
 
-    var builder = OkHttpClient.Builder()
+    var builder =
+        OkHttpClient.Builder()
+            .readTimeout(networkTimeout, TimeUnit.SECONDS)
+            .writeTimeout(networkTimeout, TimeUnit.SECONDS)
+
     if (trustAll) {
         val sslContext = SSLContext.getInstance("SSL")
         sslContext.init(null, arrayOf(TRUST_ALL_CERTS), SecureRandom())

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -127,6 +127,13 @@
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Advanced">
+        <SeekBarPreference
+            app:key="networkTimeout"
+            app:title="Network timeout in seconds"
+            app:seekBarIncrement="5"
+            app:showSeekBarValue="true"
+            android:max="120"
+            app:defaultValue="15" />
         <SwitchPreference
             app:key="trustAllCerts"
             app:title="Trust self-signed certificates"


### PR DESCRIPTION
Adds a setting to the advanced page to change the network timeout. The previous default was 10s (now 15s). Setting to zero will disable the timeout all together. Large servers can take longer than 10 seconds to run queries.

The setting is also clickable to test the server connection so you don't have to go back and forth to find a good value.

I tested this with the emulator's latency/speed controls.