### PR TITLE
Fix race condition when adding tags/performers to a scene

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -69,6 +69,7 @@ import com.github.damontecres.stashapp.views.ClassOnItemViewClickedListener
 import com.github.damontecres.stashapp.views.StashItemViewClickListener
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.math.roundToInt
 
 /**
@@ -77,6 +78,9 @@ import kotlin.math.roundToInt
  */
 class VideoDetailsFragment : DetailsSupportFragment() {
     private var mSelectedMovie: SlimSceneData? = null
+
+    private lateinit var queryEngine: QueryEngine
+    private lateinit var mutationEngine: MutationEngine
 
     private val studioAdapter = ArrayObjectAdapter(StudioPresenter())
     private val performersAdapter =
@@ -130,6 +134,11 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d(TAG, "onCreate DetailsFragment")
         super.onCreate(savedInstanceState)
+
+        val lock = ReentrantReadWriteLock()
+        queryEngine = QueryEngine(requireContext(), lock = lock)
+        mutationEngine = MutationEngine(requireContext(), lock = lock)
+
         mDetailsBackground = DetailsSupportFragmentBackgroundController(this)
         resultLauncher =
             registerForActivityResult(
@@ -184,7 +193,6 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     }
 
     private fun fetchData(sceneId: String) {
-        val queryEngine = QueryEngine(requireContext())
         viewLifecycleOwner.lifecycleScope.launch(
             StashCoroutineExceptionHandler(
                 Toast.makeText(
@@ -267,6 +275,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
             }
 
             val performerIds = mSelectedMovie!!.performers.map { it.id }
+            Log.v(TAG, "fetchData performerIds=$performerIds")
             if (performerIds.isNotEmpty()) {
                 if (mAdapter.lookup(PERFORMER_POS) == null) {
                     mAdapter.set(
@@ -456,7 +465,6 @@ class VideoDetailsFragment : DetailsSupportFragment() {
                     ),
                 ),
             ) {
-                val mutationEngine = MutationEngine(requireContext())
                 val newCounter = mutationEngine.incrementOCounter(counter.id)
                 mSelectedMovie = mSelectedMovie!!.copy(o_counter = newCounter.count)
                 sceneActionsAdapter.set(O_COUNTER_POS, newCounter)
@@ -665,7 +673,6 @@ class VideoDetailsFragment : DetailsSupportFragment() {
             item: OCounter,
             popUpItem: StashPresenter.PopUpItem,
         ) {
-            val mutationEngine = MutationEngine(requireContext())
             viewLifecycleOwner.lifecycleScope.launch(
                 StashCoroutineExceptionHandler(
                     Toast.makeText(


### PR DESCRIPTION
In some cases, a race condition can occur after adding a performer or tag to scene.

While, the `onActivityResult` is called before `onResume`, it is possible that the scene data fetched in `onResume` happens _before_ the mutation in `onActivityResult` completes. And then the UI updates in `onActivityResult` occurs before the ones in `onResume`. This is possible because network calls and UI updates occurs in different coroutines. In this surprisingly common case, the scene is successfully modified, but the UI doesn't reflect the changes.

This PR fixes that race condition by optionally allowing a `QueryEngine` and `MutationEngine` to share a `ReadWriteLock` allowing the mutations to block queries when needed.

Since this is a concurrency issue, it requires thorough testing and extra scrutiny.