### PR TITLE
Update workflow to support multiple version development

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,8 @@ jobs:
           tag: "${{ env.TAG_NAME }}"
 
           body: |
+            ### `${{ env.BRANCH_NAME }}` development build
+
             This pre-release tracks the development debug build of StashAppAndroidTV from the `${{ env.BRANCH_NAME }}` branch.
 
             See https://github.com/damontecres/StashAppAndroidTV/releases/latest for the latest stable release.


### PR DESCRIPTION
Updates the main workflow so that multiple branches can be built and released.

This allows for work to continue on `v0.2.x` on the `main` branch while developing `v0.3.0` on the `develop/v0.3.0` branch for example.