### PR TITLE
Several small bug fixes

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -68,7 +68,9 @@ class FilterListActivity : FragmentActivity(R.layout.filter_list) {
             val fragment =
                 supportFragmentManager.findFragmentById(R.id.list_fragment) as StashGridFragment?
             if (fragment != null) {
-                setTitleText(fragment.filterArgs)
+                val fa = fragment.filterArgs
+                setTitleText(fa)
+                sortButtonManager.setUpSortButton(sortButton, fa.dataType, fa.sortAndDirection)
             }
         }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/GalleryActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/GalleryActivity.kt
@@ -2,6 +2,7 @@ package com.github.damontecres.stashapp
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.util.TypedValue
 import android.view.View
 import android.widget.ImageView
@@ -145,7 +146,12 @@ class GalleryActivity : TabbedGridFragmentActivity(R.layout.gallery_activity) {
             super.onViewCreated(view, savedInstanceState)
 
             if (savedInstanceState != null) {
-                gallery = savedInstanceState.getParcelable("gallery")!!
+                val gallery = savedInstanceState.getParcelable<Gallery>("gallery")
+                if (gallery != null) {
+                    this.gallery = gallery
+                } else {
+                    Log.w(TAG, "savedInstanceState != null but gallery was null")
+                }
             }
 
             studioImage = view.findViewById(R.id.studio_image)
@@ -257,6 +263,7 @@ class GalleryActivity : TabbedGridFragmentActivity(R.layout.gallery_activity) {
     }
 
     companion object {
+        private const val TAG = "GalleryFragment"
         const val INTENT_GALLERY_OBJ = "gallery"
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -63,6 +63,8 @@ class StashGridFragment() : Fragment() {
     private lateinit var mGridViewHolder: VerticalGridPresenter.ViewHolder
     private lateinit var mAdapter: ObjectAdapter
 
+    private var titleView: View? = null
+
     // Arguments
     private lateinit var _filterArgs: FilterArgs
     private lateinit var _currentSortAndDirection: SortAndDirection
@@ -71,7 +73,7 @@ class StashGridFragment() : Fragment() {
     private var mOnItemViewSelectedListener: OnItemViewSelectedListener? = null
     private var mSelectedPosition = -1
     private var titleTransitionHelper: TitleTransitionHelper? = null
-    private var sortButtonTransitionHelper: TitleTransitionHelper? = null
+    private var gridHeaderTransitionHelper: TitleTransitionHelper? = null
     private var columns: Int? = null
     private var scrollToNextPage = false
 
@@ -307,10 +309,14 @@ class StashGridFragment() : Fragment() {
                 }
             }
         }
+
+        val gridHeader = view.findViewById<View>(R.id.grid_header)
+        gridHeaderTransitionHelper = TitleTransitionHelper(view as ViewGroup, gridHeader)
+        setTitleView(this.titleView)
+
         if (sortButtonEnabled) {
             sortButton.visibility = View.VISIBLE
             sortButton.nextFocusUpId = R.id.tab_layout
-            sortButtonTransitionHelper = TitleTransitionHelper(view as ViewGroup, sortButton)
             SortButtonManager {
                 refresh(it)
             }.setUpSortButton(sortButton, dataType, _filterArgs.sortAndDirection)
@@ -409,10 +415,11 @@ class StashGridFragment() : Fragment() {
         if (showFooter) {
             viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
                 val count = pagingSource.getCount()
-                if (count > 0) {
-                    totalCountTextView.text = count.toString()
-                    footerLayout.animateToVisible()
+                if (count == 0) {
+                    positionTextView.text = getString(R.string.zero)
                 }
+                totalCountTextView.text = count.toString()
+                footerLayout.animateToVisible()
             }
         } else {
             footerLayout.visibility = View.GONE
@@ -467,14 +474,16 @@ class StashGridFragment() : Fragment() {
 
     fun setTitleView(titleView: View?) {
         if (view is ViewGroup && titleView != null) {
+            Log.v(TAG, "setTitleView")
             titleTransitionHelper = TitleTransitionHelper(requireView() as ViewGroup, titleView)
         } else {
+            this.titleView = titleView
             titleTransitionHelper = null
         }
     }
 
     fun showTitle(show: Boolean) {
-        sortButtonTransitionHelper?.showTitle(show)
+        gridHeaderTransitionHelper?.showTitle(show)
         titleTransitionHelper?.showTitle(show)
     }
 

--- a/app/src/main/res/layout/stash_grid_fragment.xml
+++ b/app/src/main/res/layout/stash_grid_fragment.xml
@@ -7,15 +7,16 @@
     android:orientation="vertical">
 
     <LinearLayout
+        android:id="@+id/grid_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:layout_gravity="center_vertical">
 
         <Button
             android:id="@+id/sort_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="start"
             android:layout_margin="8dp"
             android:minWidth="0dp"
             android:padding="8dp"
@@ -29,14 +30,13 @@
             android:id="@+id/play_all_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="start"
             android:layout_margin="8dp"
             android:minWidth="0dp"
             android:padding="8dp"
             android:visibility="gone"
             android:textSize="14sp"
             android:background="@drawable/button_selector"
-            android:text="Play All"
+            android:text="@string/play_all"
             tools:visibility="visible" />
     </LinearLayout>
 


### PR DESCRIPTION
1. Hitting back after selected a new saved filter wouldn't update the sort by button to previous value on the filter page
2. Gallery page could crash sometimes when returning to the details tab
3. The "Play All" button (#385) wasn't being hidden when scrolling down
4. The position footer on grids wasn't being shown when there are no results. This also meant it was a kinda of unclear if there were truly no results or an error occurred fetching data. Now it will display "0 / 0" if there were results.