### PR TITLE
Performance improvement to use single Spannable TextView for icons on cards

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
@@ -1,5 +1,6 @@
 package com.github.damontecres.stashapp.data
 
+import androidx.annotation.StringRes
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.type.FilterMode
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
@@ -14,8 +15,9 @@ import com.github.damontecres.stashapp.presenters.TagPresenter
 
 enum class DataType(
     val filterMode: FilterMode,
-    val stringId: Int,
-    val pluralStringId: Int,
+    @StringRes val stringId: Int,
+    @StringRes val pluralStringId: Int,
+    @StringRes val iconStringId: Int,
     val defaultSort: SortAndDirection,
     val sortOptions: List<SortOption>,
 ) {
@@ -23,6 +25,7 @@ enum class DataType(
         FilterMode.SCENES,
         R.string.stashapp_scene,
         R.string.stashapp_scenes,
+        R.string.fa_circle_play,
         SortAndDirection("date", SortDirectionEnum.DESC),
         SCENE_SORT_OPTIONS,
     ),
@@ -30,6 +33,7 @@ enum class DataType(
         FilterMode.MOVIES,
         R.string.stashapp_movie,
         R.string.stashapp_movies,
+        R.string.fa_film,
         SortAndDirection.NAME_ASC,
         MOVIE_SORT_OPTIONS,
     ),
@@ -37,6 +41,7 @@ enum class DataType(
         FilterMode.SCENE_MARKERS,
         R.string.stashapp_markers,
         R.string.stashapp_markers,
+        R.string.fa_location_dot,
         SortAndDirection("created_at", SortDirectionEnum.DESC),
         MARKER_SORT_OPTIONS,
     ),
@@ -44,6 +49,7 @@ enum class DataType(
         FilterMode.PERFORMERS,
         R.string.stashapp_performer,
         R.string.stashapp_performers,
+        R.string.fa_user,
         SortAndDirection.NAME_ASC,
         PERFORMER_SORT_OPTIONS,
     ),
@@ -51,6 +57,7 @@ enum class DataType(
         FilterMode.STUDIOS,
         R.string.stashapp_studio,
         R.string.stashapp_studios,
+        R.string.fa_video,
         SortAndDirection.NAME_ASC,
         STUDIO_SORT_OPTIONS,
     ),
@@ -58,6 +65,7 @@ enum class DataType(
         FilterMode.TAGS,
         R.string.stashapp_tag,
         R.string.stashapp_tags,
+        R.string.fa_tag,
         SortAndDirection.NAME_ASC,
         TAG_SORT_OPTIONS,
     ),
@@ -65,6 +73,7 @@ enum class DataType(
         FilterMode.IMAGES,
         R.string.stashapp_image,
         R.string.stashapp_images,
+        R.string.fa_image,
         SortAndDirection.PATH_ASC,
         IMAGE_SORT_OPTIONS,
     ),
@@ -72,6 +81,7 @@ enum class DataType(
         FilterMode.GALLERIES,
         R.string.stashapp_gallery,
         R.string.stashapp_galleries,
+        R.string.fa_images,
         SortAndDirection.PATH_ASC,
         GALLERY_SORT_OPTIONS,
     ),

--- a/app/src/main/res/layout/image_card_icon_row.xml
+++ b/app/src/main/res/layout/image_card_icon_row.xml
@@ -13,139 +13,9 @@
     android:gravity="center_horizontal">
 
         <TextView
-            android:id="@+id/extra_scene_icon"
-            android:text="@string/fa_circle_play"
+            android:id="@+id/icon_text"
+            android:visibility="visible"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/extra_scene_count"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_scene_count"
-            app:layout_constraintStart_toEndOf="@id/extra_scene_icon"
-            app:layout_constraintEnd_toStartOf="@id/extra_movie_icon"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText"
-            tools:text="1" />
-
-
-        <TextView
-            android:id="@+id/extra_movie_icon"
-            android:text="@string/fa_film"
-            app:layout_constraintStart_toEndOf="@id/extra_scene_count"
-            app:layout_constraintEnd_toStartOf="@id/extra_movie_count"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_movie_count"
-            app:layout_constraintStart_toEndOf="@id/extra_movie_icon"
-            app:layout_constraintEnd_toStartOf="@id/extra_image_icon"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText"
-            tools:text="2" />
-
-        <TextView
-            android:id="@+id/extra_image_icon"
-            android:text="@string/fa_image"
-            app:layout_constraintStart_toEndOf="@id/extra_movie_count"
-            app:layout_constraintEnd_toStartOf="@id/extra_image_count"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_image_count"
-            app:layout_constraintStart_toEndOf="@id/extra_image_icon"
-            app:layout_constraintEnd_toStartOf="@id/extra_gallery_icon"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText"
-            tools:text="1" />
-
-        <TextView
-            android:id="@+id/extra_gallery_icon"
-            android:text="@string/fa_images"
-            app:layout_constraintStart_toEndOf="@id/extra_image_count"
-            app:layout_constraintEnd_toStartOf="@id/extra_gallery_count"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_gallery_count"
-            app:layout_constraintStart_toEndOf="@id/extra_gallery_icon"
-            app:layout_constraintEnd_toStartOf="@id/extra_tag_icon"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText"
-            tools:text="1" />
-
-        <TextView
-            android:id="@+id/extra_tag_icon"
-            android:text="@string/fa_tag"
-            app:layout_constraintStart_toEndOf="@id/extra_gallery_count"
-            app:layout_constraintEnd_toStartOf="@id/extra_tag_count"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_tag_count"
-            app:layout_constraintStart_toEndOf="@id/extra_tag_icon"
-            app:layout_constraintEnd_toStartOf="@id/extra_performer_icon"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText"
-            tools:text="1" />
-
-        <TextView
-            android:id="@+id/extra_performer_icon"
-            android:text="@string/fa_user"
-            app:layout_constraintStart_toEndOf="@id/extra_tag_count"
-            app:layout_constraintEnd_toStartOf="@id/extra_performer_count"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_performer_count"
-            app:layout_constraintStart_toEndOf="@id/extra_performer_icon"
-            app:layout_constraintEnd_toStartOf="@id/extra_marker_icon"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraText"
-            tools:text="1" />
-
-        <TextView
-            android:id="@+id/extra_marker_icon"
-            android:text="@string/fa_location_dot"
-            app:layout_constraintStart_toEndOf="@id/extra_performer_count"
-            app:layout_constraintEnd_toStartOf="@id/extra_marker_count"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            style="@style/Widget.Theme.StashAppAndroidTV.SceneExtraIcon" />
-
-        <TextView
-            android:id="@+id/extra_marker_count"
-            app:layout_constraintStart_toEndOf="@id/extra_marker_icon"
             app:layout_constraintEnd_toStartOf="@id/extra_ocounter_icon"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -159,7 +29,7 @@
             android:layout_width="@dimen/lb_basic_card_content_text_size"
             android:layout_height="@dimen/lb_basic_card_content_text_size"
             android:layout_gravity="center"
-            app:layout_constraintStart_toEndOf="@id/extra_marker_count"
+            app:layout_constraintStart_toEndOf="@id/icon_text"
             app:layout_constraintEnd_toStartOf="@id/extra_ocounter_count"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,7 +7,7 @@
     <dimen name="title_bar_margin">10dp</dimen>
     <dimen name="title_bar_start_end_margin">5dp</dimen>
     <dimen name="table_text_size">13sp</dimen>
-    <dimen name="scene_extra_spacing">4dp</dimen>
+    <dimen name="scene_extra_spacing">5dp</dimen>
     <dimen tools:override="true" name="lb_browse_rows_margin_top">120dp</dimen>
     <dimen tools:override="true" name="lb_browse_padding_start">35dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="fa_caret_up" translatable="false">&#xf0d8;</string>
     <string name="fa_caret_down" translatable="false">&#xf0d7;</string>
     <string name="fa_heart" translatable="false">&#xf004;</string>
+    <string name="fa_video" translatable="false">&#xf03d;</string>
 
     <string name="go_to">Go to</string>
     <string name="go_to_scene">Go to scene</string>


### PR DESCRIPTION
This refactors the icon row on cards to switch all icons (except O-Counter icon & text) to a single `TextView` using a `SpannableString` to set the icon font when needed.

This will help performance in two ways: 1) much fewer views to inflate/layout and 2) fewer re-layouts since the views don't need to be hidden/shown

My non-scientific estimate loading a ten row main page is ~30% faster, so this seems pretty significant!