### PR TITLE
Track scene playback activity when playing a playlist

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
@@ -30,27 +30,17 @@ import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.data.ThrottledLiveData
 import com.github.damontecres.stashapp.util.MutationEngine
-import com.github.damontecres.stashapp.util.ServerPreferences
-import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashServer
-import com.github.damontecres.stashapp.util.toMilliseconds
 import com.github.damontecres.stashapp.views.ListPopupWindowBuilder
 import com.github.damontecres.stashapp.views.durationToString
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.util.Timer
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 @OptIn(UnstableApi::class)
 class PlaybackSceneFragment : PlaybackFragment() {
     lateinit var scene: Scene
 
     private lateinit var resultLauncher: ActivityResultLauncher<Intent>
-    private var trackActivityListener: TrackActivityPlaybackListener? = null
 
     // Track whether the video is playing before calling the resultLauncher
     private var wasPlayingBeforeResultLauncher: Boolean? = null
@@ -107,19 +97,7 @@ class PlaybackSceneFragment : PlaybackFragment() {
         updateDebugInfo(streamDecision, scene)
         return StashExoPlayer.getInstance(requireContext())
             .also { exoPlayer ->
-                if (ServerPreferences(requireContext()).trackActivity) {
-                    trackActivityListener =
-                        TrackActivityPlaybackListener(
-                            requireContext(),
-                            viewLifecycleOwner.lifecycleScope,
-                        ) {
-                            TrackActivityPlaybackListener.CurrentSceneAndPosition(
-                                scene,
-                                currentVideoPosition,
-                            )
-                        }
-                    exoPlayer.addListener(trackActivityListener!!)
-                }
+                maybeAddActivityTracking(exoPlayer)
             }.also { exoPlayer ->
                 val finishedBehavior =
                     PreferenceManager.getDefaultSharedPreferences(requireContext())
@@ -291,135 +269,6 @@ class PlaybackSceneFragment : PlaybackFragment() {
                 videoView.controllerShowTimeoutMs = previousControllerShowTimeoutMs
             }.build()
                 .show()
-        }
-    }
-
-    override fun releasePlayer() {
-        super.releasePlayer()
-        trackActivityListener?.release(playbackPosition)
-        trackActivityListener = null
-    }
-
-    private inner class PlaybackListener : Player.Listener {
-        val timer: Timer
-        private val mutationEngine = MutationEngine(requireContext())
-        private val minimumPlayPercent = ServerPreferences(requireContext()).minimumPlayPercent
-        private val maxPlayPercent: Int
-
-        private var totalPlayDurationSeconds = AtomicInteger(0)
-        private var currentDurationSeconds = AtomicInteger(0)
-        private var isPlaying = AtomicBoolean(false)
-        private var incrementedPlayCount = AtomicBoolean(false)
-
-        init {
-            val manager = PreferenceManager.getDefaultSharedPreferences(requireContext())
-            val playbackDurationInterval = manager.getInt("playbackDurationInterval", 1)
-            val saveActivityInterval = manager.getInt("saveActivityInterval", 10)
-            maxPlayPercent = manager.getInt("maxPlayPercent", 98)
-
-            val delay =
-                playbackDurationInterval.toDuration(DurationUnit.SECONDS).inWholeMilliseconds
-            // Every x seconds, check if the video is playing
-            timer =
-                kotlin.concurrent.timer(
-                    name = "playbackTrackerTimer",
-                    initialDelay = delay,
-                    period = delay,
-                ) {
-                    try {
-                        if (isPlaying.get()) {
-                            // If it is playing, add the interval to currently tracked duration
-                            val current = currentDurationSeconds.addAndGet(playbackDurationInterval)
-                            // TODO currentDuration.getAndUpdate would be better, but requires API 24+
-                            if (current >= saveActivityInterval) {
-                                // If the accumulated currently tracked duration > threshold, reset it and save activity
-                                currentDurationSeconds.set(0)
-                                totalPlayDurationSeconds.addAndGet(current)
-                                saveSceneActivity(-1L, current)
-                            }
-                        }
-                    } catch (ex: Exception) {
-                        Log.w(TAG, "Exception during track activity timer", ex)
-                    }
-                }
-        }
-
-        fun release(position: Long) {
-            timer.cancel()
-            saveSceneActivity(position)
-        }
-
-        override fun onIsPlayingChanged(isPlaying: Boolean) {
-            this.isPlaying.set(isPlaying)
-            if (!isPlaying) {
-                val diff = currentDurationSeconds.getAndSet(0)
-                if (diff > 0) {
-                    totalPlayDurationSeconds.addAndGet(diff)
-                    saveSceneActivity(currentVideoPosition, diff)
-                }
-            }
-        }
-
-        override fun onPlaybackStateChanged(playbackState: Int) {
-            if (playbackState == Player.STATE_ENDED) {
-                Log.v(TAG, "onPlaybackStateChanged STATE_ENDED")
-                val sceneDuration = scene.durationPosition
-                val diff = currentDurationSeconds.getAndSet(0)
-                totalPlayDurationSeconds.addAndGet(diff)
-                if (sceneDuration != null) {
-                    saveSceneActivity(sceneDuration, diff)
-                }
-            }
-        }
-
-        fun saveSceneActivity(position: Long) {
-            val duration = currentDurationSeconds.getAndSet(0)
-            saveSceneActivity(position, duration)
-        }
-
-        fun saveSceneActivity(
-            position: Long,
-            duration: Int,
-        ) {
-            viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main + StashCoroutineExceptionHandler()) {
-                val sceneDuration = scene.duration
-                val totalDuration = totalPlayDurationSeconds.get()
-                val calcPosition = if (position >= 0) position else currentVideoPosition
-                Log.v(
-                    TAG,
-                    "saveSceneActivity: position=$position, duration=$duration, calcPosition=$calcPosition, totalDuration=$totalDuration",
-                )
-                if (sceneDuration != null) {
-                    val playedPercent = (calcPosition.toMilliseconds / sceneDuration) * 100
-                    val positionToSave =
-                        if (playedPercent >= maxPlayPercent) {
-                            Log.v(
-                                TAG,
-                                "Setting position to 0 since $playedPercent >= $maxPlayPercent",
-                            )
-                            0L
-                        } else {
-                            calcPosition
-                        }
-                    mutationEngine.saveSceneActivity(scene.id, positionToSave, duration)
-                    val totalPlayPercent = (totalDuration / sceneDuration) * 100
-                    Log.v(
-                        TAG,
-                        "totalPlayPercent=$totalPlayPercent, minimumPlayPercent=$minimumPlayPercent",
-                    )
-                    if (totalPlayPercent >= minimumPlayPercent) {
-                        // If the current session hasn't incremented the play count yet, do it
-                        val shouldIncrement = !incrementedPlayCount.getAndSet(true)
-                        if (shouldIncrement) {
-                            Log.v(TAG, "Incrementing play count for ${scene.id}")
-                            mutationEngine.incrementPlayCount(scene.id)
-                        }
-                    }
-                } else {
-                    // No scene duration
-                    mutationEngine.saveSceneActivity(scene.id, calcPosition, duration)
-                }
-            }
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistFragment.kt
@@ -16,6 +16,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import com.apollographql.apollo3.api.Query
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.StashExoPlayer
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.suppliers.DataSupplierFactory
 import com.github.damontecres.stashapp.suppliers.StashPagingSource
@@ -81,6 +82,10 @@ abstract class PlaylistFragment<T : Query.Data, D : Any, C : Query.Data> :
                 },
             )
             exoPlayer.addListener(PlaylistListener())
+            if (viewModel.filterArgs.value?.dataType == DataType.SCENE) {
+                // Only track activity for scene playback
+                maybeAddActivityTracking(exoPlayer)
+            }
         }.also { exoPlayer ->
             exoPlayer.repeatMode = Player.REPEAT_MODE_ALL
             if (videoView.controllerShowTimeoutMs > 0) {
@@ -176,6 +181,13 @@ abstract class PlaylistFragment<T : Query.Data, D : Any, C : Query.Data> :
                 Log.v(TAG, "Starting playback of ${scene.id}")
                 currentScene = scene
                 updateDebugInfo(tag.streamDecision, scene)
+
+                // Replace activity tracker
+                if (trackActivityListener != null) {
+                    trackActivityListener?.release()
+                    player!!.removeListener(trackActivityListener!!)
+                }
+                maybeAddActivityTracking(player!!)
             }
             if (hasMorePages) {
                 val count = player!!.mediaItemCount

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistScenesFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistScenesFragment.kt
@@ -43,7 +43,6 @@ class PlaylistScenesFragment :
                 moreOptionsButton,
                 listOf(debugToggleText, "Show playlist"),
             ) { position ->
-
                 if (position == 0) {
                     if (debugView.isVisible) {
                         debugView.visibility = View.GONE

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/TrackActivityPlaybackListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/TrackActivityPlaybackListener.kt
@@ -1,0 +1,160 @@
+package com.github.damontecres.stashapp.playback
+
+import android.util.Log
+import androidx.annotation.OptIn
+import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.preference.PreferenceManager
+import com.github.damontecres.stashapp.util.MutationEngine
+import com.github.damontecres.stashapp.util.ServerPreferences
+import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
+import com.github.damontecres.stashapp.util.toMilliseconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.Timer
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+/**
+ * Listens to playback and periodically saves playback activity to the server
+ */
+@OptIn(UnstableApi::class)
+class TrackActivityPlaybackListener(
+    private val fragment: PlaybackFragment,
+) : Player.Listener {
+    private val timer: Timer
+    private val mutationEngine = MutationEngine(fragment.requireContext())
+    private val minimumPlayPercent = ServerPreferences(fragment.requireContext()).minimumPlayPercent
+    private val maxPlayPercent: Int
+
+    private var totalPlayDurationSeconds = AtomicInteger(0)
+    private var currentDurationSeconds = AtomicInteger(0)
+    private var isPlaying = AtomicBoolean(false)
+    private var incrementedPlayCount = AtomicBoolean(false)
+
+    init {
+        val manager = PreferenceManager.getDefaultSharedPreferences(fragment.requireContext())
+        val playbackDurationInterval = manager.getInt("playbackDurationInterval", 1)
+        val saveActivityInterval = manager.getInt("saveActivityInterval", 10)
+        maxPlayPercent = manager.getInt("maxPlayPercent", 98)
+
+        val delay =
+            playbackDurationInterval.toDuration(DurationUnit.SECONDS).inWholeMilliseconds
+        // Every x seconds, check if the video is playing
+        timer =
+            kotlin.concurrent.timer(
+                name = "playbackTrackerTimer",
+                initialDelay = delay,
+                period = delay,
+            ) {
+                try {
+                    if (isPlaying.get()) {
+                        // If it is playing, add the interval to currently tracked duration
+                        val current = currentDurationSeconds.addAndGet(playbackDurationInterval)
+                        // TODO currentDuration.getAndUpdate would be better, but requires API 24+
+                        if (current >= saveActivityInterval) {
+                            // If the accumulated currently tracked duration > threshold, reset it and save activity
+                            currentDurationSeconds.set(0)
+                            totalPlayDurationSeconds.addAndGet(current)
+                            saveSceneActivity(-1L, current)
+                        }
+                    }
+                } catch (ex: Exception) {
+                    Log.w(TAG, "Exception during track activity timer", ex)
+                }
+            }
+    }
+
+    fun release() {
+        timer.cancel()
+    }
+
+    fun release(position: Long) {
+        timer.cancel()
+        if (position >= 0) {
+            saveSceneActivity(position, currentDurationSeconds.getAndSet(0))
+        }
+    }
+
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        this.isPlaying.set(isPlaying)
+        if (!isPlaying) {
+            val diff = currentDurationSeconds.getAndSet(0)
+            if (diff > 0) {
+                totalPlayDurationSeconds.addAndGet(diff)
+                saveSceneActivity(-1, diff)
+            }
+        }
+    }
+
+    override fun onPlaybackStateChanged(playbackState: Int) {
+        if (playbackState == Player.STATE_ENDED) {
+            Log.v(TAG, "onPlaybackStateChanged STATE_ENDED")
+            val scene = fragment.currentScene
+            if (scene != null) {
+                val sceneDuration = scene.durationPosition
+                val diff = currentDurationSeconds.getAndSet(0)
+                totalPlayDurationSeconds.addAndGet(diff)
+                if (sceneDuration != null) {
+                    saveSceneActivity(sceneDuration, diff)
+                }
+            }
+        }
+    }
+
+    private fun saveSceneActivity(
+        position: Long,
+        duration: Int,
+    ) {
+        fragment.viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main + StashCoroutineExceptionHandler()) {
+            val scene = fragment.currentScene
+            if (scene != null) {
+                val sceneDuration = scene.duration
+                val totalDuration = totalPlayDurationSeconds.get()
+                val calcPosition = if (position >= 0) position else fragment.currentVideoPosition
+                Log.v(
+                    TAG,
+                    "saveSceneActivity: scene=${scene.id}, position=$position, duration=$duration, " +
+                        "calcPosition=$calcPosition, totalDuration=$totalDuration",
+                )
+                if (sceneDuration != null) {
+                    val playedPercent = (calcPosition.toMilliseconds / sceneDuration) * 100
+                    val positionToSave =
+                        if (playedPercent >= maxPlayPercent) {
+                            Log.v(
+                                TAG,
+                                "Setting position to 0 since $playedPercent >= $maxPlayPercent",
+                            )
+                            0L
+                        } else {
+                            calcPosition
+                        }
+                    mutationEngine.saveSceneActivity(scene.id, positionToSave, duration)
+                    val totalPlayPercent = (totalDuration / sceneDuration) * 100
+                    Log.v(
+                        TAG,
+                        "totalPlayPercent=$totalPlayPercent, minimumPlayPercent=$minimumPlayPercent",
+                    )
+                    if (totalPlayPercent >= minimumPlayPercent) {
+                        // If the current session hasn't incremented the play count yet, do it
+                        val shouldIncrement = !incrementedPlayCount.getAndSet(true)
+                        if (shouldIncrement) {
+                            Log.v(TAG, "Incrementing play count for ${scene.id}")
+                            mutationEngine.incrementPlayCount(scene.id)
+                        }
+                    }
+                } else {
+                    // No scene duration
+                    mutationEngine.saveSceneActivity(scene.id, calcPosition, duration)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "TrackActivityPlaybackListener"
+    }
+}


### PR DESCRIPTION
Follow up to #381 

When playing scenes (not markers) in a playlist, the playback activity will be sent to the server if enabled server-side.