### PR TITLE
Add some extra details to scene page

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <integer tools:override="true" name="lb_details_description_body_max_lines">1000</integer>
+    <integer tools:override="true" name="lb_details_description_body_min_lines">1000</integer>
     <dimen tools:override="true" name="lb_basic_card_info_padding">6dp</dimen>
     <dimen name="title_bar_height">74dp</dimen>
     <dimen name="title_bar_icon_size">54dp</dimen>


### PR DESCRIPTION
A few minor UI tweaks

1. If playback debug details is enabled, the scene details page will now show whether or not the codec/format is unsupported
2. Show the play count/duration if available on scene details page
3. Adjusts the minimum lines shown so that videos without a description don't get truncated