### PR TITLE
Clean up apks after update

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/util/AppUpgradeHandler.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/AppUpgradeHandler.kt
@@ -16,6 +16,8 @@ class AppUpgradeHandler(
     }
 
     override fun run() {
+        UpdateChecker.cleanup(context)
+
         // Add mpegts as a default force direct play format
         if (previousVersion.isEqualOrBefore(Version.fromString("0.2.9")) &&
             installedVersion.isAtLeast(Version.fromString("0.2.7"))


### PR DESCRIPTION
After the app is updated, clean up the previously downloaded APKs.

The content resolver will stop downloading after the 32nd update and you would have to manually delete the APKs to update again. Also while the APKs aren't huge, there's usually not a ton of storage on Android TV devices, so it is a good idea to clean things up.

This should work retroactively to clean up all previous downloads, not just the latest.