### PR TITLE
Use ViewModel for current server

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -36,7 +36,7 @@ import com.github.damontecres.stashapp.views.ClassOnItemViewClickedListener
 import com.github.damontecres.stashapp.views.MainTitleView
 import com.github.damontecres.stashapp.views.OnImageFilterClickedListener
 import com.github.damontecres.stashapp.views.StashItemViewClickListener
-import com.github.damontecres.stashapp.views.models.GlobalViewModel
+import com.github.damontecres.stashapp.views.models.ServerViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -46,7 +46,7 @@ import kotlinx.coroutines.withContext
  * Loads a grid of cards with movies to browse.
  */
 class MainFragment : BrowseSupportFragment() {
-    private val viewModel: GlobalViewModel by activityViewModels()
+    private val viewModel: ServerViewModel by activityViewModels()
 
     private val rowsAdapter = SparseArrayObjectAdapter(ListRowPresenter())
     private val adapters = ArrayList<ArrayObjectAdapter>()

--- a/app/src/main/java/com/github/damontecres/stashapp/setup/ManageServersFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/setup/ManageServersFragment.kt
@@ -10,10 +10,10 @@ import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.SettingsFragment
 import com.github.damontecres.stashapp.util.StashServer
-import com.github.damontecres.stashapp.views.models.GlobalViewModel
+import com.github.damontecres.stashapp.views.models.ServerViewModel
 
 class ManageServersFragment : GuidedStepSupportFragment() {
-    private val viewModel: GlobalViewModel by activityViewModels()
+    private val viewModel: ServerViewModel by activityViewModels()
 
     private var currentServer: StashServer? = null
     private lateinit var allServers: List<StashServer>

--- a/app/src/main/java/com/github/damontecres/stashapp/views/models/ServerViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/models/ServerViewModel.kt
@@ -10,7 +10,7 @@ import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.getInt
 import java.util.Objects
 
-class GlobalViewModel : ViewModel() {
+class ServerViewModel : ViewModel() {
     private val _currentServer = MutableLiveData<StashServer?>(StashServer.getCurrentStashServer(StashApplication.getApplication()))
     val currentServer: LiveData<StashServer?> = _currentServer
 


### PR DESCRIPTION
Update the main page and settings to use a ViewModel to store the current server which allows for observing changes and reacting more reliably.