### PR TITLE
Fixes performer tab focus issues

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerActivity.kt
@@ -3,6 +3,7 @@ package com.github.damontecres.stashapp
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.core.view.children
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
@@ -59,6 +60,9 @@ class PerformerActivity : FragmentActivity() {
             val viewPager = findViewById<LeanbackViewPager>(R.id.performer_view_pager)
             viewPager.adapter = PagerAdapter(columns, supportFragmentManager)
             tabLayout.setupWithViewPager(viewPager)
+
+            tabLayout.nextFocusDownId = R.id.performer_view_pager
+            tabLayout.children.forEach { it.nextFocusDownId = R.id.performer_view_pager }
 
             supportFragmentManager.beginTransaction()
                 .replace(R.id.performer_details, PerformerFragment())


### PR DESCRIPTION
Related to #288 

I haven't been able to reproduce the issue in #288, so I don't know if this PR will fix it, but this PR doesn't break anything either.

Specify the focus-down views for the performer tabs to be the `ViewPager` which holds the scene grid. This _should_ mean that when a tab is focused, pressing D-Pad down will _always_ focus down to the `ViewPager`.