### PR TITLE
Fixes main page reloading on every resume

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -67,8 +67,6 @@ class MainFragment : BrowseSupportFragment() {
         setupEventListeners()
 
         adapter = rowsAdapter
-
-        viewModel.recomputeSettingsHash()
     }
 
     override fun onViewCreated(
@@ -109,6 +107,7 @@ class MainFragment : BrowseSupportFragment() {
                     )
                 },
             ) {
+                Log.d(TAG, "Settings hash changed: $it")
                 if (!firstTime) {
                     clearData()
                     rowsAdapter.clear()

--- a/app/src/main/java/com/github/damontecres/stashapp/views/models/EqualityMutableLiveData.java
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/models/EqualityMutableLiveData.java
@@ -1,0 +1,35 @@
+package com.github.damontecres.stashapp.views.models;
+
+import androidx.lifecycle.MutableLiveData;
+
+import java.util.Objects;
+
+/**
+ * A MutableLiveData that only notifies observers if the value does not equal the previous value
+ * @param <T>
+ */
+public class EqualityMutableLiveData<T> extends MutableLiveData<T> {
+
+    // Using Java since MutableLiveData is written in Java and it is easier to support the overrides
+    public EqualityMutableLiveData(){
+        super();
+    }
+
+    public EqualityMutableLiveData(T value){
+        super(value);
+    }
+
+    @Override
+    public void setValue(T value) {
+        if(!Objects.equals(value, getValue())) {
+            super.setValue(value);
+        }
+    }
+
+    @Override
+    public void postValue(T value) {
+        if(!Objects.equals(value, getValue())) {
+            super.postValue(value);
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/views/models/ServerViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/models/ServerViewModel.kt
@@ -14,7 +14,7 @@ class ServerViewModel : ViewModel() {
     private val _currentServer = MutableLiveData<StashServer?>(StashServer.getCurrentStashServer(StashApplication.getApplication()))
     val currentServer: LiveData<StashServer?> = _currentServer
 
-    private val _currentSettingsHash = MutableLiveData<Int>(computeSettingsHash())
+    private val _currentSettingsHash = EqualityMutableLiveData(computeSettingsHash())
     val currentSettingsHash: LiveData<Int> = _currentSettingsHash
 
     fun switchServer(newServer: StashServer) {
@@ -33,6 +33,7 @@ class ServerViewModel : ViewModel() {
     }
 
     fun recomputeSettingsHash() {
-        _currentSettingsHash.value = computeSettingsHash()
+        val newHash = computeSettingsHash()
+        _currentSettingsHash.value = newHash
     }
 }


### PR DESCRIPTION
#351 introduced a bug where when resuming the main page, it would reload all of the data/rows. This occurred because the "hash" is always recomputed and set, but by default setting a value (event the same value) triggers a notification to observers.

This PR ensures the observers of the hash are only notified when it changes.

I decided to use Java instead of Kotlin for `EqualityMutableLiveData` since `MutableLiveData` is written in Java and the override semantics are more simple in Java.