### PR TITLE
Fixes a crash when clicking an image on the main page

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/GalleryFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/GalleryFragment.kt
@@ -35,7 +35,7 @@ import com.github.damontecres.stashapp.util.StashFragmentPagerAdapter
 import com.github.damontecres.stashapp.util.StashGlide
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
-import com.github.damontecres.stashapp.util.putExtra
+import com.github.damontecres.stashapp.util.putFilterArgs
 import com.github.damontecres.stashapp.util.showSetRatingToast
 import com.github.damontecres.stashapp.views.StashOnFocusChangeListener
 import com.github.damontecres.stashapp.views.StashRatingBar
@@ -251,7 +251,7 @@ class GalleryFragment : TabbedFragment() {
                         )
                     val intent =
                         Intent(requireContext(), FilterListActivity::class.java)
-                            .putExtra(FilterListActivity.INTENT_FILTER_ARGS, filterArgs)
+                            .putFilterArgs(FilterListActivity.INTENT_FILTER_ARGS, filterArgs)
                     requireContext().startActivity(intent)
                 }
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/MainFragment.kt
@@ -3,7 +3,6 @@ package com.github.damontecres.stashapp
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import android.util.SparseArray
 import android.view.View
 import android.widget.Toast
 import androidx.core.content.ContextCompat
@@ -50,7 +49,7 @@ class MainFragment : BrowseSupportFragment() {
 
     private val rowsAdapter = SparseArrayObjectAdapter(ListRowPresenter())
     private val adapters = ArrayList<ArrayObjectAdapter>()
-    private val filterList = SparseArray<FilterArgs>()
+    private val filterList = ArrayList<FilterArgs>()
     private lateinit var mBackgroundManager: BackgroundManager
 
     @Volatile
@@ -206,15 +205,13 @@ class MainFragment : BrowseSupportFragment() {
                     OnImageFilterClickedListener(requireContext()) { image: ImageData ->
                         val position = getCurrentPosition()
                         if (position != null) {
-                            val filter = filterList.get(position.row)
-                            if (filter != null) {
-                                return@OnImageFilterClickedListener OnImageFilterClickedListener.FilterPosition(
-                                    filter,
-                                    position.column,
-                                )
-                            }
+                            val filter = filterList[position.row]
+                            return@OnImageFilterClickedListener OnImageFilterClickedListener.FilterPosition(
+                                filter,
+                                position.column,
+                            )
                         }
-                        OnImageFilterClickedListener.FilterPosition(null, null)
+                        null
                     },
                 )
     }
@@ -276,7 +273,7 @@ class MainFragment : BrowseSupportFragment() {
                             job.await().let { row ->
                                 if (row.successful) {
                                     val rowData = row.data!!
-                                    filterList.set(index, rowData.filter)
+                                    filterList.add(rowData.filter)
 
                                     val adapter = ArrayObjectAdapter(StashPresenter.SELECTOR)
                                     adapter.addAll(0, rowData.data)

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
@@ -29,7 +29,7 @@ import com.github.damontecres.stashapp.presenters.TagPresenter
 import com.github.damontecres.stashapp.suppliers.DataSupplierOverride
 import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.util.StashFragmentPagerAdapter
-import com.github.damontecres.stashapp.util.putExtra
+import com.github.damontecres.stashapp.util.putFilterArgs
 import com.github.damontecres.stashapp.views.StashItemViewClickListener
 
 class PerformerFragment : TabbedFragment() {
@@ -188,7 +188,7 @@ class PerformerFragment : TabbedFragment() {
                     val name = "${performer.name} & ${item.name}"
                     val intent =
                         Intent(context, FilterListActivity::class.java)
-                            .putExtra(
+                            .putFilterArgs(
                                 FilterListActivity.INTENT_FILTER_ARGS,
                                 FilterArgs(
                                     dataType = DataType.SCENE,
@@ -237,7 +237,7 @@ class PerformerFragment : TabbedFragment() {
                     val name = "Performers with ${item.name}"
                     val intent =
                         Intent(context, FilterListActivity::class.java)
-                            .putExtra(
+                            .putFilterArgs(
                                 FilterListActivity.INTENT_FILTER_ARGS,
                                 FilterArgs(
                                     dataType = DataType.PERFORMER,

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/TagPresenter.kt
@@ -13,7 +13,7 @@ import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.util.putDataType
-import com.github.damontecres.stashapp.util.putExtra
+import com.github.damontecres.stashapp.util.putFilterArgs
 import java.util.EnumMap
 
 class TagPresenter(callback: LongClickCallBack<TagData>? = null) :
@@ -116,7 +116,7 @@ class TagPresenter(callback: LongClickCallBack<TagData>? = null) :
                     val name = context.getString(R.string.stashapp_parent_of, item.name)
                     val intent =
                         Intent(context, FilterListActivity::class.java)
-                            .putExtra(
+                            .putFilterArgs(
                                 FilterListActivity.INTENT_FILTER_ARGS,
                                 FilterArgs(
                                     dataType = DataType.TAG,
@@ -141,7 +141,7 @@ class TagPresenter(callback: LongClickCallBack<TagData>? = null) :
                     val name = context.getString(R.string.stashapp_sub_tag_of, item.name)
                     val intent =
                         Intent(context, FilterListActivity::class.java)
-                            .putExtra(
+                            .putFilterArgs(
                                 FilterListActivity.INTENT_SCROLL_NEXT_PAGE,
                                 FilterArgs(
                                     dataType = DataType.TAG,

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -756,7 +756,7 @@ fun Intent.getDataType(): DataType {
 }
 
 @OptIn(ExperimentalSerializationApi::class)
-fun Intent.putExtra(
+fun Intent.putFilterArgs(
     name: String,
     filterArgs: FilterArgs,
 ): Intent {

--- a/app/src/main/java/com/github/damontecres/stashapp/views/ImageGridClickedListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/ImageGridClickedListener.kt
@@ -6,7 +6,7 @@ import com.github.damontecres.stashapp.ImageActivity
 import com.github.damontecres.stashapp.StashGridFragment
 import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.util.maxFileSize
-import com.github.damontecres.stashapp.util.putExtra
+import com.github.damontecres.stashapp.util.putFilterArgs
 import com.github.damontecres.stashapp.views.ClassOnItemViewClickedListener.SimpleOnItemViewClickedListener
 
 class ImageGridClickedListener(val fragment: StashGridFragment) :
@@ -19,7 +19,7 @@ class ImageGridClickedListener(val fragment: StashGridFragment) :
         intent.putExtra(ImageActivity.INTENT_IMAGE_URL, item.paths.image)
         intent.putExtra(ImageActivity.INTENT_IMAGE_SIZE, item.maxFileSize)
         intent.putExtra(ImageActivity.INTENT_POSITION, position)
-        intent.putExtra(ImageActivity.INTENT_FILTER_ARGS, fragment.filterArgs)
+        intent.putFilterArgs(ImageActivity.INTENT_FILTER_ARGS, fragment.filterArgs)
         fragment.requireActivity().startActivity(intent)
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/views/MainTitleView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/MainTitleView.kt
@@ -29,7 +29,7 @@ import com.github.damontecres.stashapp.util.QueryEngine
 import com.github.damontecres.stashapp.util.ServerPreferences
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashServer
-import com.github.damontecres.stashapp.util.putExtra
+import com.github.damontecres.stashapp.util.putFilterArgs
 import kotlinx.coroutines.launch
 
 class MainTitleView(context: Context, attrs: AttributeSet) :
@@ -173,7 +173,7 @@ class MainTitleView(context: Context, attrs: AttributeSet) :
                     )
                 val intent =
                     Intent(v.context, FilterListActivity::class.java)
-                        .putExtra(FilterListActivity.INTENT_FILTER_ARGS, filterArgs)
+                        .putFilterArgs(FilterListActivity.INTENT_FILTER_ARGS, filterArgs)
                 startActivity(v.context, intent, null)
             }
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/views/OnImageFilterClickedListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/OnImageFilterClickedListener.kt
@@ -6,15 +6,15 @@ import androidx.leanback.widget.OnItemViewClickedListener
 import androidx.leanback.widget.Presenter
 import androidx.leanback.widget.Row
 import androidx.leanback.widget.RowPresenter
-import com.chrynan.parcelable.core.putExtra
 import com.github.damontecres.stashapp.ImageActivity
 import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.util.addToIntent
+import com.github.damontecres.stashapp.util.putFilterArgs
 
 class OnImageFilterClickedListener(
     private val context: Context,
-    private val callback: (ImageData) -> FilterPosition,
+    private val callback: (ImageData) -> FilterPosition?,
 ) : OnItemViewClickedListener {
     override fun onItemClicked(
         itemViewHolder: Presenter.ViewHolder?,
@@ -27,10 +27,12 @@ class OnImageFilterClickedListener(
         val filterPosition = callback(image)
         val intent = Intent(context, ImageActivity::class.java)
         image.addToIntent(intent)
-        intent.putExtra(ImageActivity.INTENT_POSITION, filterPosition.position)
-        intent.putExtra(ImageActivity.INTENT_FILTER_ARGS, filterPosition.filter)
+        if (filterPosition != null) {
+            intent.putExtra(ImageActivity.INTENT_POSITION, filterPosition.position)
+            intent.putFilterArgs(ImageActivity.INTENT_FILTER_ARGS, filterPosition.filter)
+        }
         context.startActivity(intent)
     }
 
-    data class FilterPosition(val filter: FilterArgs?, val position: Int?)
+    data class FilterPosition(val filter: FilterArgs, val position: Int)
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/views/PlayAllOnClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/PlayAllOnClickListener.kt
@@ -9,7 +9,7 @@ import com.github.damontecres.stashapp.data.SortAndDirection
 import com.github.damontecres.stashapp.playback.PlaylistActivity
 import com.github.damontecres.stashapp.playback.PlaylistMarkersFragment
 import com.github.damontecres.stashapp.suppliers.FilterArgs
-import com.github.damontecres.stashapp.util.putExtra
+import com.github.damontecres.stashapp.util.putFilterArgs
 
 class PlayAllOnClickListener(
     private val context: Context,
@@ -29,7 +29,7 @@ class PlayAllOnClickListener(
                             else -> 30_000L
                         }
                     val intent = Intent(context, PlaylistActivity::class.java)
-                    intent.putExtra(PlaylistActivity.INTENT_FILTER, getFilter())
+                    intent.putFilterArgs(PlaylistActivity.INTENT_FILTER, getFilter())
                     intent.putExtra(PlaylistMarkersFragment.INTENT_DURATION_ID, duration)
                     context.startActivity(intent)
                 }
@@ -44,7 +44,7 @@ class PlayAllOnClickListener(
                             else -> throw IllegalStateException("$it")
                         }
                     val intent = Intent(context, PlaylistActivity::class.java)
-                    intent.putExtra(PlaylistActivity.INTENT_FILTER, filter)
+                    intent.putFilterArgs(PlaylistActivity.INTENT_FILTER, filter)
                     context.startActivity(intent)
                 }
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/views/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/StashItemViewClickListener.kt
@@ -32,7 +32,7 @@ import com.github.damontecres.stashapp.playback.PlaybackActivity
 import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.util.addToIntent
 import com.github.damontecres.stashapp.util.putDataType
-import com.github.damontecres.stashapp.util.putExtra
+import com.github.damontecres.stashapp.util.putFilterArgs
 
 /**
  * A OnItemViewClickedListener that starts activities for scenes, performers, etc
@@ -98,7 +98,7 @@ class StashItemViewClickListener(
         } else if (item is FilterArgs) {
             val intent =
                 Intent(context, FilterListActivity::class.java)
-                    .putExtra(FilterListActivity.INTENT_FILTER_ARGS, item)
+                    .putFilterArgs(FilterListActivity.INTENT_FILTER_ARGS, item)
                     .putExtra(FilterListActivity.INTENT_SCROLL_NEXT_PAGE, true)
             context.startActivity(intent)
         } else if (item is StashAction) {


### PR DESCRIPTION
From #399, the filter wasn't not serialized correctly when clicking on an image on the main page which caused a crash.

Also renamed the extension function for adding a filter to an `Intent`.