### PR TITLE
Add play all button to all pages with scenes or markers

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -41,6 +41,7 @@ import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.animateToVisible
 import com.github.damontecres.stashapp.util.getInt
 import com.github.damontecres.stashapp.views.ImageGridClickedListener
+import com.github.damontecres.stashapp.views.PlayAllOnClickListener
 import com.github.damontecres.stashapp.views.SortButtonManager
 import com.github.damontecres.stashapp.views.StashItemViewClickListener
 import com.github.damontecres.stashapp.views.TitleTransitionHelper
@@ -55,6 +56,7 @@ import kotlinx.coroutines.launch
 class StashGridFragment() : Fragment() {
     // Views
     private lateinit var sortButton: Button
+    private lateinit var playAllButton: Button
     private lateinit var positionTextView: TextView
     private lateinit var totalCountTextView: TextView
     private lateinit var mGridPresenter: VerticalGridPresenter
@@ -86,9 +88,14 @@ class StashGridFragment() : Fragment() {
     var name: String? = null
 
     /**
-     * Whether to enable the built-in sort button, defaults to false
+     * Whether to enable the built-in sort button, defaults to true
      */
-    var sortButtonEnabled = false
+    var sortButtonEnabled = true
+
+    /**
+     * Whether to enable the built-in play all button, defaults to true
+     */
+    var playAllButtonEnabled = true
 
     /**
      * The presenter for the items, defaults to [StashPresenter.SELECTOR]
@@ -253,6 +260,7 @@ class StashGridFragment() : Fragment() {
             ) as ViewGroup
         val gridFrame = root.findViewById<View>(androidx.leanback.R.id.grid_frame) as ViewGroup
         sortButton = root.findViewById(R.id.sort_button)
+        playAllButton = root.findViewById(R.id.play_all_button)
         val gridDock = root.findViewById<View>(androidx.leanback.R.id.browse_grid_dock) as ViewGroup
         mGridViewHolder = mGridPresenter.onCreateViewHolder(gridDock)
         gridDock.addView(mGridViewHolder.view)
@@ -306,6 +314,15 @@ class StashGridFragment() : Fragment() {
             SortButtonManager {
                 refresh(it)
             }.setUpSortButton(sortButton, dataType, _filterArgs.sortAndDirection)
+        }
+        if (playAllButtonEnabled && dataType.supportsPlaylists) {
+            playAllButton.visibility = View.VISIBLE
+            playAllButton.nextFocusUpId = R.id.tab_layout
+            playAllButton.setOnClickListener(
+                PlayAllOnClickListener(requireContext(), dataType) {
+                    filterArgs
+                },
+            )
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
@@ -106,6 +106,8 @@ enum class DataType(
         get() =
             ScenePresenter.CARD_WIDTH.toDouble() / defaultCardWidth
 
+    val supportsPlaylists get() = this == SCENE || this == MARKER
+
     companion object {
         fun fromFilterMode(mode: FilterMode): DataType? {
             return DataType.entries.firstOrNull {

--- a/app/src/main/java/com/github/damontecres/stashapp/views/PlayAllOnClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/PlayAllOnClickListener.kt
@@ -1,0 +1,54 @@
+package com.github.damontecres.stashapp.views
+
+import android.content.Context
+import android.content.Intent
+import android.view.View
+import android.view.View.OnClickListener
+import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.data.SortAndDirection
+import com.github.damontecres.stashapp.playback.PlaylistActivity
+import com.github.damontecres.stashapp.playback.PlaylistMarkersFragment
+import com.github.damontecres.stashapp.suppliers.FilterArgs
+
+class PlayAllOnClickListener(
+    private val context: Context,
+    private val dataType: DataType,
+    private val getFilter: () -> FilterArgs,
+) : OnClickListener {
+    override fun onClick(v: View) {
+        when (dataType) {
+            DataType.MARKER -> {
+                showSimpleListPopupWindow(v, listOf("15 seconds", "20 seconds", "30 seconds", "60 seconds")) {
+                    val duration =
+                        when (it) {
+                            0 -> 15_000L
+                            1 -> 20_000L
+                            2 -> 30_000L
+                            3 -> 60_000L
+                            else -> 30_000L
+                        }
+                    val intent = Intent(context, PlaylistActivity::class.java)
+                    intent.putExtra(PlaylistActivity.INTENT_FILTER, getFilter())
+                    intent.putExtra(PlaylistMarkersFragment.INTENT_DURATION_ID, duration)
+                    context.startActivity(intent)
+                }
+            }
+
+            DataType.SCENE -> {
+                showSimpleListPopupWindow(v, listOf("In order", "Shuffle")) {
+                    val filter =
+                        when (it) {
+                            0 -> getFilter()
+                            1 -> getFilter().with(SortAndDirection.random())
+                            else -> throw IllegalStateException("$it")
+                        }
+                    val intent = Intent(context, PlaylistActivity::class.java)
+                    intent.putExtra(PlaylistActivity.INTENT_FILTER, filter)
+                    context.startActivity(intent)
+                }
+            }
+
+            else -> throw UnsupportedOperationException("DataType $dataType")
+        }
+    }
+}

--- a/app/src/main/res/layout/stash_grid_fragment.xml
+++ b/app/src/main/res/layout/stash_grid_fragment.xml
@@ -6,20 +6,39 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <Button
-        android:id="@+id/sort_button"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:layout_margin="8dp"
-        android:minWidth="0dp"
-        android:padding="8dp"
-        android:visibility="gone"
-        android:textSize="14sp"
-        android:background="@drawable/button_selector"
-        tools:visibility="visible"
-        tools:text="Sort By"
-        />
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/sort_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_margin="8dp"
+            android:minWidth="0dp"
+            android:padding="8dp"
+            android:visibility="gone"
+            android:textSize="14sp"
+            android:background="@drawable/button_selector"
+            tools:visibility="visible"
+            tools:text="Sort By" />
+
+        <Button
+            android:id="@+id/play_all_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_margin="8dp"
+            android:minWidth="0dp"
+            android:padding="8dp"
+            android:visibility="gone"
+            android:textSize="14sp"
+            android:background="@drawable/button_selector"
+            android:text="Play All"
+            tools:visibility="visible" />
+    </LinearLayout>
 
     <androidx.leanback.widget.BrowseFrameLayout
         android:id="@+id/grid_frame"


### PR DESCRIPTION
Follow up to #381

Closes #20

Adds a `Play All` button to every page that has scenes or scene markers allowing to play them as a playlist.

`StashGridFragment` now defaults to showing the sort & play all buttons since that is the desired behavior in every page except in `FilterListActivity` which explicitly turns them off anyway.