### PR TITLE
Add option to show changelog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -160,6 +160,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-process:2.7.0")
     implementation("com.otaliastudios:zoomlayout:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation("io.noties.markwon:core:4.6.2")
 
     testImplementation("androidx.test:core-ktx:1.5.0")
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -112,6 +112,10 @@
             android:name=".MarkerActivity"
             android:exported="false"
             android:theme="@style/NoTitleTheme" />
+        <activity
+            android:name=".UpdateChangelogActivity"
+            android:exported="false"
+            android:theme="@style/NoTitleTheme" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/github/damontecres/stashapp/UpdateAppFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/UpdateAppFragment.kt
@@ -1,5 +1,6 @@
 package com.github.damontecres.stashapp
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.content.res.AppCompatResources
@@ -7,19 +8,17 @@ import androidx.leanback.app.GuidedStepSupportFragment
 import androidx.leanback.widget.GuidanceStylist
 import androidx.leanback.widget.GuidedAction
 import androidx.lifecycle.lifecycleScope
+import com.github.damontecres.stashapp.UpdateChangelogActivity.Companion.INTENT_CHANGELOG
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.UpdateChecker
+import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import kotlinx.coroutines.launch
 
 class UpdateAppFragment(private val release: UpdateChecker.Release) : GuidedStepSupportFragment() {
     override fun onCreateGuidance(savedInstanceState: Bundle?): GuidanceStylist.Guidance {
         val installedVersion = UpdateChecker.getInstalledVersion(requireActivity())
         val description =
-            """
-            ${getString(R.string.stashapp_package_manager_installed_version)}: $installedVersion
-
-            Note: Upgrading in-app is experimental!
-            """.trimIndent()
+            "${getString(R.string.stashapp_package_manager_installed_version)}: $installedVersion"
         return GuidanceStylist.Guidance(
             "${release.version} available!",
             description,
@@ -41,6 +40,15 @@ class UpdateAppFragment(private val release: UpdateChecker.Release) : GuidedStep
                 .hasNext(false)
                 .build(),
         )
+        if (release.body.isNotNullOrBlank()) {
+            actions.add(
+                GuidedAction.Builder(requireContext())
+                    .id(1000L)
+                    .title("See changelog")
+                    .hasNext(false)
+                    .build(),
+            )
+        }
         actions.add(
             GuidedAction.Builder(requireContext())
                 .clickAction(GuidedAction.ACTION_ID_CANCEL)
@@ -53,11 +61,28 @@ class UpdateAppFragment(private val release: UpdateChecker.Release) : GuidedStep
         if (action.id == GuidedAction.ACTION_ID_YES) {
             viewLifecycleOwner.lifecycleScope.launch(
                 StashCoroutineExceptionHandler {
-                    Toast.makeText(requireContext(), "Update failed: ${it.message}", Toast.LENGTH_LONG)
+                    Toast.makeText(
+                        requireContext(),
+                        "Update failed: ${it.message}",
+                        Toast.LENGTH_LONG,
+                    )
                 },
             ) {
                 UpdateChecker.installRelease(requireActivity(), release)
             }
+        } else if (action.id == 1000L) {
+            val intent = Intent(requireContext(), UpdateChangelogActivity::class.java)
+            val changelog =
+                "# ${release.version}\n\n${release.body}"
+                    // Convert PR urls to number
+                    .replace(
+                        Regex("https://github.com/damontecres/StashAppAndroidTV/pull/(\\d+)"),
+                        "#$1",
+                    )
+                    // Remove the last line for full changelog since its just a link
+                    .replace(Regex("\\*\\*Full Changelog\\*\\*.*"), "")
+            intent.putExtra(INTENT_CHANGELOG, changelog)
+            startActivity(intent)
         } else {
             finishGuidedStepSupportFragments()
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/UpdateChangelogActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/UpdateChangelogActivity.kt
@@ -1,0 +1,39 @@
+package com.github.damontecres.stashapp
+
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import io.noties.markwon.Markwon
+
+class UpdateChangelogActivity : FragmentActivity() {
+    companion object {
+        const val INTENT_CHANGELOG = "changelog"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null) {
+            setContentView(R.layout.activity_main)
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.main_browse_fragment, UpdateChangelogFragment())
+                .commitNow()
+        }
+    }
+
+    class UpdateChangelogFragment : Fragment(R.layout.changelog) {
+        override fun onViewCreated(
+            view: View,
+            savedInstanceState: Bundle?,
+        ) {
+            super.onViewCreated(view, savedInstanceState)
+            if (savedInstanceState == null) {
+                val changelogText = requireActivity().intent.getStringExtra(INTENT_CHANGELOG)!!
+                val textView = view.findViewById<TextView>(R.id.changelog_text)
+                val markdown = Markwon.create(requireContext())
+                markdown.setMarkdown(textView, changelogText)
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/selected_rectangle.xml
+++ b/app/src/main/res/drawable/selected_rectangle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/selected_background"/>
+</shape>

--- a/app/src/main/res/layout/changelog.xml
+++ b/app/src/main/res/layout/changelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fadeScrollbars="false"
+    android:scrollbarThumbVertical="@drawable/selected_rectangle">
+    <TextView
+        android:id="@+id/changelog_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="20dp"
+        android:textSize="18sp"
+        />
+</ScrollView>


### PR DESCRIPTION
Adds a button to show the changelog for an update, if available.

This shows _only_ the changelog for for the _latest_ version, not all of the changes between the installed and latest versions.