### PR TITLE
Refactor query/mutation engines for Apollo 4

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/QueryEngine.kt
@@ -2,15 +2,11 @@ package com.github.damontecres.stashapp.util
 
 import android.content.Context
 import android.util.Log
-import android.widget.Toast
 import com.apollographql.apollo.ApolloCall
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.api.Query
-import com.apollographql.apollo.exception.ApolloException
-import com.apollographql.apollo.exception.ApolloHttpException
-import com.apollographql.apollo.exception.ApolloNetworkException
 import com.github.damontecres.stashapp.api.ConfigurationQuery
 import com.github.damontecres.stashapp.api.FindDefaultFilterQuery
 import com.github.damontecres.stashapp.api.FindGalleriesQuery
@@ -65,46 +61,33 @@ import kotlin.time.toDuration
  *
  * @param context
  * @param showToasts show a toast when errors occur
- * @param lock an optional lock, when if shared with [MutationEngine], can prevent race conditions
  */
 class QueryEngine(
-    private val context: Context,
-    private val showToasts: Boolean = false,
-) {
-    private val serverVersion = ServerPreferences(context).serverVersion
-    private val client = StashClient.getApolloClient(context)
-
+    context: Context,
+    showToasts: Boolean = false,
+) : StashEngine(context, showToasts) {
     private suspend fun <D : Operation.Data> executeQuery(query: ApolloCall<D>): ApolloResponse<D> =
         withContext(Dispatchers.IO) {
             val queryName = query.operation.name()
             val id = QUERY_ID.getAndIncrement()
             Log.v(TAG, "executeQuery $id $queryName")
-            try {
-                val response = query.executeV3()
-                if (response.errors.isNullOrEmpty()) {
-                    Log.v(TAG, "executeQuery $id $queryName successful")
-                    return@withContext response
-                } else {
-                    val errorMsgs = response.errors!!.joinToString("\n") { it.message }
-                    showToast("${response.errors!!.size} errors in response ($queryName)\n$errorMsgs")
-                    Log.e(TAG, "Errors in $id $queryName: ${response.errors}")
-                    throw QueryException(
-                        id,
-                        "($queryName), ${response.errors!!.size} errors in graphql response",
-                    )
+
+            val response = query.execute()
+            if (response.data != null) {
+                Log.v(TAG, "executeQuery $id $queryName successful")
+                return@withContext response
+            } else if (response.exception != null) {
+                throw createException(id, queryName, response.exception!!) { id, msg, ex ->
+                    QueryException(id, msg, ex)
                 }
-            } catch (ex: ApolloNetworkException) {
-                showToast("Network error ($queryName). Message: ${ex.message}, ${ex.cause?.message}")
-                Log.e(TAG, "Network error in $id $queryName", ex)
-                throw QueryException(id, "Network error ($queryName)", ex)
-            } catch (ex: ApolloHttpException) {
-                showToast("HTTP error ($queryName). Status=${ex.statusCode}, Msg=${ex.message}, ${ex.cause?.message}")
-                Log.e(TAG, "HTTP ${ex.statusCode} error in $id $queryName", ex)
-                throw QueryException(id, "HTTP ${ex.statusCode} ($queryName)", ex)
-            } catch (ex: ApolloException) {
-                showToast("Server query error ($queryName). Msg=${ex.message}, ${ex.cause?.message}")
-                Log.e(TAG, "ApolloException in $id $queryName", ex)
-                throw QueryException(id, "Apollo exception ($queryName)", ex)
+            } else {
+                val errorMsgs = response.errors!!.joinToString("\n") { it.message }
+                showToast("${response.errors!!.size} errors in response ($queryName)\n$errorMsgs")
+                Log.e(TAG, "Errors in $id $queryName: ${response.errors}")
+                throw QueryException(
+                    id,
+                    "($queryName), ${response.errors!!.size} errors in graphql response",
+                )
             }
         }
 
@@ -236,7 +219,7 @@ class QueryEngine(
 
     suspend fun getMovie(movieId: String): MovieData? {
         val query = client.query(FindMovieQuery(movieId))
-        return query.executeV3().data?.findMovie?.movieData
+        return executeQuery(query).data?.findMovie?.movieData
     }
 
     suspend fun findMarkers(
@@ -391,21 +374,13 @@ class QueryEngine(
         }
     }
 
-    private suspend fun showToast(message: String) {
-        if (showToasts) {
-            withContext(Dispatchers.Main) {
-                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
-            }
-        }
-    }
-
     companion object {
-        const val TAG = "QueryEngine"
+        private const val TAG = "QueryEngine"
 
         private val QUERY_ID = AtomicInteger(0)
     }
 
-    open class QueryException(val id: Int, msg: String? = null, cause: ApolloException? = null) :
+    open class QueryException(val id: Int, msg: String? = null, cause: Exception? = null) :
         RuntimeException(msg, cause)
 
     class StashNotConfiguredException : RuntimeException()

--- a/app/src/main/java/com/github/damontecres/stashapp/util/StashEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/StashEngine.kt
@@ -1,0 +1,64 @@
+package com.github.damontecres.stashapp.util
+
+import android.content.Context
+import android.util.Log
+import android.widget.Toast
+import com.apollographql.apollo.exception.ApolloException
+import com.apollographql.apollo.exception.ApolloHttpException
+import com.apollographql.apollo.exception.ApolloNetworkException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+abstract class StashEngine(
+    private val context: Context,
+    private val showToasts: Boolean = false,
+) {
+    protected val serverPreferences = ServerPreferences(context)
+    protected val serverVersion = serverPreferences.serverVersion
+    protected val client = StashClient.getApolloClient(context)
+
+    protected suspend fun <T : Exception> createException(
+        id: Int,
+        queryName: String,
+        ex: Exception,
+        rethrow: (Int, String, Exception) -> T,
+    ): T {
+        return when (ex) {
+            is ApolloNetworkException -> {
+                showToast("Network error ($queryName). Message: ${ex.message}, ${ex.cause?.message}")
+                Log.e(TAG, "Network error in $id $queryName", ex)
+                rethrow(id, "Network error ($queryName)", ex)
+            }
+
+            is ApolloHttpException -> {
+                showToast("HTTP error ($queryName). Status=${ex.statusCode}, Msg=${ex.message}, ${ex.cause?.message}")
+                Log.e(TAG, "HTTP ${ex.statusCode} error in $id $queryName", ex)
+                rethrow(id, "HTTP ${ex.statusCode} ($queryName)", ex)
+            }
+
+            is ApolloException -> {
+                showToast("Server query error ($queryName). Msg=${ex.message}, ${ex.cause?.message}")
+                Log.e(TAG, "ApolloException in $id $queryName", ex)
+                rethrow(id, "Apollo exception ($queryName)", ex)
+            }
+
+            else -> {
+                showToast("Error ($queryName). Msg=${ex.message}, ${ex.cause?.message}")
+                Log.e(TAG, "Error in $id $queryName", ex)
+                rethrow(id, "Apollo exception ($queryName)", ex)
+            }
+        }
+    }
+
+    protected suspend fun showToast(message: String) {
+        if (showToasts) {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "StashEngine"
+    }
+}


### PR DESCRIPTION
Follow up to #399 to finish the migration to Apollo 4.

Also refactors `QueryEngine` & `MutationEngine` to use a parent class with shared functions.