### PR TITLE
Add support for image clips

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ImageClipFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ImageClipFragment.kt
@@ -1,0 +1,84 @@
+package com.github.damontecres.stashapp
+
+import android.os.Bundle
+import android.view.View
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.preference.PreferenceManager
+import com.github.damontecres.stashapp.api.fragment.ImageData
+import com.github.damontecres.stashapp.playback.CodecSupport
+import com.github.damontecres.stashapp.playback.PlaybackFragment
+
+@OptIn(UnstableApi::class)
+class ImageClipFragment(private val imageData: ImageData) : PlaybackFragment(), ImageActivity.StashImageFragment {
+    override val previewsEnabled: Boolean
+        get() = false
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val videoFile = imageData.visual_files.firstOrNull()?.onVideoFile
+
+        val supportedCodecs = CodecSupport.getSupportedCodecs(requireContext())
+        val videoCodec = videoFile?.video_codec
+        val audioCodec = videoFile?.audio_codec
+        val videoSupported = supportedCodecs.isVideoSupported(videoCodec)
+        val audioSupported = supportedCodecs.isAudioSupported(audioCodec)
+        val formatSupported = supportedCodecs.isContainerFormatSupported(videoFile?.format)
+
+        debugPlaybackTextView.text = "Force direct"
+        debugVideoTextView.text = if (videoSupported) videoCodec else "$videoCodec (unsupported)"
+        debugAudioTextView.text = if (audioSupported) audioCodec else "$audioCodec (unsupported)"
+        debugContainerTextView.text = if (formatSupported) videoFile?.format else "${videoFile?.format} (unsupported)"
+
+        titleText.text = imageData.title
+        dateText.text = imageData.date
+
+//        val previousButton = exoCenterControls.findViewById<ImageButton>(androidx.media3.ui.R.id.exo_prev)
+//        val nextButton = exoCenterControls.findViewById<ImageButton>(androidx.media3.ui.R.id.exo_next)
+        moreOptionsButton.visibility = View.GONE
+
+        viewCreated = true
+    }
+
+    override fun initializePlayer(): ExoPlayer {
+        val skipForward =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getInt("skip_forward_time", 30)
+        val skipBack =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getInt("skip_back_time", 10)
+        // TODO maybe refactor so the player is tied to the context's (Activity) lifecycle, not the fragment's?
+        return StashExoPlayer.createInstance(requireContext(), skipForward * 1000L, skipBack * 1000L)
+            .also { exoPlayer ->
+                exoPlayer.repeatMode = Player.REPEAT_MODE_ONE
+                val mediaItem =
+                    MediaItem.Builder()
+                        .setUri(imageData.paths.image)
+                        .build()
+                exoPlayer.setMediaItem(mediaItem)
+                exoPlayer.prepare()
+                exoPlayer.play()
+            }
+    }
+
+    override var viewCreated: Boolean = false
+
+    override fun isOverlayVisible(): Boolean = isControllerVisible
+
+    override fun hideOverlay() {
+        hideControlsIfVisible()
+    }
+
+    override fun isImageZoomedIn(): Boolean = false
+
+    override fun resetImageZoom() {
+        // no-op
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/StashExoPlayer.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashExoPlayer.kt
@@ -38,24 +38,35 @@ class StashExoPlayer private constructor() {
             if (instance == null) {
                 synchronized(this) { // synchronized to avoid concurrency problem
                     if (instance == null) {
-                        val dataSourceFactory =
-                            OkHttpDataSource.Factory(StashClient.getStreamHttpClient(context))
-                                .setCacheControl(CacheControl.FORCE_NETWORK)
-
-                        instance =
-                            ExoPlayer.Builder(context)
-                                .setMediaSourceFactory(
-                                    DefaultMediaSourceFactory(context).setDataSourceFactory(
-                                        dataSourceFactory,
-                                    ),
-                                )
-                                .setSeekBackIncrementMs(skipBack)
-                                .setSeekForwardIncrementMs(skipForward)
-                                .build()
+                        instance = createInstance(context, skipForward, skipBack)
                     }
                 }
             }
             return instance!!
+        }
+
+        /**
+         * Create a new [ExoPlayer] instance. [getInstance] should be preferred where possible.
+         */
+        @UnstableApi
+        fun createInstance(
+            context: Context,
+            skipForward: Long,
+            skipBack: Long,
+        ): ExoPlayer {
+            val dataSourceFactory =
+                OkHttpDataSource.Factory(StashClient.getStreamHttpClient(context))
+                    .setCacheControl(CacheControl.FORCE_NETWORK)
+
+            return ExoPlayer.Builder(context)
+                .setMediaSourceFactory(
+                    DefaultMediaSourceFactory(context).setDataSourceFactory(
+                        dataSourceFactory,
+                    ),
+                )
+                .setSeekBackIncrementMs(skipBack)
+                .setSeekForwardIncrementMs(skipForward)
+                .build()
         }
 
         fun releasePlayer() {

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
@@ -11,6 +11,7 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.annotation.LayoutRes
 import androidx.annotation.OptIn
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -44,7 +45,10 @@ import java.time.format.DateTimeParseException
  * Parent [Fragment] for playing videos
  */
 @UnstableApi
-abstract class PlaybackFragment : Fragment(R.layout.video_playback) {
+abstract class PlaybackFragment(
+    @LayoutRes layoutId: Int = R.layout.video_playback,
+) :
+    Fragment(layoutId) {
     /**
      * Whether to show video previews when scrubbing
      */

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ImagePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ImagePresenter.kt
@@ -3,6 +3,7 @@ package com.github.damontecres.stashapp.presenters
 import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.util.concatIfNotBlank
+import com.github.damontecres.stashapp.util.isImageClip
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import java.util.EnumMap
 
@@ -28,7 +29,7 @@ class ImagePresenter(callback: LongClickCallBack<ImageData>? = null) : StashPres
         cardView.setMainImageDimensions(CARD_WIDTH, CARD_HEIGHT)
         if (item.paths.thumbnail.isNotNullOrBlank()) {
             loadImage(cardView, item.paths.thumbnail)
-        } else if (item.paths.image.isNotNullOrBlank()) {
+        } else if (item.paths.image.isNotNullOrBlank() && !item.isImageClip) {
             loadImage(cardView, item.paths.image)
         }
         if (item.paths.preview.isNotNullOrBlank()) {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -689,3 +689,6 @@ fun VideoFileData.resolutionName(): CharSequence {
 fun getRandomSort(): String {
     return "random_" + Random.nextInt(1e8.toInt()).toString()
 }
+
+val ImageData.isImageClip: Boolean
+    get() = visual_files.firstOrNull()?.onVideoFile != null


### PR DESCRIPTION
Closes #331

Adds support for video files added as image clips. You can scroll through images/clips as before with left/right (unless the overlay is showing). The overlay for image clips is basically the scene playback controls.

There's no ability to rate an image clip since they use a different overlay. This will have to be a follow up I think.

This was pretty straightforward thanks to the refactoring in #327. Also, this is affected by #328.