### PR TITLE
Create new tags or performers from search

### DIFF
--- a/app/src/main/graphql/FindPerformers.graphql
+++ b/app/src/main/graphql/FindPerformers.graphql
@@ -43,6 +43,12 @@ mutation UpdatePerformer($input: PerformerUpdateInput!) {
   }
 }
 
+mutation CreatePerformer($input: PerformerCreateInput!){
+  performerCreate(input: $input){
+    ...PerformerData
+  }
+}
+
 fragment PerformerData on Performer {
   id
   name

--- a/app/src/main/graphql/FindTags.graphql
+++ b/app/src/main/graphql/FindTags.graphql
@@ -12,3 +12,9 @@ query CountTags($filter: FindFilterType, $tag_filter: TagFilterType)  {
     count
   }
 }
+
+mutation CreateTag($input: TagCreateInput!) {
+  tagCreate(input: $input) {
+    ...TagData
+  }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/actions/StashAction.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/actions/StashAction.kt
@@ -6,6 +6,7 @@ enum class StashAction(val id: Long, val actionName: String) {
     FORCE_TRANSCODE(3L, "Play with Transcoding"),
     CREATE_MARKER(4L, "Create Marker"),
     FORCE_DIRECT_PLAY(5L, "Play directly"),
+    CREATE_NEW(6L, "Create new"),
     ;
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
@@ -10,6 +10,8 @@ import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.github.damontecres.stashapp.api.CreateMarkerMutation
+import com.github.damontecres.stashapp.api.CreatePerformerMutation
+import com.github.damontecres.stashapp.api.CreateTagMutation
 import com.github.damontecres.stashapp.api.DeleteMarkerMutation
 import com.github.damontecres.stashapp.api.ImageDecrementOMutation
 import com.github.damontecres.stashapp.api.ImageIncrementOMutation
@@ -27,13 +29,16 @@ import com.github.damontecres.stashapp.api.UpdateMarkerMutation
 import com.github.damontecres.stashapp.api.UpdatePerformerMutation
 import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
+import com.github.damontecres.stashapp.api.fragment.TagData
 import com.github.damontecres.stashapp.api.type.GenerateMetadataInput
 import com.github.damontecres.stashapp.api.type.ImageUpdateInput
+import com.github.damontecres.stashapp.api.type.PerformerCreateInput
 import com.github.damontecres.stashapp.api.type.PerformerUpdateInput
 import com.github.damontecres.stashapp.api.type.ScanMetadataInput
 import com.github.damontecres.stashapp.api.type.SceneMarkerCreateInput
 import com.github.damontecres.stashapp.api.type.SceneMarkerUpdateInput
 import com.github.damontecres.stashapp.api.type.SceneUpdateInput
+import com.github.damontecres.stashapp.api.type.TagCreateInput
 import com.github.damontecres.stashapp.data.OCounter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -374,6 +379,18 @@ class MutationEngine(
         val mutation = UpdatePerformerMutation(input)
         val result = executeMutation(mutation)
         return result.data?.performerUpdate?.performerData
+    }
+
+    suspend fun createTag(input: TagCreateInput): TagData? {
+        val mutation = CreateTagMutation(input)
+        val result = executeMutation(mutation)
+        return result.data?.tagCreate?.tagData
+    }
+
+    suspend fun createPerformer(input: PerformerCreateInput): PerformerData? {
+        val mutation = CreatePerformerMutation(input)
+        val result = executeMutation(mutation)
+        return result.data?.performerCreate?.performerData
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/SingleItemObjectAdapter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/SingleItemObjectAdapter.kt
@@ -4,6 +4,10 @@ import androidx.leanback.widget.ObjectAdapter
 import com.github.damontecres.stashapp.presenters.StashPresenter
 
 class SingleItemObjectAdapter<T : Any>(presenter: StashPresenter<T>) : ObjectAdapter(presenter) {
+    constructor(presenter: StashPresenter<T>, item: T) : this(presenter) {
+        this.item = item
+    }
+
     var item: T? = null
         set(newValue) {
             field = newValue


### PR DESCRIPTION
When adding a tag or performers to a scene, adds the option to create a tag or performer named from the current search query 

In other words, if searching for "new tag" which does not exist, an option to create a new tag called "New Tag" is available.