### PR TITLE
Add parsing to get app update notes

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/UpdateAppFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/UpdateAppFragment.kt
@@ -12,15 +12,20 @@ import com.github.damontecres.stashapp.UpdateChangelogActivity.Companion.INTENT_
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.UpdateChecker
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
+import com.github.damontecres.stashapp.util.joinNotNullOrBlank
 import kotlinx.coroutines.launch
 
 class UpdateAppFragment(private val release: UpdateChecker.Release) : GuidedStepSupportFragment() {
     override fun onCreateGuidance(savedInstanceState: Bundle?): GuidanceStylist.Guidance {
         val installedVersion = UpdateChecker.getInstalledVersion(requireActivity())
         val description =
-            "${getString(R.string.stashapp_package_manager_installed_version)}: $installedVersion"
+            buildList {
+                add("${getString(R.string.stashapp_package_manager_installed_version)}: $installedVersion")
+                addAll(release.notes)
+            }.joinNotNullOrBlank("\n\n")
+
         return GuidanceStylist.Guidance(
-            "${release.version} available!",
+            "${getString(R.string.stashapp_package_manager_latest_version)}: ${release.version}",
             description,
             null,
             AppCompatResources.getDrawable(requireContext(), R.mipmap.stash_logo),

--- a/app/src/main/java/com/github/damontecres/stashapp/util/UpdateChecker.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/UpdateChecker.kt
@@ -39,6 +39,8 @@ class UpdateChecker {
 
         private const val TAG = "UpdateChecker"
 
+        private val NOTE_REGEX = Regex("<!-- app-note:(.+) -->")
+
         suspend fun checkForUpdate(
             activity: Activity,
             showNegativeToast: Boolean = false,
@@ -83,7 +85,15 @@ class UpdateChecker {
                                 assetName == ASSET_NAME || assetName == DEBUG_ASSET_NAME
                             }?.jsonObject?.get("browser_download_url")?.jsonPrimitive?.contentOrNull
                         if (version != null) {
-                            return@use Release(version, downloadUrl, publishedAt, body)
+                            val notes =
+                                if (body.isNotNullOrBlank()) {
+                                    NOTE_REGEX.findAll(body).map { m ->
+                                        m.groupValues[1]
+                                    }.toList()
+                                } else {
+                                    listOf()
+                                }
+                            return@use Release(version, downloadUrl, publishedAt, body, notes)
                         } else {
                             Log.w(TAG, "Update version parsing failed. name=$name")
                         }
@@ -197,5 +207,11 @@ class UpdateChecker {
         }
     }
 
-    data class Release(val version: Version, val downloadUrl: String?, val publishedAt: String?, val body: String?)
+    data class Release(
+        val version: Version,
+        val downloadUrl: String?,
+        val publishedAt: String?,
+        val body: String?,
+        val notes: List<String>,
+    )
 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -37,6 +37,13 @@
         <item name="background">@color/default_background</item>
         <item name="guidedActionsBackground">@color/popup_background</item>
         <item name="guidedActionsSelectorDrawable">@drawable/guided_actions_selector</item>
+        <item name="guidanceDescriptionStyle">
+            @style/Theme.StashAppAndroidTV.GuidedStep.Description
+        </item>
+    </style>
+
+    <style name="Theme.StashAppAndroidTV.GuidedStep.Description" parent="Widget.Leanback.GuidanceDescriptionStyle">
+        <item name="android:maxLines">12</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Adds the ability to parse out "app notes" from a GitHub release body. This allows the app to show important information about an app update such as breaking changes.

They are encoded as comments, one per line: `<!-- app-note:This is the app note -->` in the body message of a GitHub release.