### PR TITLE
Manage servers from main page icon

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -85,22 +85,10 @@ class MainFragment : BrowseSupportFragment() {
         setupEventListeners()
 
         adapter = rowsAdapter
-
-        lifecycleScope.launch(StashCoroutineExceptionHandler()) {
-            val result =
-                testStashConnection(
-                    requireContext(),
-                    false,
-                    StashClient.getApolloClient(requireContext()),
-                )
-            if (result.status == TestResultStatus.SUCCESS) {
-                val serverInfo = result.serverInfo!!
-                ServerPreferences(requireContext()).updatePreferences()
-                val mainTitleView =
-                    requireActivity().findViewById<MainTitleView>(R.id.browse_title_group)
-                mainTitleView.refreshMenuItems()
-                if (rowsAdapter.size() == 0) {
-                    fetchData(serverInfo)
+        if (savedInstanceState == null) {
+            requireActivity().supportFragmentManager.addOnBackStackChangedListener {
+                if (requireActivity().supportFragmentManager.backStackEntryCount == 0) {
+                    doOnResume()
                 }
             }
         }
@@ -122,11 +110,17 @@ class MainFragment : BrowseSupportFragment() {
                     null
                 }
             }
+        if (savedInstanceState == null) {
+            doOnResume()
+        }
     }
 
     override fun onResume() {
         super.onResume()
+        doOnResume()
+    }
 
+    private fun doOnResume() {
         val newServerHash = computeServerHash()
         if (serverHash != newServerHash) {
             Log.v(TAG, "server hash changed")

--- a/app/src/main/java/com/github/damontecres/stashapp/views/MainTitleView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/MainTitleView.kt
@@ -9,12 +9,16 @@ import android.widget.Button
 import android.widget.ImageButton
 import android.widget.RelativeLayout
 import androidx.core.content.ContextCompat.startActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.findFragment
+import androidx.leanback.app.GuidedStepSupportFragment
 import androidx.leanback.widget.TitleViewAdapter
 import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.FilterListActivity
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.SettingsActivity
 import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.setup.ManageServersFragment
 import com.github.damontecres.stashapp.util.ServerPreferences
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 
@@ -24,6 +28,7 @@ class MainTitleView(context: Context, attrs: AttributeSet) :
     private var mPreferencesView: ImageButton
     private lateinit var searchButton: ImageButton
 
+    private val iconButtom: ImageButton
     private val scenesButton: Button
     private val performersButton: Button
     private val studiosButton: Button
@@ -42,6 +47,13 @@ class MainTitleView(context: Context, attrs: AttributeSet) :
 
     init {
         val root = LayoutInflater.from(context).inflate(R.layout.title, this)
+        iconButtom = root.findViewById(R.id.icon)
+        iconButtom.setOnClickListener {
+            GuidedStepSupportFragment.add(
+                findFragment<Fragment>().parentFragmentManager,
+                ManageServersFragment(),
+            )
+        }
         searchButton = root.findViewById(R.id.search_button)
         mPreferencesView = root.findViewById(R.id.settings_button)
         mPreferencesView.setOnClickListener {

--- a/app/src/main/res/drawable/icon_button_selector.xml
+++ b/app/src/main/res/drawable/icon_button_selector.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <layer-list>
+            <item>
+                <ripple android:color="@color/selected_background">
+                    <item>
+                        <shape android:shape="oval">
+                            <solid android:color="@color/selected_background"/>
+                        </shape>
+                    </item>
+                </ripple>
+            </item>
+            <item android:drawable="@mipmap/stash_logo"/>
+        </layer-list>
+    </item>
+    <item android:state_focused="true">
+        <layer-list>
+            <item>
+                <shape android:shape="oval">
+                    <solid android:color="@color/selected_background"/>
+                </shape>
+            </item>
+            <item android:drawable="@mipmap/stash_logo"/>
+        </layer-list>
+    </item>
+    <item android:drawable="@mipmap/stash_logo"/>
+</selector>

--- a/app/src/main/res/layout/title.xml
+++ b/app/src/main/res/layout/title.xml
@@ -6,12 +6,12 @@
     android:layout_height="@dimen/title_bar_height"
     android:layout_margin="0dp">
 
-    <ImageView
+    <ImageButton
         android:id="@+id/icon"
         android:layout_width="@dimen/title_bar_icon_size"
         android:layout_height="@dimen/title_bar_icon_size"
         android:layout_margin="@dimen/title_bar_margin"
-        android:src="@mipmap/stash_logo"
+        android:background="@drawable/icon_button_selector"
         android:contentDescription="@string/stashapp_image"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
Changes the logo icon on the main page to be a button that goes to the manage servers page.

This saves a bunch of clicks when trying to change servers.