### PR TITLE
Add favorite indicator for tags & studios

### DIFF
--- a/app/src/main/graphql/FindStudios.graphql
+++ b/app/src/main/graphql/FindStudios.graphql
@@ -51,5 +51,6 @@ fragment StudioData on Studio {
   details
   rating100
   aliases
+  favorite
   __typename
 }

--- a/app/src/main/graphql/Fragments.graphql
+++ b/app/src/main/graphql/Fragments.graphql
@@ -2,6 +2,7 @@ fragment SlimTagData on Tag {
   id
   name
   description
+  favorite
   image_path
 }
 
@@ -9,6 +10,7 @@ fragment TagData on Tag {
   id
   name
   description
+  favorite
   aliases
   scene_count
   performer_count

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StudioPresenter.kt
@@ -37,6 +37,10 @@ class StudioPresenter(callback: LongClickCallBack<StudioData>? = null) :
         }
 
         cardView.setRating100(item.rating100)
+
+        if (item.favorite) {
+            cardView.setIsFavorite()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
@@ -49,6 +49,10 @@ class TagPresenter(callback: LongClickCallBack<TagData>? = null) :
         if (item.image_path != null) {
             loadImage(cardView, item.image_path)
         }
+
+        if (item.favorite) {
+            cardView.setIsFavorite()
+        }
     }
 
     override fun getDefaultLongClickCallBack(cardView: StashImageCardView): LongClickCallBack<TagData> {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -430,7 +430,7 @@ val FullSceneData.asSlimeSceneData: SlimSceneData
         )
 
 val TagData.asSlimTagData: SlimTagData
-    get() = SlimTagData(id, name, description, image_path)
+    get() = SlimTagData(id, name, description, favorite, image_path)
 
 val PerformerData.ageInYears: Int?
     @RequiresApi(Build.VERSION_CODES.O)


### PR DESCRIPTION
Adds the heart indicator to the overlay for favorite tag and studio cards.

Requires server `v0.26.0`

Ref:
- https://github.com/stashapp/stash/pull/4675
- https://github.com/stashapp/stash/pull/4728