### PR TITLE
Fix main page not loading when returning to it

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -85,9 +85,7 @@ class MainFragment : BrowseSupportFragment() {
                     null
                 }
             }
-        if (savedInstanceState == null) {
-            setupObservers()
-        }
+        setupObservers()
     }
 
     override fun onResume() {


### PR DESCRIPTION
If the main page activity/fragment was destroyed, when navigating back to it, no data would be loaded.

This PR fixes that.