### PR TITLE
Check if server is supported by app update

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/UpdateAppFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/UpdateAppFragment.kt
@@ -10,7 +10,9 @@ import androidx.leanback.widget.GuidedAction
 import androidx.lifecycle.lifecycleScope
 import com.github.damontecres.stashapp.UpdateChangelogActivity.Companion.INTENT_CHANGELOG
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
+import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.UpdateChecker
+import com.github.damontecres.stashapp.util.Version
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.util.joinNotNullOrBlank
 import kotlinx.coroutines.launch
@@ -18,9 +20,13 @@ import kotlinx.coroutines.launch
 class UpdateAppFragment(private val release: UpdateChecker.Release) : GuidedStepSupportFragment() {
     override fun onCreateGuidance(savedInstanceState: Bundle?): GuidanceStylist.Guidance {
         val installedVersion = UpdateChecker.getInstalledVersion(requireActivity())
+        val serverVersion = StashServer.getCurrentServerVersion()
         val description =
             buildList {
                 add("${getString(R.string.stashapp_package_manager_installed_version)}: $installedVersion")
+                if (!Version.isServerSupportedByAppVersion(serverVersion, release.version)) {
+                    add("Warning!! This update does not support the current server's version $serverVersion!!")
+                }
                 addAll(release.notes)
             }.joinNotNullOrBlank("\n\n")
 

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Version.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Version.kt
@@ -102,5 +102,14 @@ data class Version(
             }
             return version.isAtLeast(MINIMUM_STASH_VERSION)
         }
+
+        fun isServerSupportedByAppVersion(
+            serverVersion: Version,
+            appVersion: Version,
+        ): Boolean {
+            // Versions are offset by 22: https://github.com/damontecres/StashAppAndroidTV/discussions/308
+            val minServerVer = appVersion.copy(minor = appVersion.minor + 22, patch = 0)
+            return serverVersion.isAtLeast(minServerVer)
+        }
     }
 }


### PR DESCRIPTION
If installing the update would mean the current server is not supported, add a warning to the app update page.

This does not prevent the user from installing the update if they want to though.

This doesn't help warn current users for the upcoming `v0.4.0` release, but it will in future releases.