### PR TITLE
Respect the `alwaysStartFromBeginning` server-side setting

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -522,17 +522,18 @@ class VideoDetailsFragment : DetailsSupportFragment() {
     }
 
     private fun setupPlayActionsAdapter() {
-        if (position > 0) {
-            playActionsAdapter.set(0, Action(ACTION_RESUME_SCENE, "Resume"))
-            // Force focus to move to Resume
-            playActionsAdapter.clear(1)
-            playActionsAdapter.set(1, Action(ACTION_PLAY_SCENE, "Restart"))
-        } else {
+        val serverPreferences = ServerPreferences(requireContext())
+        if (position <= 0L || serverPreferences.alwaysStartFromBeginning) {
             playActionsAdapter.set(
                 0,
                 Action(ACTION_PLAY_SCENE, resources.getString(R.string.play_scene)),
             )
             playActionsAdapter.clear(1)
+        } else {
+            playActionsAdapter.set(0, Action(ACTION_RESUME_SCENE, "Resume"))
+            // Force focus to move to Resume
+            playActionsAdapter.clear(1)
+            playActionsAdapter.set(1, Action(ACTION_PLAY_SCENE, "Restart"))
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
@@ -36,6 +36,8 @@ class ServerPreferences(private val context: Context) {
 
     val ratingsAsStars get() = preferences.getString(PREF_RATING_TYPE, "stars") == "stars"
 
+    val alwaysStartFromBeginning get() = preferences.getBoolean(PREF_ALWAYS_START_BEGINNING, false)
+
     suspend fun updatePreferences(): ServerPreferences {
         val queryEngine = QueryEngine(context)
         val query = ConfigurationQuery()
@@ -92,6 +94,14 @@ class ServerPreferences(private val context: Context) {
                             "Exception parsing ratingSystemOptions: $ratingSystemOptionsRaw",
                         )
                     }
+                }
+
+                val alwaysStartFromBeginning = ui.getCaseInsensitive("alwaysStartFromBeginning")
+                if (alwaysStartFromBeginning != null) {
+                    putBoolean(
+                        PREF_ALWAYS_START_BEGINNING,
+                        alwaysStartFromBeginning.toString().toBoolean(),
+                    )
                 }
 
                 val scan = config.defaults.scan
@@ -163,6 +173,7 @@ class ServerPreferences(private val context: Context) {
         const val PREF_MINIMUM_PLAY_PERCENT = "minimumPlayPercent"
         const val PREF_RATING_TYPE = "ratingSystemOptions.type"
         const val PREF_RATING_PRECISION = "ratingSystemOptions.starPrecision"
+        const val PREF_ALWAYS_START_BEGINNING = "ui.alwaysStartFromBeginning"
 
         // Scan default settings
         const val PREF_SCAN_GENERATE_COVERS = "scanGenerateCovers"


### PR DESCRIPTION
Closes #282 

The app will respect the server-side setting "Always start video from beginning" (accessible via Settings->Interface->Scene Player).

When enabled, the scene details page always shows just the "Play" button which always starts playback at the beginning.