### PR TITLE
Use user selections for scan/generate tasks

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
@@ -221,6 +221,7 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
             findPreference<Preference>("triggerScan")!!
                 .setOnPreferenceClickListener {
                     viewLifecycleOwner.lifecycleScope.launch(triggerExceptionHandler) {
+                        ServerPreferences(requireContext()).updatePreferences()
                         MutationEngine(requireContext()).triggerScan()
                         Toast.makeText(
                             requireContext(),
@@ -234,6 +235,7 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
             findPreference<Preference>("triggerGenerate")!!
                 .setOnPreferenceClickListener {
                     viewLifecycleOwner.lifecycleScope.launch(triggerExceptionHandler) {
+                        ServerPreferences(requireContext()).updatePreferences()
                         MutationEngine(requireContext()).triggerGenerate()
                         Toast.makeText(
                             requireContext(),

--- a/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
@@ -60,6 +60,7 @@ class ServerPreferences(private val context: Context) {
      */
     fun updatePreferences(config: ConfigurationQuery.Data) {
         val serverVersion = Version.tryFromString(config.version.version)
+        Log.i(TAG, "updatePreferences for server version $serverVersion")
 
         val companionPluginVersion =
             config.plugins?.firstOrNull { it.id == CompanionPlugin.PLUGIN_ID }?.version
@@ -84,79 +85,49 @@ class ServerPreferences(private val context: Context) {
                         putBoolean(PREF_TRACK_ACTIVITY, false)
                     }
                 }
-                ui.getCaseInsensitive(PREF_MINIMUM_PLAY_PERCENT)?.let {
-                    try {
-                        putInt(PREF_MINIMUM_PLAY_PERCENT, it.toString().toInt())
-                    } catch (ex: NumberFormatException) {
-                        Log.w(TAG, "$PREF_MINIMUM_PLAY_PERCENT is not an integer: '$it'")
-                    }
+                val minPlayPercent = ui.getCaseInsensitive(PREF_MINIMUM_PLAY_PERCENT)
+                try {
+                    putInt(PREF_MINIMUM_PLAY_PERCENT, minPlayPercent?.toString()?.toInt() ?: 20)
+                } catch (ex: NumberFormatException) {
+                    Log.w(TAG, "$PREF_MINIMUM_PLAY_PERCENT is not an integer: '$minPlayPercent'")
                 }
+
                 val ratingSystemOptionsRaw = ui.getCaseInsensitive("ratingSystemOptions")
-                if (ratingSystemOptionsRaw != null) {
-                    try {
-                        val ratingSystemOptions = ratingSystemOptionsRaw as Map<String, String>
-                        val type = ratingSystemOptions.getCaseInsensitive("type") ?: "stars"
-                        val starPrecision =
-                            when (
-                                ratingSystemOptions.getCaseInsensitive("starPrecision")
-                                    ?.lowercase()
-                            ) {
-                                "full" -> 1.0f
-                                "half" -> 0.5f
-                                "quarter" -> 0.25f
-                                "tenth" -> 0.1f
-                                else -> null
-                            }
-                        putString(PREF_RATING_TYPE, type)
-                        if (starPrecision != null) {
-                            putFloat(PREF_RATING_PRECISION, starPrecision)
+
+                try {
+                    val ratingSystemOptions = ratingSystemOptionsRaw as Map<String, String>?
+                    val type = ratingSystemOptions?.getCaseInsensitive("type") ?: "stars"
+                    val starPrecision =
+                        when (
+                            ratingSystemOptions?.getCaseInsensitive("starPrecision")?.lowercase()
+                        ) {
+                            "full" -> 1.0f
+                            "half" -> 0.5f
+                            "quarter" -> 0.25f
+                            "tenth" -> 0.1f
+                            else -> 0.5f
                         }
-                    } catch (ex: Exception) {
-                        Log.e(
-                            TAG,
-                            "Exception parsing ratingSystemOptions: $ratingSystemOptionsRaw",
-                        )
-                    }
+                    putString(PREF_RATING_TYPE, type)
+                    putFloat(PREF_RATING_PRECISION, starPrecision)
+                } catch (ex: Exception) {
+                    Log.e(
+                        TAG,
+                        "Exception parsing ratingSystemOptions: $ratingSystemOptionsRaw",
+                    )
                 }
 
                 val alwaysStartFromBeginning = ui.getCaseInsensitive("alwaysStartFromBeginning")
-                if (alwaysStartFromBeginning != null) {
-                    putBoolean(
-                        PREF_ALWAYS_START_BEGINNING,
-                        alwaysStartFromBeginning.toString().toBoolean(),
-                    )
-                }
+                putBoolean(
+                    PREF_ALWAYS_START_BEGINNING,
+                    alwaysStartFromBeginning?.toString()?.toBoolean() ?: false,
+                )
 
-                val scan = config.configuration.defaults.scan
-                if (scan != null) {
-                    putBoolean(PREF_SCAN_GENERATE_COVERS, scan.scanGenerateCovers)
-                    putBoolean(PREF_SCAN_GENERATE_PREVIEWS, scan.scanGeneratePreviews)
-                    putBoolean(PREF_SCAN_GENERATE_IMAGE_PREVIEWS, scan.scanGenerateImagePreviews)
-                    putBoolean(PREF_SCAN_GENERATE_SPRITES, scan.scanGenerateSprites)
-                    putBoolean(PREF_SCAN_GENERATE_PHASHES, scan.scanGeneratePhashes)
-                    putBoolean(PREF_SCAN_GENERATE_THUMBNAILS, scan.scanGenerateThumbnails)
-                    putBoolean(PREF_SCAN_GENERATE_CLIP_PREVIEWS, scan.scanGenerateClipPreviews)
-                }
-
-                val generate = config.configuration.defaults.generate
-                if (generate != null) {
-                    putBoolean(PREF_GEN_CLIP_PREVIEWS, generate.clipPreviews ?: false)
-                    putBoolean(PREF_GEN_COVERS, generate.covers ?: false)
-                    putBoolean(PREF_GEN_IMAGE_PREVIEWS, generate.imagePreviews ?: false)
-                    putBoolean(
-                        PREF_GEN_INTERACTIVE_HEATMAPS_SPEEDS,
-                        generate.interactiveHeatmapsSpeeds ?: false,
-                    )
-                    putBoolean(
-                        PREF_GEN_MARKER_IMAGE_PREVIEWS,
-                        generate.markerImagePreviews ?: false,
-                    )
-                    putBoolean(PREF_GEN_MARKERS, generate.markers ?: false)
-                    putBoolean(PREF_GEN_MARKER_SCREENSHOTS, generate.markerScreenshots ?: false)
-                    putBoolean(PREF_GEN_PHASHES, generate.phashes ?: false)
-                    putBoolean(PREF_GEN_PREVIEWS, generate.previews ?: false)
-                    putBoolean(PREF_GEN_SPRITES, generate.sprites ?: false)
-                    putBoolean(PREF_GEN_TRANSCODES, generate.transcodes ?: false)
+                val taskDefaults = ui.getCaseInsensitive("taskDefaults") as Map<String, *>?
+                try {
+                    parseScan(config.configuration.defaults.scan, taskDefaults).invoke(this)
+                    parseGenerate(config.configuration.defaults.generate, taskDefaults).invoke(this)
+                } catch (ex: Exception) {
+                    Log.e(TAG, "Exception during scan/generate parsing", ex)
                 }
 
                 val menuItems =
@@ -169,6 +140,124 @@ class ServerPreferences(private val context: Context) {
                 )
             }
         }
+    }
+
+    private fun parseScan(
+        defaultScan: ConfigurationQuery.Scan?,
+        uiTaskDefaults: Map<String, *>?,
+    ): SharedPreferences.Editor.() -> Unit {
+        return {
+            val scan = uiTaskDefaults?.getCaseInsensitive("scan") as Map<String, *>?
+            putBoolean(
+                PREF_SCAN_GENERATE_COVERS,
+                scan.getBoolean("scanGenerateCovers", defaultScan?.scanGenerateCovers, false),
+            )
+            putBoolean(
+                PREF_SCAN_GENERATE_PREVIEWS,
+                scan.getBoolean("scanGeneratePreviews", defaultScan?.scanGeneratePreviews, false),
+            )
+            putBoolean(
+                PREF_SCAN_GENERATE_IMAGE_PREVIEWS,
+                scan.getBoolean(
+                    "scanGenerateImagePreviews",
+                    defaultScan?.scanGenerateImagePreviews,
+                    false,
+                ),
+            )
+            putBoolean(
+                PREF_SCAN_GENERATE_SPRITES,
+                scan.getBoolean("scanGenerateSprites", defaultScan?.scanGenerateSprites, false),
+            )
+            putBoolean(
+                PREF_SCAN_GENERATE_PHASHES,
+                scan.getBoolean("scanGeneratePhashes", defaultScan?.scanGeneratePhashes, false),
+            )
+            putBoolean(
+                PREF_SCAN_GENERATE_THUMBNAILS,
+                scan.getBoolean(
+                    "scanGenerateThumbnails",
+                    defaultScan?.scanGenerateThumbnails,
+                    false,
+                ),
+            )
+            putBoolean(
+                PREF_SCAN_GENERATE_CLIP_PREVIEWS,
+                scan.getBoolean(
+                    "scanGenerateClipPreviews",
+                    defaultScan?.scanGenerateClipPreviews,
+                    false,
+                ),
+            )
+        }
+    }
+
+    private fun parseGenerate(
+        defaultGenerate: ConfigurationQuery.Generate?,
+        uiTaskDefaults: Map<String, *>?,
+    ): SharedPreferences.Editor.() -> Unit {
+        return {
+            val generate = uiTaskDefaults?.getCaseInsensitive("generate") as Map<String, *>?
+            putBoolean(
+                PREF_GEN_CLIP_PREVIEWS,
+                generate.getBoolean("clipPreviews", defaultGenerate?.clipPreviews, false),
+            )
+            putBoolean(
+                PREF_GEN_COVERS,
+                generate.getBoolean("covers", defaultGenerate?.covers, false),
+            )
+            putBoolean(
+                PREF_GEN_IMAGE_PREVIEWS,
+                generate.getBoolean("imagePreviews", defaultGenerate?.imagePreviews, false),
+            )
+            putBoolean(
+                PREF_GEN_INTERACTIVE_HEATMAPS_SPEEDS,
+                generate.getBoolean(
+                    "interactiveHeatmapsSpeeds",
+                    defaultGenerate?.interactiveHeatmapsSpeeds,
+                    false,
+                ),
+            )
+            putBoolean(
+                PREF_GEN_MARKER_IMAGE_PREVIEWS,
+                generate.getBoolean(
+                    "markerImagePreviews",
+                    defaultGenerate?.markerImagePreviews,
+                    false,
+                ),
+            )
+            putBoolean(
+                PREF_GEN_MARKERS,
+                generate.getBoolean("markers", defaultGenerate?.markers, false),
+            )
+            putBoolean(
+                PREF_GEN_MARKER_SCREENSHOTS,
+                generate.getBoolean("markerScreenshots", defaultGenerate?.markerScreenshots, false),
+            )
+            putBoolean(
+                PREF_GEN_PHASHES,
+                generate.getBoolean("phashes", defaultGenerate?.phashes, false),
+            )
+            putBoolean(
+                PREF_GEN_PREVIEWS,
+                generate.getBoolean("previews", defaultGenerate?.previews, false),
+            )
+            putBoolean(
+                PREF_GEN_SPRITES,
+                generate.getBoolean("sprites", defaultGenerate?.sprites, false),
+            )
+            putBoolean(
+                PREF_GEN_TRANSCODES,
+                generate.getBoolean("transcodes", defaultGenerate?.transcodes, false),
+            )
+        }
+    }
+
+    private fun Map<String, *>?.getBoolean(
+        key: String,
+        defaultsValue: Boolean?,
+        default: Boolean,
+    ): Boolean {
+        return this?.getCaseInsensitive(key)?.toString()?.toBoolean() ?: defaultsValue ?: default
     }
 
     companion object {


### PR DESCRIPTION
Fixes #380

Uses `configuration.ui.taskDefaults` falling back to `configuration.defaults` for triggering the generate or scan tasks in settings.

Also this PR helps ensure all server preferences are replaced when switching servers.