### PR TITLE
Add support for mpeg-ts container format direct play

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/StashApplication.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashApplication.kt
@@ -15,6 +15,12 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.setup.SetupActivity
+import com.github.damontecres.stashapp.util.AppUpgradeHandler
+import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
+import com.github.damontecres.stashapp.util.Version
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class StashApplication : Application() {
     private var wasEnterBackground = false
@@ -46,6 +52,15 @@ class StashApplication : Application() {
                 putLong(VERSION_CODE_PREVIOUS_KEY, currentVersionCode)
                 putString(VERSION_NAME_CURRENT_KEY, pkgInfo.versionName)
                 putLong(VERSION_CODE_CURRENT_KEY, pkgInfo.versionCode.toLong())
+            }
+            if (currentVersion != null) {
+                CoroutineScope(Dispatchers.IO + StashCoroutineExceptionHandler()).launch {
+                    AppUpgradeHandler(
+                        this@StashApplication,
+                        Version.fromString(currentVersion),
+                        Version.fromString(pkgInfo.versionName),
+                    ).run()
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/AppUpgradeHandler.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/AppUpgradeHandler.kt
@@ -1,0 +1,44 @@
+package com.github.damontecres.stashapp.util
+
+import android.content.Context
+import android.util.Log
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import com.github.damontecres.stashapp.R
+
+class AppUpgradeHandler(
+    private val context: Context,
+    private val previousVersion: Version,
+    private val installedVersion: Version,
+) : Runnable {
+    companion object {
+        private const val TAG = "AppUpgradeHandler"
+    }
+
+    override fun run() {
+        // Add mpegts as a default force direct play format
+        if (previousVersion.isEqualOrBefore(Version.fromString("0.2.9")) &&
+            installedVersion.isAtLeast(Version.fromString("0.2.7"))
+        ) {
+            Log.d(TAG, "Checking for mpegts direct play")
+            val defaultFormats =
+                context.resources.getStringArray(R.array.default_force_container_formats).toSet()
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            val current =
+                prefs.getStringSet(
+                    context.getString(R.string.pref_key_default_forced_direct_containers),
+                    defaultFormats,
+                )!!
+            if (!current.contains("mpegts")) {
+                prefs.edit {
+                    val newSet = current.toMutableSet()
+                    newSet.add("mpegts")
+                    putStringSet(
+                        context.getString(R.string.pref_key_default_forced_direct_containers),
+                        newSet,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Version.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Version.kt
@@ -45,6 +45,10 @@ data class Version(
         return false
     }
 
+    fun isEqualOrBefore(version: Version): Boolean {
+        return !isGreaterThan(version)
+    }
+
     private fun compareNumCommits(version: Version): Int {
         return (this.numCommits ?: 0) - (version.numCommits ?: 0)
     }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -116,6 +116,7 @@
         <item>mov</item>
         <item>mp4</item>
         <item>mpeg</item>
+        <item>mpegts</item>
         <item>mpegvideo</item>
         <item>rm</item>
         <item>webm</item>
@@ -128,6 +129,7 @@
         <item>mov</item>
         <item>mp4</item>
         <item>mpeg</item>
+        <item>mpegts</item>
         <item>webm</item>
     </string-array>
 

--- a/app/src/test/java/com/github/damontecres/stashapp/VersionCompareTests.kt
+++ b/app/src/test/java/com/github/damontecres/stashapp/VersionCompareTests.kt
@@ -49,4 +49,12 @@ class VersionCompareTests {
         Assert.assertTrue(V_0_1_1_4.isGreaterThan(V_0_1_0_6))
         Assert.assertTrue(V_0_1_1_4.isGreaterThan(V_0_1_0))
     }
+
+    @Test
+    fun testEqualOrBefore() {
+        Assert.assertTrue(V_0_2_0.isEqualOrBefore(V_0_2_0))
+        Assert.assertTrue(V_0_1_1.isEqualOrBefore(V_0_2_0))
+
+        Assert.assertFalse(V_0_2_0.isEqualOrBefore(V_0_1_1))
+    }
 }


### PR DESCRIPTION
Adds MPEG-TS container format to the list of formats. It is set as supported by default and upgrading the app will add it to the supported list.

Dev: Adds a new class `AppUpgradeHandler` which is run whenever the app is upgraded allowing for making changes when needed.