### PR TITLE
Add ability to shift a marker's timestamp

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/actions/StashAction.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/actions/StashAction.kt
@@ -8,6 +8,7 @@ enum class StashAction(val id: Long, val actionName: String) {
     FORCE_DIRECT_PLAY(5L, "Play directly"),
     CREATE_NEW(6L, "Create new"),
     SET_STUDIO(7L, "Set Studio"),
+    SHIFT_MARKERS(8L, "Shift marker timestamp"),
     ;
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/data/Marker.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/Marker.kt
@@ -2,6 +2,7 @@ package com.github.damontecres.stashapp.data
 
 import android.os.Parcelable
 import com.github.damontecres.stashapp.api.fragment.MarkerData
+import com.github.damontecres.stashapp.util.titleOrFilename
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -14,6 +15,7 @@ data class Marker(
     val screenshot: String,
     val seconds: Double,
     val sceneId: String,
+    val sceneTitle: String?,
 ) : Parcelable {
     constructor(
         markerData: MarkerData,
@@ -26,5 +28,6 @@ data class Marker(
         markerData.screenshot,
         markerData.seconds,
         markerData.scene.videoSceneData.id,
+        markerData.scene.videoSceneData.titleOrFilename,
     )
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
@@ -235,23 +235,25 @@ class MutationEngine(
         return result.data?.sceneUpdate
     }
 
+    suspend fun updateMarker(input: SceneMarkerUpdateInput): MarkerData? {
+        val mutation = UpdateMarkerMutation(input = input)
+        val result = executeMutation(mutation)
+        return result.data?.sceneMarkerUpdate?.markerData
+    }
+
     suspend fun setTagsOnMarker(
         markerId: String,
         primaryTagId: String,
         tagIds: List<String>,
     ): MarkerData? {
         Log.v(TAG, "setTagsOnMarker markerId=$markerId, primaryTagId=$primaryTagId, tagIds=$tagIds")
-        val mutation =
-            UpdateMarkerMutation(
-                input =
-                    SceneMarkerUpdateInput(
-                        id = markerId,
-                        primary_tag_id = Optional.present(primaryTagId),
-                        tag_ids = Optional.present(tagIds),
-                    ),
-            )
-        val result = executeMutation(mutation)
-        return result.data?.sceneMarkerUpdate?.markerData
+        return updateMarker(
+            SceneMarkerUpdateInput(
+                id = markerId,
+                primary_tag_id = Optional.present(primaryTagId),
+                tag_ids = Optional.present(tagIds),
+            ),
+        )
     }
 
     suspend fun setPerformersOnScene(

--- a/app/src/main/java/com/github/damontecres/stashapp/views/MarkerPickerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/MarkerPickerFragment.kt
@@ -1,0 +1,84 @@
+package com.github.damontecres.stashapp.views
+
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.TextView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.leanback.widget.picker.Picker
+import androidx.leanback.widget.picker.PickerColumn
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.PreferenceManager
+import com.apollographql.apollo3.api.Optional
+import com.github.damontecres.stashapp.MarkerActivity.MarkerDetailsViewModel
+import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.api.type.SceneMarkerUpdateInput
+import com.github.damontecres.stashapp.data.Marker
+import com.github.damontecres.stashapp.util.MutationEngine
+import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
+import kotlinx.coroutines.launch
+
+class MarkerPickerFragment : Fragment(R.layout.marker_picker) {
+    private val viewModel by activityViewModels<MarkerDetailsViewModel>()
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val marker = requireActivity().intent.getParcelableExtra<Marker>("marker")!!
+
+        val picker = view.findViewById<Picker>(R.id.picker)
+        val sceneTitle = view.findViewById<TextView>(R.id.scene_title)
+        val markerTitle = view.findViewById<TextView>(R.id.marker_title)
+
+        sceneTitle.text = marker.sceneTitle
+        markerTitle.text = "${marker.primaryTagName} - ${durationToString(marker.seconds)}"
+
+        val preferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        val skipForward = preferences.getInt("skip_forward_time", 30)
+        val skipBack = preferences.getInt("skip_back_time", 10)
+        val maxShift = skipBack.coerceAtMost(skipForward)
+
+        val column = PickerColumn()
+        column.labelFormat = "%1\$d seconds"
+        column.minValue = viewModel.seconds.value!!.toInt().coerceAtMost(maxShift) * -1
+        column.maxValue = maxShift
+        column.currentValue = column.minValue
+
+        picker.separator = ""
+        picker.setColumns(listOf(column))
+        picker.setColumnValue(0, 0, true)
+        picker.isActivated = true
+        picker.setOnClickListener {
+            viewLifecycleOwner.lifecycleScope.launch(
+                StashCoroutineExceptionHandler { ex ->
+                    Toast.makeText(requireContext(), "Error: ${ex.message}", Toast.LENGTH_LONG)
+                },
+            ) {
+                if (column.currentValue != 0) {
+                    val seconds = (viewModel.seconds.value!! + column.currentValue).coerceAtLeast(0.0)
+                    val mutationEngine = MutationEngine(requireContext(), true)
+                    val result =
+                        mutationEngine.updateMarker(
+                            SceneMarkerUpdateInput(
+                                id = marker.id,
+                                scene_id = Optional.present(marker.sceneId),
+                                seconds = Optional.present(seconds),
+                            ),
+                        )
+                    Log.v(TAG, "newSeconds=${result?.seconds}")
+                    viewModel.seconds.value = result!!.seconds
+                }
+                requireActivity().supportFragmentManager.popBackStackImmediate()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "MarkerPicker"
+    }
+}

--- a/app/src/main/res/layout/marker_picker.xml
+++ b/app/src/main/res/layout/marker_picker.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/scene_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="22sp"
+        android:textAlignment="center"
+        tools:text="Scene Title"/>
+
+    <TextView
+        android:id="@+id/marker_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="18sp"
+        android:textAlignment="center"
+        tools:text="Tag - 10m30s"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:textSize="16sp"
+        android:textAlignment="center"
+        android:text="Shift by..."/>
+
+    <androidx.leanback.widget.picker.Picker
+        android:id="@+id/picker"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="12dp"
+        />
+</LinearLayout>


### PR DESCRIPTION
Adds an action to the marker details page to select the number of seconds to shift the marker's timestamp by.

This is especially useful if creating markers in the app since it's difficult to exactly get the precise timestamp. This feature allows for refining the value.

The range is equal to the smaller of the skip back or skip forward settings.