### PR TITLE
Fixes zoom aspect ratio for images (except for gifs)

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ImageActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ImageActivity.kt
@@ -50,6 +50,7 @@ import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashGlide
 import com.github.damontecres.stashapp.util.concatIfNotBlank
 import com.github.damontecres.stashapp.util.height
+import com.github.damontecres.stashapp.util.isGif
 import com.github.damontecres.stashapp.util.isImageClip
 import com.github.damontecres.stashapp.util.maxFileSize
 import com.github.damontecres.stashapp.util.showSetRatingToast
@@ -446,25 +447,28 @@ class ImageActivity : FragmentActivity() {
         }
 
         private fun loadImage() {
-            mainImage.post {
-                // Properly scale the image after layout
-                val imageFile = image!!.visual_files.first()
-                val width = imageFile.width!!
-                val height = imageFile.height!!
+            if (image.isGif) {
+                Log.v(TAG, "Image ${image.id} is a gif")
+                mainImage.post {
+                    // Properly scale the image after layout
+                    val imageFile = image.visual_files.first()
+                    val width = imageFile.width!!
+                    val height = imageFile.height!!
 
-                val scale =
-                    Math.min(
-                        mainImage.height.toDouble() / height,
-                        mainImage.width.toDouble() / width,
-                    )
+                    val scale =
+                        Math.min(
+                            mainImage.height.toDouble() / height,
+                            mainImage.width.toDouble() / width,
+                        )
 
-                val targetHeight = height * scale
-                val targetWidth = width * scale
+                    val targetHeight = height * scale
+                    val targetWidth = width * scale
 
-                val lp = mainImage.layoutParams
-                lp.width = targetWidth.toInt()
-                lp.height = targetHeight.toInt()
-                mainImage.layoutParams = lp
+                    val lp = mainImage.layoutParams
+                    lp.width = targetWidth.toInt()
+                    lp.height = targetHeight.toInt()
+                    mainImage.layoutParams = lp
+                }
             }
 
             val placeholder =

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -691,4 +691,11 @@ fun getRandomSort(): String {
 }
 
 val ImageData.isImageClip: Boolean
-    get() = visual_files.firstOrNull()?.onVideoFile != null
+    get() =
+        visual_files.firstOrNull()?.onVideoFile != null &&
+            visual_files.firstOrNull()?.onVideoFile!!.format != "gif"
+
+val ImageData.isGif: Boolean
+    get() =
+        visual_files.firstOrNull()?.onVideoFile != null &&
+            visual_files.firstOrNull()?.onVideoFile!!.format == "gif"


### PR DESCRIPTION
Fixes #332 except for gifs

Zooming in on images will scale in both directions now instead of maintaining the aspect ratio. Gifs still zoom within the aspect ratio unfortunately. I haven't figured out a fix for them yet.

Also fixes a bug from #333 where gifs were treated as image clips.