### PR TITLE
Add ability to install the companion plugin directly in the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Check the [Tips & Tricks](https://github.com/damontecres/StashAppAndroidTV/wiki/
 1. [Configure the app](#configuration)
 1. Optionally, install the [StashAppAndroidTV Companion](https://github.com/damontecres/StashAppAndroidTV-Companion) plugin on your server to enable additional features
     - Search for `StashAppAndroidTV Companion` on your server's Settings->Plugins page
+    - Alternatively, trigger an install from the Android TV app in `Settings->Advanced->Install companion plugin`
 
 ### Upgrading the app
 

--- a/app/src/main/graphql/Configuration.graphql
+++ b/app/src/main/graphql/Configuration.graphql
@@ -56,3 +56,18 @@ mutation MetadataScan($input: ScanMetadataInput!){
 mutation MetadataGenerate($input: GenerateMetadataInput!){
   metadataGenerate(input: $input)
 }
+
+mutation InstallPackages($type: PackageType!, $packages: [PackageSpecInput!]!) {
+  installPackages(type: $type, packages: $packages)
+}
+
+query FindJob($input: FindJobInput!) {
+  findJob(input: $input) {
+    id
+    status
+    progress
+    startTime
+    endTime
+    error
+  }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/data/JobResult.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/JobResult.kt
@@ -1,0 +1,9 @@
+package com.github.damontecres.stashapp.data
+
+sealed class JobResult {
+    data object NotFound : JobResult()
+
+    data class Failure(val message: String?) : JobResult()
+
+    data object Success : JobResult()
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
@@ -16,6 +16,7 @@ import com.github.damontecres.stashapp.api.DeleteMarkerMutation
 import com.github.damontecres.stashapp.api.ImageDecrementOMutation
 import com.github.damontecres.stashapp.api.ImageIncrementOMutation
 import com.github.damontecres.stashapp.api.ImageResetOMutation
+import com.github.damontecres.stashapp.api.InstallPackagesMutation
 import com.github.damontecres.stashapp.api.MetadataGenerateMutation
 import com.github.damontecres.stashapp.api.MetadataScanMutation
 import com.github.damontecres.stashapp.api.SceneAddOMutation
@@ -32,6 +33,8 @@ import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.TagData
 import com.github.damontecres.stashapp.api.type.GenerateMetadataInput
 import com.github.damontecres.stashapp.api.type.ImageUpdateInput
+import com.github.damontecres.stashapp.api.type.PackageSpecInput
+import com.github.damontecres.stashapp.api.type.PackageType
 import com.github.damontecres.stashapp.api.type.PerformerCreateInput
 import com.github.damontecres.stashapp.api.type.PerformerUpdateInput
 import com.github.damontecres.stashapp.api.type.ScanMetadataInput
@@ -408,6 +411,15 @@ class MutationEngine(
         val mutation = CreatePerformerMutation(input)
         val result = executeMutation(mutation)
         return result.data?.performerCreate?.performerData
+    }
+
+    suspend fun installPackage(
+        type: PackageType,
+        input: PackageSpecInput,
+    ): String {
+        val mutation = InstallPackagesMutation(type, listOf(input))
+        val result = executeMutation(mutation)
+        return result.data!!.installPackages
     }
 
     companion object {


### PR DESCRIPTION
Add ability to trigger the installation of the companion plugin from the app itself.

Also, sending logs is no longer fire-and-forget, but will now wait for confirmation. Sending the crash report is still fire-and-forget because it has to be quick.