### PR TITLE
Fix gifs from being stretched out of their aspect ratio

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ImageActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ImageActivity.kt
@@ -193,7 +193,7 @@ class ImageActivity : FragmentActivity() {
                     if (image != null && image.paths.image != null) {
                         currentPosition = newPosition
                         imageFragment =
-                            ImageFragment(image.id, image.paths.image, image.maxFileSize)
+                            ImageFragment(image.id, image.paths.image, image.maxFileSize, image)
                         imageFragment.image = image
                         supportFragmentManager.beginTransaction()
                             .replace(R.id.image_fragment, imageFragment)
@@ -276,6 +276,7 @@ class ImageActivity : FragmentActivity() {
         val imageId: String,
         val imageUrl: String,
         val imageSize: Int = -1,
+        var image: ImageData? = null,
     ) :
         Fragment(R.layout.image_layout) {
         lateinit var mainImage: ZoomImageView
@@ -284,7 +285,6 @@ class ImageActivity : FragmentActivity() {
         lateinit var oCounterTextView: TextView
         lateinit var table: TableLayout
         lateinit var ratingBar: StashRatingBar
-        var image: ImageData? = null
 
         private var animationDuration by Delegates.notNull<Long>()
 
@@ -307,15 +307,6 @@ class ImageActivity : FragmentActivity() {
             ratingBar = view.findViewById(R.id.rating_bar)
 
             Log.v(TAG, "imageId=$imageId")
-            if (image != null) {
-                configureUI()
-            } else {
-                viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
-                    val queryEngine = QueryEngine(requireContext())
-                    image = queryEngine.getImage(imageId)!!
-                    configureUI()
-                }
-            }
 
             ratingBar.nextFocusDownId = R.id.o_counter_button
             val focusListener = ImageButtonFocusListener(ratingBar)
@@ -416,6 +407,44 @@ class ImageActivity : FragmentActivity() {
             }
             zoomOutButton.nextFocusUpId = ratingBar.focusableViewId
 
+            viewCreated = true
+        }
+
+        override fun onStart() {
+            super.onStart()
+            if (image != null) {
+                configureUI()
+            } else {
+                viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
+                    val queryEngine = QueryEngine(requireContext())
+                    image = queryEngine.getImage(imageId)!!
+                    configureUI()
+                }
+            }
+        }
+
+        private fun loadImage() {
+            mainImage.post {
+                // Properly scale the image after layout
+                val imageFile = image!!.visual_files.first()
+                val width = imageFile.width!!
+                val height = imageFile.height!!
+
+                val scale =
+                    Math.min(
+                        mainImage.height.toDouble() / width,
+                        mainImage.width.toDouble() / height,
+                    )
+
+                val targetHeight = height * scale
+                val targetWidth = width * scale
+
+                val lp = mainImage.layoutParams
+                lp.width = targetWidth.toInt()
+                lp.height = targetHeight.toInt()
+                mainImage.layoutParams = lp
+            }
+
             val placeholder =
                 object : CircularProgressDrawable(requireContext()) {
                     // ZoomImageView requires that drawables have an intrinsic height/width
@@ -464,11 +493,11 @@ class ImageActivity : FragmentActivity() {
                     },
                 )
                 .into(mainImage)
-            viewCreated = true
         }
 
         fun configureUI() {
             val image = image!!
+            loadImage()
             titleText.text = image.title
 
             ratingBar.rating100 = image.rating100 ?: 0

--- a/app/src/main/res/layout/image_layout.xml
+++ b/app/src/main/res/layout/image_layout.xml
@@ -16,6 +16,8 @@
         android:id="@+id/image_view_image"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
         android:scrollbars="vertical|horizontal"
         app:transformation="centerInside"
         app:transformationGravity="auto"


### PR DESCRIPTION
For some reason Glide's `GifDrawable` and `ZoomImageView` don't work well together and gifs will be stretch to fill the view.

This PR alters the `ZoomImageView`'s layout parameters so that they match the aspect ratio of the image being loaded.

Ref: https://github.com/damontecres/StashAppAndroidTV/issues/214#issuecomment-2048487322