### PR TITLE
Fix setting default activity tracking

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
@@ -67,6 +67,9 @@ class ServerPreferences(private val context: Context) {
                         // If server is >=0.26.0 and doesn't provide a value, default to true
                         // See https://github.com/stashapp/stash/pull/4710
                         putBoolean(PREF_TRACK_ACTIVITY, true)
+                    } else {
+                        // Server <0.26.0 default to false
+                        putBoolean(PREF_TRACK_ACTIVITY, false)
                     }
                 }
                 ui.getCaseInsensitive(PREF_MINIMUM_PLAY_PERCENT)?.let {


### PR DESCRIPTION
Fixes #299 

Tracking activity was changed to default to `true` in https://github.com/stashapp/stash/pull/4710, but this app would default it to `false` if the server didn't provide a value.

The server won't provide a value by default until the user explicitly changes the setting. This means, for example, a brand new install of server version `0.26.1` would have server-side tracking enabled but would not provide the value in the UI config query. So this app would read it as a `null` value and translate that to `false`.

This PR fixes this behavior so that if the server is at least `0.26.0` and no value is provided by the server, it will default to true.