### PR TITLE
Fix determining next page

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
@@ -105,7 +105,7 @@ class StashPagingSource<T : Query.Data, D : Any, C : Query.Data>(
                 // If the total fetched results is less than the total number of items, then there is a next page
                 // Advance the page by the number of requested items
                 val nextPageNum =
-                    if (results.isNotEmpty()) {
+                    if (results.size >= loadSize) {
                         pageNum + (params.loadSize / pageSize)
                     } else {
                         null


### PR DESCRIPTION
In some rare cases if there is a single item returned, the `StashPagingSource` will go nuts and load the same page over and over.

There is only potentially a next page if we loaded at least the max number of items.