### PR TITLE
Add ability to wrap around rating selection 0->5->0

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/views/DecimalRatingBar.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/DecimalRatingBar.kt
@@ -1,0 +1,24 @@
+package com.github.damontecres.stashapp.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.KeyEvent
+import androidx.appcompat.widget.AppCompatSeekBar
+
+class DecimalRatingBar(context: Context, attrs: AttributeSet?) : AppCompatSeekBar(context, attrs) {
+    override fun onKeyDown(
+        keyCode: Int,
+        event: KeyEvent?,
+    ): Boolean {
+        if (super.isEnabled()) {
+            if ((keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_MINUS) && progress <= 0) {
+                progress = 100
+                return true
+            } else if ((keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_PLUS) && progress >= 100) {
+                progress = 0
+                return true
+            }
+        }
+        return super.onKeyDown(keyCode, event)
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/views/StarRatingBar.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/StarRatingBar.kt
@@ -1,0 +1,24 @@
+package com.github.damontecres.stashapp.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.KeyEvent
+import androidx.appcompat.widget.AppCompatRatingBar
+
+class StarRatingBar(context: Context, attrs: AttributeSet?) : AppCompatRatingBar(context, attrs) {
+    override fun onKeyDown(
+        keyCode: Int,
+        event: KeyEvent?,
+    ): Boolean {
+        if (super.isEnabled()) {
+            if ((keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_MINUS) && rating < .05f) {
+                rating = 5f
+                return true
+            } else if ((keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_PLUS) && rating > 4.95f) {
+                rating = 0f
+                return true
+            }
+        }
+        return super.onKeyDown(keyCode, event)
+    }
+}

--- a/app/src/main/res/layout/stash_rating_bar.xml
+++ b/app/src/main/res/layout/stash_rating_bar.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools">
-    <RatingBar
+
+    <com.github.damontecres.stashapp.views.StarRatingBar
         android:id="@+id/rating_star"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -27,7 +28,7 @@
             android:textAlignment="center"
             tools:text="@string/stashapp_rating" />
 
-        <SeekBar
+        <com.github.damontecres.stashapp.views.DecimalRatingBar
             android:id="@+id/rating_decimal"
             android:layout_width="match_parent"
             android:minWidth="160dp"


### PR DESCRIPTION
Closes #283 


Pressing left on a zero rating will wrap around to 5 stars (or 10.0 decimal). And pressing right on a five star or 10.0 decimal rating to wrap around to zero.

This makes it easier/faster to pick a higher value.