### PR TITLE
Migrate test connection to apollo 4

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/util/plugin/CrashReportSenderFactory.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/plugin/CrashReportSenderFactory.kt
@@ -40,8 +40,10 @@ class CrashReportSenderFactory : ReportSenderFactory {
                         args_map = mapOf(CompanionPlugin.CRASH_TASK_NAME to errorContent.toJSON()),
                     )
                 runBlocking {
-                    val response = client.mutation(mutation).executeV3()
-                    if (response.hasErrors()) {
+                    val response = client.mutation(mutation).execute()
+                    if (response.exception != null) {
+                        throw ReportSenderException("Exception", response.exception!!)
+                    } else if (response.hasErrors()) {
                         throw ReportSenderException(response.errors.toString())
                     }
                 }


### PR DESCRIPTION
Missed updating `testStashConnection` and the crash reporting to use Apollo 4 functions in #409, so this PR fixes those two functions.