### PR TITLE
Move video filters out of experimental

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.stashapp
 
 import android.annotation.SuppressLint
+import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.text.InputType
@@ -42,6 +43,7 @@ import com.github.damontecres.stashapp.util.cacheDurationPrefToDuration
 import com.github.damontecres.stashapp.util.launchIO
 import com.github.damontecres.stashapp.util.plugin.CompanionPlugin
 import com.github.damontecres.stashapp.util.testStashConnection
+import com.github.damontecres.stashapp.views.dialog.ConfirmationDialogFragment
 import com.github.damontecres.stashapp.views.models.ServerViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
@@ -450,6 +452,21 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
                     }
                 }
                 true
+            }
+
+            val videoEffectsPref =
+                findPreference<SwitchPreference>(getString(R.string.pref_key_video_filters))!!
+            videoEffectsPref.setOnPreferenceChangeListener { _, newValue ->
+                if (newValue == true) {
+                    ConfirmationDialogFragment(
+                        "Some device do not support video filters!\n\nWould you like to enable it?",
+                    ) { _, which ->
+                        if (which == DialogInterface.BUTTON_POSITIVE) {
+                            videoEffectsPref.isChecked = true
+                        }
+                    }.show(childFragmentManager, null)
+                }
+                newValue == false
             }
         }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFilterFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFilterFragment.kt
@@ -8,6 +8,7 @@ import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.data.room.VideoFilter
 
@@ -102,12 +103,20 @@ class PlaybackFilterFragment : Fragment(R.layout.apply_video_filters) {
             val vf = getOrCreateVideoFilter()
             viewModel.videoFilter.value = vf.copy(rotation = vf.rotation - 90)
         }
-        val submitButton = view.findViewById<Button>(R.id.apply_button)
-        submitButton.setOnClickListener {
+        val saveButton = view.findViewById<Button>(R.id.save_button)
+        saveButton.setOnClickListener {
             viewModel.maybeSaveFilter()
             requireActivity().supportFragmentManager.beginTransaction()
                 .remove(this@PlaybackFilterFragment)
                 .commitNow()
+        }
+        val saveFilters =
+            PreferenceManager.getDefaultSharedPreferences(requireContext()).getBoolean(
+                getString(R.string.pref_key_playback_save_effects),
+                true,
+            )
+        if (!saveFilters) {
+            saveButton.visibility = View.GONE
         }
 
         val resetButton = view.findViewById<Button>(R.id.reset_button)
@@ -117,7 +126,7 @@ class PlaybackFilterFragment : Fragment(R.layout.apply_video_filters) {
             setUi(vf)
         }
 
-        submitButton.requestFocus()
+        saveButton.requestFocus()
     }
 
     private fun getOrCreateVideoFilter(): VideoFilter {

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
@@ -53,7 +53,7 @@ class PlaybackSceneFragment : PlaybackFragment() {
 
     private fun applyEffects(exoPlayer: ExoPlayer) {
         if (PreferenceManager.getDefaultSharedPreferences(requireContext())
-                .getBoolean(getString(R.string.pref_key_experimental_features), false)
+                .getBoolean(getString(R.string.pref_key_video_filters), false)
         ) {
             Log.v(TAG, "Initializing video effects")
             exoPlayer.setVideoEffects(listOf())
@@ -208,7 +208,7 @@ class PlaybackSceneFragment : PlaybackFragment() {
             preferences.getBoolean(
                 getString(R.string.pref_key_playback_save_effects),
                 true,
-            ) && preferences.getBoolean(getString(R.string.pref_key_experimental_features), false)
+            ) && preferences.getBoolean(getString(R.string.pref_key_video_filters), false)
         viewModel.initialize(
             StashServer.getCurrentStashServer(requireContext())!!,
             scene.id,
@@ -221,11 +221,11 @@ class PlaybackSceneFragment : PlaybackFragment() {
                 if (debugView.isVisible) "Hide transcode info" else "Show transcode info"
             val applyFiltersText =
                 if (preferences.getBoolean(
-                        getString(R.string.pref_key_experimental_features),
+                        getString(R.string.pref_key_video_filters),
                         false,
                     )
                 ) {
-                    "Apply Filters"
+                    "Apply Video Filters"
                 } else {
                     null
                 }

--- a/app/src/main/java/com/github/damontecres/stashapp/views/dialog/ConfirmationDialogFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/dialog/ConfirmationDialogFragment.kt
@@ -1,0 +1,21 @@
+package com.github.damontecres.stashapp.views.dialog
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.github.damontecres.stashapp.R
+
+class ConfirmationDialogFragment(
+    private val message: String,
+    private val onClickListener: DialogInterface.OnClickListener,
+) : DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return AlertDialog.Builder(requireContext())
+            .setMessage(message)
+            .setPositiveButton(getString(R.string.stashapp_actions_confirm), onClickListener)
+            .setNegativeButton(getString(R.string.stashapp_actions_cancel), onClickListener)
+            .create()
+    }
+}

--- a/app/src/main/res/layout/apply_video_filters.xml
+++ b/app/src/main/res/layout/apply_video_filters.xml
@@ -232,7 +232,7 @@
             android:text="@string/fa_rotate_right" />
 
         <Button
-            android:id="@+id/apply_button"
+            android:id="@+id/save_button"
             style="?android:attr/buttonBarButtonStyle"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -17,4 +17,5 @@
     <string name="pref_key_playback_save_effects" translatable="false">playback.saveEffects</string>
     <string name="pref_key_crop_card_images" translatable="false">card.cropImages</string>
     <string name="pref_key_back_button_scroll" translatable="false">grid_back_button_scroll</string>
+    <string name="pref_key_video_filters" translatable="false">playback.videoFilters</string>
 </resources>

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -102,6 +102,15 @@
             app:summaryOn="Show title &amp; date"
             app:summaryOff="Hide title &amp; date"
             app:defaultValue="true" />
+    </PreferenceCategory>
+
+    <PreferenceCategory app:title="Scene Video Filters">
+        <SwitchPreference
+            app:key="@string/pref_key_video_filters"
+            app:title="Enable video filters"
+            app:summaryOn="Enabled"
+            app:summaryOff="Disabled"
+            app:defaultValue="false" />
         <SwitchPreference
             app:key="@string/pref_key_playback_save_effects"
             app:title="Persist scene filters"


### PR DESCRIPTION
Separate enabling video filters from experimental features. It works great on supported devices.

When enabling it, users must confirm a dialog so they are aware some devices aren't supported.

Ref: #349