### PR TITLE
Fix restoring name/sort in a filter list

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -65,23 +65,21 @@ class FilterListActivity : FragmentActivity(R.layout.filter_list) {
                 fragment.refresh(sortAndDirection)
             }
 
-        fun setTitle(filterArgs: FilterArgs) {
-            titleTextView.text = filterArgs.name ?: getString(filterArgs.dataType.pluralStringId)
-        }
-
         supportFragmentManager.addFragmentOnAttachListener { _, fragment ->
-            setTitle((fragment as StashGridFragment).filterArgs)
+            setTitleText((fragment as StashGridFragment).filterArgs)
         }
         supportFragmentManager.addOnBackStackChangedListener {
             val fragment =
                 supportFragmentManager.findFragmentById(R.id.list_fragment) as StashGridFragment?
             if (fragment != null) {
-                setTitle(fragment.filterArgs)
+                setTitleText(fragment.filterArgs)
             }
         }
 
         val startingFilter = intent.getParcelableExtra<FilterArgs>(INTENT_FILTER_ARGS)!!
-        setup(startingFilter, first = true)
+        if (savedInstanceState == null) {
+            setup(startingFilter, first = true)
+        }
 
         val experimentalEnabled =
             preferences.getBoolean(getString(R.string.pref_key_experimental_features), false)
@@ -94,11 +92,22 @@ class FilterListActivity : FragmentActivity(R.layout.filter_list) {
         }
     }
 
+    private fun setTitleText(filterArgs: FilterArgs) {
+        titleTextView.text = filterArgs.name ?: getString(filterArgs.dataType.pluralStringId)
+    }
+
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
         val fragment =
             supportFragmentManager.findFragmentById(R.id.list_fragment) as StashGridFragment?
-        titleTextView.text = fragment?.filterArgs?.name
+        if (fragment != null) {
+            setTitleText(fragment.filterArgs)
+            sortButtonManager.setUpSortButton(
+                sortButton,
+                fragment.dataType,
+                fragment.filterArgs.sortAndDirection,
+            )
+        }
     }
 
     private suspend fun populateSavedFilters(dataType: DataType) {

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -268,6 +268,7 @@ class StashGridFragment() : Fragment() {
             onItemViewClickedListener ?: StashItemViewClickListener(requireContext())
 
         if (savedInstanceState == null) {
+            Log.v(TAG, "onViewCreated first time")
             refresh(_filterArgs.sortAndDirection) {
                 if (scrollToNextPage) {
                     Log.v(TAG, "scrolling to next page")
@@ -277,6 +278,7 @@ class StashGridFragment() : Fragment() {
                 }
             }
         } else {
+            Log.v(TAG, "onViewCreated restoring")
             _filterArgs = savedInstanceState.getParcelable("_filterArgs")!!
             Log.v(TAG, "sortAndDirection=${_filterArgs.sortAndDirection}")
             val previousPosition = savedInstanceState.getInt("mSelectedPosition")


### PR DESCRIPTION
Just tweaks some logic when a `FilterListActivity` is restored after being destroyed.