### PR TITLE
Use optional crops to prevent exception when loading animated images

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/GalleryActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/GalleryActivity.kt
@@ -186,7 +186,7 @@ class GalleryActivity : FragmentActivity() {
             if (gallery.studio?.image_path.isNotNullOrBlank()) {
                 StashGlide.with(requireContext(), gallery.studio!!.image_path!!)
                     .override(gallerySidebar.width, Target.SIZE_ORIGINAL)
-                    .fitCenter()
+                    .optionalFitCenter()
                     .error(StashPresenter.glideError(requireContext()))
                     .into(studioImage)
             } else {

--- a/app/src/main/java/com/github/damontecres/stashapp/MarkerActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MarkerActivity.kt
@@ -231,7 +231,7 @@ class MarkerActivity : FragmentActivity() {
                         ScenePresenter.CARD_HEIGHT,
                     )
                 StashGlide.with(requireActivity(), screenshotUrl)
-                    .centerCrop()
+                    .optionalCenterCrop()
                     .error(StashPresenter.glideError(requireContext()))
                     .into<CustomTarget<Drawable>>(
                         object : CustomTarget<Drawable>(width, height) {
@@ -266,7 +266,7 @@ class MarkerActivity : FragmentActivity() {
 
                 if (screenshotUrl.isNotNullOrBlank()) {
                     StashGlide.withBitmap(requireActivity(), screenshotUrl)
-                        .centerCrop()
+                        .optionalCenterCrop()
                         .error(R.drawable.baseline_camera_indoor_48)
                         .into<CustomTarget<Bitmap>>(
                             object : CustomTarget<Bitmap>() {

--- a/app/src/main/java/com/github/damontecres/stashapp/MovieFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MovieFragment.kt
@@ -44,14 +44,14 @@ class MovieFragment : Fragment(R.layout.movie_view) {
             if (movie.frontImagePath != null) {
                 configureLayout(frontImage)
                 StashGlide.with(requireActivity(), movie.frontImagePath)
-                    .centerCrop()
+                    .optionalCenterCrop()
                     .error(StashPresenter.glideError(requireContext()))
                     .into(frontImage)
             }
             if (movie.backImagePath != null) {
                 configureLayout(backImage)
                 StashGlide.with(requireActivity(), movie.backImagePath)
-                    .centerCrop()
+                    .optionalCenterCrop()
                     .error(StashPresenter.glideError(requireContext()))
                     .into(backImage)
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
@@ -135,7 +135,7 @@ class PerformerFragment : Fragment(R.layout.performer_view) {
         }
         if (perf.image_path != null) {
             StashGlide.with(requireContext(), perf.image_path)
-                .centerCrop()
+                .optionalCenterCrop()
                 .error(StashPresenter.glideError(requireContext()))
                 .into(mPerformerImage)
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/VideoDetailsFragment.kt
@@ -355,7 +355,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
 
             if (screenshotUrl.isNotNullOrBlank()) {
                 StashGlide.withBitmap(requireActivity(), screenshotUrl)
-                    .centerCrop()
+                    .optionalCenterCrop()
                     .error(R.drawable.baseline_camera_indoor_48)
                     .into<CustomTarget<Bitmap>>(
                         object : CustomTarget<Bitmap>() {
@@ -385,7 +385,7 @@ class VideoDetailsFragment : DetailsSupportFragment() {
             val width = convertDpToPixel(requireActivity(), DETAIL_THUMB_WIDTH)
             val height = convertDpToPixel(requireActivity(), DETAIL_THUMB_HEIGHT)
             StashGlide.with(requireActivity(), screenshotUrl)
-                .centerCrop()
+                .optionalCenterCrop()
                 .error(StashPresenter.glideError(requireContext()))
                 .into<CustomTarget<Drawable>>(
                     object : CustomTarget<Drawable>(width, height) {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/GalleryPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/GalleryPresenter.kt
@@ -1,9 +1,7 @@
 package com.github.damontecres.stashapp.presenters
 
-import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.github.damontecres.stashapp.api.fragment.GalleryData
 import com.github.damontecres.stashapp.data.DataType
-import com.github.damontecres.stashapp.util.StashGlide
 import com.github.damontecres.stashapp.util.concatIfNotBlank
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.util.name
@@ -31,11 +29,8 @@ class GalleryPresenter(callback: LongClickCallBack<GalleryData>? = null) : Stash
 
         cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
         val coverPaths = item.cover?.paths
-        if (coverPaths?.thumbnail.isNotNullOrBlank()) {
-            StashGlide.with(cardView.context, coverPaths!!.thumbnail!!)
-                .transform(CenterCrop())
-                .error(glideError(cardView.context))
-                .into(cardView.mainImageView!!)
+        if (coverPaths != null && coverPaths.thumbnail.isNotNullOrBlank()) {
+            loadImage(cardView, coverPaths.thumbnail)
         }
         if (coverPaths?.preview.isNotNullOrBlank()) {
             cardView.videoUrl = coverPaths?.preview

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ImagePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ImagePresenter.kt
@@ -1,9 +1,7 @@
 package com.github.damontecres.stashapp.presenters
 
-import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.data.DataType
-import com.github.damontecres.stashapp.util.StashGlide
 import com.github.damontecres.stashapp.util.concatIfNotBlank
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import java.util.EnumMap
@@ -29,10 +27,9 @@ class ImagePresenter(callback: LongClickCallBack<ImageData>? = null) : StashPres
 
         cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
         if (item.paths.thumbnail.isNotNullOrBlank()) {
-            StashGlide.with(cardView.context, item.paths.thumbnail)
-                .transform(CenterCrop())
-                .error(glideError(cardView.context))
-                .into(cardView.mainImageView!!)
+            loadImage(cardView, item.paths.thumbnail)
+        } else if (item.paths.image.isNotNullOrBlank()) {
+            loadImage(cardView, item.paths.image)
         }
         if (item.paths.preview.isNotNullOrBlank()) {
             cardView.videoUrl = item.paths.preview

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
@@ -10,7 +10,6 @@ import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.util.ServerPreferences
-import com.github.damontecres.stashapp.util.StashGlide
 import com.github.damontecres.stashapp.util.concatIfNotBlank
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.util.resolutionName
@@ -73,11 +72,7 @@ class ScenePresenter(callback: LongClickCallBack<SlimSceneData>? = null) :
         }
 
         if (!item.paths.screenshot.isNullOrBlank()) {
-            StashGlide.with(cardView.context, item.paths.screenshot)
-                .centerCrop()
-                // .transform(CenterCrop(), TextOverlay(cardView.context, item))
-                .error(glideError(cardView.context))
-                .into(cardView.mainImageView!!)
+            loadImage(cardView, item.paths.screenshot)
         }
         if (item.paths.preview.isNotNullOrBlank()) {
             cardView.videoUrl = item.paths.preview

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -76,7 +76,6 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
         url: String,
     ) {
         StashGlide.with(cardView.context, url)
-            .fitCenter()
             .error(glideError(cardView.context))
             .into(cardView.mainImageView!!)
     }


### PR DESCRIPTION
Closes #321 

Forcing a transform on animated images causes an exception such as `IllegalArgumentException: Unable to convert android.graphics.drawable.AnimatedImageDrawable to a Bitmap`.

This PR update the crop calls to be optional and let the `ImageView` crop instead. The PR also refactors a few image loading calls for consistency.