### PR TITLE
Tweak the color for focused buttons in the setup UI

### DIFF
--- a/app/src/main/res/drawable/guided_actions_selector.xml
+++ b/app/src/main/res/drawable/guided_actions_selector.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <ripple android:color="@color/transparent_grey_25"/>
+    </item>
+    <item android:state_focused="true" android:drawable="@color/transparent_grey_25" />
+    <item android:drawable="@android:color/transparent"/>
+</selector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,6 +10,7 @@
     <color name="transparent_black_25">#40000000</color>
     <color name="transparent_black_50">#80000000</color>
     <color name="transparent_black_75">#BF000000</color>
+    <color name="transparent_grey_25">#40888888</color>
 
     <array name="rating_colors">
         <item>#80939393</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -36,6 +36,7 @@
         <item name="android:colorBackground">@color/default_background</item>
         <item name="background">@color/default_background</item>
         <item name="guidedActionsBackground">@color/popup_background</item>
+        <item name="guidedActionsSelectorDrawable">@drawable/guided_actions_selector</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Follow up to #262 

The focused color for buttons in the guided actions setup UI is very transparent and if the device brightness is low it can be tough to distinguish what button is focused particularly when switching servers.

So this PR changes the color to a more consistent one with better contrast.