### PR TITLE
Fix crashes from very large scrolls

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistListFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistListFragment.kt
@@ -101,7 +101,7 @@ class PlaylistListFragment<T : Query.Data, D : Any, Count : Query.Data> : Fragme
         pagingAdapter.registerObserver(
             object : ObjectAdapter.DataObserver() {
                 override fun onChanged() {
-                    mGridViewHolder.gridView.scrollToPosition(player.currentMediaItemIndex)
+                    mGridViewHolder.gridView.selectedPosition = player.currentMediaItemIndex
                     pagingAdapter.unregisterObserver(this)
                 }
             },

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/NullPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/NullPresenter.kt
@@ -1,0 +1,13 @@
+package com.github.damontecres.stashapp.presenters
+
+/**
+ * A no-op implementation of [StashPresenter] that accepts a null item
+ */
+class NullPresenter : StashPresenter<Any?>() {
+    override fun doOnBindViewHolder(
+        cardView: StashImageCardView,
+        item: Any?,
+    ) {
+        // no-op
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/NullPresenterSelector.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/NullPresenterSelector.kt
@@ -1,0 +1,20 @@
+package com.github.damontecres.stashapp.presenters
+
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.PresenterSelector
+
+/**
+ * A [PresenterSelector] that delegates to another [PresenterSelector] except when the item is null, it return the specified [Presenter]
+ */
+class NullPresenterSelector(
+    private val presenterSelector: PresenterSelector,
+    private val nullPresenter: Presenter = NullPresenter(),
+) : PresenterSelector() {
+    override fun getPresenter(item: Any?): Presenter {
+        return if (item == null) {
+            nullPresenter
+        } else {
+            presenterSelector.getPresenter(item)
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/PlaylistItemPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/PlaylistItemPresenter.kt
@@ -25,19 +25,21 @@ class PlaylistItemPresenter : Presenter() {
     @SuppressLint("SetTextI18n")
     override fun onBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any,
+        item: Any?,
     ) {
         val vh = viewHolder as PlaylistItemViewHolder
-        item as PlaylistItem
-        vh.indexView.text = (item.index + 1).toString()
-        vh.titleView.text = item.title
-        vh.subtitleView.text = item.subtitle
-        vh.details1View.text = item.details1
-        vh.details2View.text = item.details2
+        if (item != null) {
+            item as PlaylistItem
+            vh.indexView.text = (item.index + 1).toString()
+            vh.titleView.text = item.title
+            vh.subtitleView.text = item.subtitle
+            vh.details1View.text = item.details1
+            vh.details2View.text = item.details2
 
-        if (item.imageUrl.isNotNullOrBlank()) {
-            StashGlide.with(vh.view.context, item.imageUrl)
-                .into(vh.imageView)
+            if (item.imageUrl.isNotNullOrBlank()) {
+                StashGlide.with(vh.view.context, item.imageUrl)
+                    .into(vh.imageView)
+            }
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -51,24 +51,26 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
 
     final override fun onBindViewHolder(
         viewHolder: ViewHolder,
-        item: Any,
+        item: Any?,
     ) {
-        val cardView = viewHolder.view as StashImageCardView
+        if (item != null) {
+            val cardView = viewHolder.view as StashImageCardView
 
-        val localCallBack = callback ?: getDefaultLongClickCallBack(cardView)
-        val popUpItems = localCallBack.getPopUpItems(cardView.context, item as T)
-        cardView.setOnLongClickListener(
-            PopupOnLongClickListener(
-                popUpItems.map { it.text },
-            ) { _, _, pos, _ ->
-                localCallBack.onItemLongClick(cardView.context, item as T, popUpItems[pos])
-            },
-        )
+            val localCallBack = callback ?: getDefaultLongClickCallBack(cardView)
+            val popUpItems = localCallBack.getPopUpItems(cardView.context, item as T)
+            cardView.setOnLongClickListener(
+                PopupOnLongClickListener(
+                    popUpItems.map { it.text },
+                ) { _, _, pos, _ ->
+                    localCallBack.onItemLongClick(cardView.context, item as T, popUpItems[pos])
+                },
+            )
 
-        cardView.mainImageView.visibility = View.VISIBLE
-        doOnBindViewHolder(viewHolder.view as StashImageCardView, item as T)
-        if (cardView.isSelected) {
-            cardView.isSelected = true
+            cardView.mainImageView.visibility = View.VISIBLE
+            doOnBindViewHolder(viewHolder.view as StashImageCardView, item as T)
+            if (cardView.isSelected) {
+                cardView.isSelected = true
+            }
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
@@ -145,6 +145,9 @@ class StashPagingSource<T : Query.Data, D : Any, S : Any, C : Query.Data>(
             }
         }
 
+    override val jumpingSupported: Boolean
+        get() = true
+
     override fun getRefreshKey(state: PagingState<Int, S>): Int? {
         // Try to find the page key of the closest page to anchorPosition from
         // either the prevKey or the nextKey; you need to handle nullability


### PR DESCRIPTION
Scrolling a far distance quickly could cause a crash. This is because it would try to load placeholders, but the presenters don't handle null items (placeholders are null).

So this PR updates the presenters to handle nulls, but also tweaks large scrolls to jump instead of smooth scroll.

Also the playlist list will now jump to the currently playing item instead of scrolling.