### PR TITLE
Fixes a few Todos and resolution names

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -146,8 +146,6 @@ class FilterListActivity : FragmentActivity() {
         lifecycleScope.launch(exHandler) {
             val savedFilters = queryEngine.getSavedFilters(dataType)
             if (savedFilters.isEmpty()) {
-                // TODO: Hide the filter button?
-//                filterButton.visibility = View.INVISIBLE
                 filterButton.setOnClickListener {
                     Toast.makeText(
                         this@FilterListActivity,

--- a/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
@@ -19,6 +19,7 @@ import androidx.leanback.widget.SparseArrayObjectAdapter
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo3.api.Optional
+import com.github.damontecres.stashapp.api.fragment.GalleryData
 import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.MovieData
@@ -94,7 +95,7 @@ class SearchForFragment(
                     DataType.PERFORMER -> (item as PerformerData).id
                     DataType.MARKER -> (item as MarkerData).id
                     DataType.IMAGE -> (item as ImageData).id
-                    DataType.GALLERY -> TODO()
+                    DataType.GALLERY -> (item as GalleryData).id
                 }
             result.putExtra(RESULT_ID_KEY, resultId)
             result.putExtra(ID_KEY, requireActivity().intent.getLongExtra("id", -1))

--- a/app/src/main/java/com/github/damontecres/stashapp/StashExoPlayer.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashExoPlayer.kt
@@ -25,7 +25,6 @@ class StashExoPlayer private constructor() {
             val skipBack =
                 PreferenceManager.getDefaultSharedPreferences(context)
                     .getInt("skip_back_time", 10)
-            // TODO invalidate
             if (instance == null) {
                 synchronized(this) { // synchronized to avoid concurrency problem
                     if (instance == null) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
@@ -14,6 +14,7 @@ import com.github.damontecres.stashapp.util.ServerPreferences
 import com.github.damontecres.stashapp.util.StashGlide
 import com.github.damontecres.stashapp.util.concatIfNotBlank
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
+import com.github.damontecres.stashapp.util.resolutionName
 import com.github.damontecres.stashapp.util.resume_position
 import com.github.damontecres.stashapp.util.titleOrFilename
 import java.util.EnumMap
@@ -45,11 +46,9 @@ class ScenePresenter(callback: LongClickCallBack<SlimSceneData>? = null) :
             val duration = Constants.durationToString(videoFile.duration)
             cardView.setTextOverlayText(StashImageCardView.OverlayPosition.BOTTOM_RIGHT, duration)
 
-            // TODO: 2160P => 4k, etc
-            val resolution = "${videoFile.height}P"
             val resText = cardView.getTextOverlay(StashImageCardView.OverlayPosition.BOTTOM_LEFT)
             resText.setTypeface(null, Typeface.BOLD)
-            resText.text = resolution
+            resText.text = videoFile.resolutionName()
 
             if (item.resume_time != null) {
                 val percentWatched = item.resume_time / videoFile.duration

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -41,6 +41,7 @@ import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SavedFilterData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
+import com.github.damontecres.stashapp.api.fragment.VideoFileData
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.util.Constants.OK_HTTP_TAG
@@ -679,4 +680,39 @@ suspend fun showToastOnMain(
     length: Int,
 ) = withContext(Dispatchers.Main) {
     Toast.makeText(context, message, length).show()
+}
+
+fun VideoFileData.resolutionName(): CharSequence {
+    val number = if (width > height) height else width
+    return if (number >= 6144) {
+        "HUGE"
+    } else if (number >= 3840) {
+        "8K"
+    } else if (number >= 3584) {
+        "7K"
+    } else if (number >= 3000) {
+        "6K"
+    } else if (number >= 2560) {
+        "5K"
+    } else if (number >= 1920) {
+        "4K"
+    } else if (number >= 1440) {
+        "1440p"
+    } else if (number >= 1080) {
+        "1080p"
+    } else if (number >= 720) {
+        "720p"
+    } else if (number >= 540) {
+        "540p"
+    } else if (number >= 480) {
+        "480p"
+    } else if (number >= 360) {
+        "360p"
+    } else if (number >= 240) {
+        "240p"
+    } else if (number >= 144) {
+        "144p"
+    } else {
+        "${number}p"
+    }
 }


### PR DESCRIPTION
Resolves a few `// TODO`.

Updates the scene card to use the same resolution names as the server web UI (from https://github.com/stashapp/stash/blob/12af7d65158c9cdd80abd1959c61b49cbf85d9fa/ui/v2.5/src/utils/text.ts#L326).