### PR TITLE
Fix crash due to missing `@Serializable`

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/DataSupplierFactory.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/DataSupplierFactory.kt
@@ -91,10 +91,13 @@ class DataSupplierFactory(val serverVersion: Version) {
  */
 @Serializable
 sealed class DataSupplierOverride {
+    @Serializable
     data class PerformerTags(val performerId: String) : DataSupplierOverride()
 
+    @Serializable
     data class GalleryPerformer(val galleryId: String) : DataSupplierOverride()
 
+    @Serializable
     data class GalleryTag(val galleryId: String) : DataSupplierOverride()
 }
 


### PR DESCRIPTION
Each `DataSupplierOverride` must be explicitly marked with `@Serializable` following #399.

If not, the fragment using that override will crash when trying to restore.