### PR TITLE
Fixes duplicated tabs when restoring activity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,7 +150,6 @@ dependencies {
     implementation("androidx.leanback:leanback-tab:1.1.0-beta01")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.test.ext:junit-ktx:1.2.1")
-    implementation("androidx.viewpager2:viewpager2:1.1.0")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     ksp("com.github.bumptech.glide:ksp:$glideVersion")
     implementation("com.caverock:androidsvg-aar:1.4")

--- a/app/src/main/java/com/github/damontecres/stashapp/DataTypeActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/DataTypeActivity.kt
@@ -12,18 +12,20 @@ import com.github.damontecres.stashapp.util.getDataType
 class DataTypeActivity : FragmentActivity(R.layout.activity_main) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val dataType = intent.getDataType()
-        val fragment =
-            when (dataType) {
-                DataType.TAG -> TagFragment()
-                DataType.MOVIE -> MovieFragment()
-                DataType.PERFORMER -> PerformerFragment()
-                DataType.STUDIO -> StudioFragment()
-                DataType.GALLERY -> GalleryFragment()
-                else -> throw IllegalArgumentException(dataType.name)
+        if (savedInstanceState == null) {
+            val dataType = intent.getDataType()
+            val fragment =
+                when (dataType) {
+                    DataType.TAG -> TagFragment()
+                    DataType.MOVIE -> MovieFragment()
+                    DataType.PERFORMER -> PerformerFragment()
+                    DataType.STUDIO -> StudioFragment()
+                    DataType.GALLERY -> GalleryFragment()
+                    else -> throw IllegalArgumentException(dataType.name)
+                }
+            supportFragmentManager.commit {
+                replace(android.R.id.content, fragment)
             }
-        supportFragmentManager.commit {
-            add(android.R.id.content, fragment)
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/StashFragmentPagerAdapter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/StashFragmentPagerAdapter.kt
@@ -1,42 +1,40 @@
 package com.github.damontecres.stashapp.util
 
+import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
-import androidx.leanback.widget.SparseArrayObjectAdapter
 import com.github.damontecres.stashapp.StashApplication
 import com.github.damontecres.stashapp.data.DataType
 
-abstract class StashFragmentPagerAdapter(private val items: List<PagerEntry>, fm: FragmentManager) :
-    FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
-    private val fragments = SparseArrayObjectAdapter()
+abstract class StashFragmentPagerAdapter(
+    private val items: List<PagerEntry>,
+    fm: FragmentManager,
+) : FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+    var fragmentCreatedListener: ((Fragment, Int) -> Unit)? = null
 
     override fun getCount(): Int {
         return items.size
     }
 
     override fun getItem(position: Int): Fragment {
-        val fragment = fragments.lookup(position) as Fragment?
-        if (fragment != null) {
-            return fragment
-        } else {
-            val newFragment = getFragment(position)
-            fragments.set(position, newFragment)
-            return newFragment
-        }
+        val newFragment = getFragment(position)
+        Log.v(TAG, "newFragment for $position")
+        fragmentCreatedListener?.invoke(newFragment, position)
+        return newFragment
     }
 
     override fun getPageTitle(position: Int): CharSequence {
         return items[position].title
     }
 
-    fun getItems(): List<Fragment> {
-        return (0..<count).map(::getItem)
-    }
-
     abstract fun getFragment(position: Int): Fragment
 
     data class PagerEntry(val title: String, val dataType: DataType?) {
         constructor(dataType: DataType) : this(StashApplication.getApplication().getString(dataType.pluralStringId), dataType)
+    }
+
+    companion object {
+        private const val TAG = "StashFragmentPagerAdapter"
     }
 }


### PR DESCRIPTION
If a `DataTypeActivity` is stopped/destroyed and returned to, it would both restore the tab state and add another set. This would cause two layers of tabs showing.

This PR fixes that and also cleans up some of the code.