### PR TITLE
Add preference to scale instead of crop card images

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/FilterArgsPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/FilterArgsPresenter.kt
@@ -67,6 +67,7 @@ class FilterArgsPresenter(callback: LongClickCallBack<FilterArgs>? = null) :
             }
         }
 
+        cardView.mainImageView.setBackgroundColor(cardView.context.getColor(android.R.color.transparent))
         cardView.mainImageView.setImageDrawable(
             AppCompatResources.getDrawable(
                 cardView.context,

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -5,10 +5,12 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.PictureDrawable
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import androidx.leanback.widget.ClassPresenterSelector
 import androidx.leanback.widget.ImageCardView
 import androidx.leanback.widget.Presenter
+import androidx.preference.PreferenceManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -74,9 +76,26 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
         cardView: ImageCardView,
         url: String,
     ) {
-        StashGlide.with(cardView.context, url)
-            .error(glideError(cardView.context))
-            .into(cardView.mainImageView!!)
+        val cropImages =
+            PreferenceManager.getDefaultSharedPreferences(cardView.context)
+                .getBoolean(cardView.context.getString(R.string.pref_key_crop_card_images), true)
+        if (url.contains("default=true")) {
+            cardView.mainImageView.setBackgroundColor(cardView.context.getColor(android.R.color.transparent))
+        } else {
+            cardView.mainImageView.setBackgroundColor(cardView.context.getColor(android.R.color.black))
+        }
+        if (cropImages) {
+            cardView.mainImageView.scaleType = ImageView.ScaleType.CENTER_CROP
+            StashGlide.with(cardView.context, url)
+                .optionalCenterCrop()
+                .error(glideError(cardView.context))
+                .into(cardView.mainImageView!!)
+        } else {
+            cardView.mainImageView.scaleType = ImageView.ScaleType.FIT_CENTER
+            StashGlide.with(cardView.context, url)
+                .error(glideError(cardView.context))
+                .into(cardView.mainImageView!!)
+        }
     }
 
     abstract fun doOnBindViewHolder(

--- a/app/src/main/java/com/github/damontecres/stashapp/views/models/ServerViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/models/ServerViewModel.kt
@@ -29,7 +29,9 @@ class ServerViewModel : ViewModel() {
         val playVideoPreviews = manager.getBoolean("playVideoPreviews", true)
         val columns = manager.getInt("cardSize", context.getString(R.string.card_size_default))
         val showRatings = manager.getBoolean(context.getString(R.string.pref_key_show_rating), true)
-        return Objects.hash(maxSearchResults, playVideoPreviews, columns, showRatings)
+        val imageCrop =
+            manager.getBoolean(context.getString(R.string.pref_key_crop_card_images), true)
+        return Objects.hash(maxSearchResults, playVideoPreviews, columns, showRatings, imageCrop)
     }
 
     fun refresh() {

--- a/app/src/main/res/layout/lb_image_card_view.xml
+++ b/app/src/main/res/layout/lb_image_card_view.xml
@@ -40,7 +40,6 @@
                 android:id="@+id/main_image"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:scaleType="centerCrop"
                 android:adjustViewBounds="true"
                 android:contentDescription="@null"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -15,4 +15,5 @@
     <string name="pref_key_show_playback_debug_info" translatable="false">playback.showDebugInfo</string>
     <string name="pref_key_experimental_features" translatable="false">playback.experimentalFeatures</string>
     <string name="pref_key_playback_save_effects" translatable="false">playback.saveEffects</string>
+    <string name="pref_key_crop_card_images" translatable="false">card.cropImages</string>
 </resources>

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -32,6 +32,12 @@
             app:summaryOn="Play audio"
             app:summaryOff="Don't play audio"
             app:defaultValue="false" />
+        <SwitchPreference
+            app:key="@string/pref_key_crop_card_images"
+            app:title="Card image handling"
+            app:summaryOn="Crop center"
+            app:summaryOff="Don't crop, scale to fit"
+            app:defaultValue="true" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Playback">


### PR DESCRIPTION
Adds a preference to choose whether to crop or scale images on cards.

The current behavior of cropping is the default.