### PR TITLE
Don't stretch gifs

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -684,6 +684,8 @@ val ImageData.isImageClip: Boolean
             visual_files.firstOrNull()?.onVideoFile!!.format != "gif"
 
 val ImageData.isGif: Boolean
-    get() =
-        visual_files.firstOrNull()?.onVideoFile != null &&
-            visual_files.firstOrNull()?.onVideoFile!!.format == "gif"
+    get() {
+        val file = visual_files.firstOrNull()
+        return (file?.onVideoFile != null && file.onVideoFile.format == "gif") ||
+            file?.onBaseFile?.path?.endsWith(".gif", true) == true
+    }


### PR DESCRIPTION
#334 didn't recognize all gifs as gifs and so some were still stretched. The zoom issue is still present though.

Related to #332 & https://github.com/stashapp/stash/issues/5111