### PR TITLE
Bug fixes when playing scenes without files in playlist mode

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistActivity.kt
@@ -22,7 +22,7 @@ class PlaylistActivity : FragmentActivity() {
         if (savedInstanceState == null) {
             val filter = intent.getFilterArgs(INTENT_FILTER)!!
             Log.v(TAG, "filter=${filter.sortAndDirection}")
-            viewModel.filterArgs.value = filter
+            viewModel.setFilter(filter)
             fragment =
                 when (filter.dataType) {
                     DataType.MARKER -> PlaylistMarkersFragment()

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistFragment.kt
@@ -152,16 +152,12 @@ abstract class PlaylistFragment<T : Query.Data, D : StashData, C : Query.Data> :
         Log.v(TAG, "Fetching page #$page")
         val newItems = pagingSource.fetchPage(page, PAGE_SIZE)
         val mediaItems =
-            newItems.mapNotNull { item ->
+            newItems.map { item ->
                 val scene = convertToScene(item)
-                if (scene.streams.isEmpty()) {
-                    null
-                } else {
-                    val streamDecision = getStreamDecision(requireContext(), scene)
-                    buildMediaItem(requireContext(), streamDecision, scene) {
-                        builderCallback(item)?.invoke(this)
-                        setTag(MediaItemTag(scene, streamDecision))
-                    }
+                val streamDecision = getStreamDecision(requireContext(), scene)
+                buildMediaItem(requireContext(), streamDecision, scene) {
+                    builderCallback(item)?.invoke(this)
+                    setTag(MediaItemTag(scene, streamDecision))
                 }
             }
         Log.v(TAG, "Got ${mediaItems.size} media items")

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistViewModel.kt
@@ -1,9 +1,41 @@
 package com.github.damontecres.stashapp.playback
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.apollographql.apollo.api.Optional
+import com.github.damontecres.stashapp.api.type.CriterionModifier
+import com.github.damontecres.stashapp.api.type.IntCriterionInput
+import com.github.damontecres.stashapp.api.type.SceneFilterType
+import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.suppliers.FilterArgs
 
 class PlaylistViewModel : ViewModel() {
-    val filterArgs = MutableLiveData<FilterArgs>()
+    private val _filterArgs = MutableLiveData<FilterArgs>()
+    val filterArgs: LiveData<FilterArgs> = _filterArgs
+
+    fun setFilter(filter: FilterArgs) {
+        if (filter.dataType == DataType.SCENE) {
+            val objectFilter = filter.objectFilter as SceneFilterType? ?: SceneFilterType()
+            val newObjectFilter =
+                if (objectFilter.file_count.getOrNull() == null) {
+                    // Playlist cannot contain scenes with no files, so modify the filter if necessary
+                    objectFilter.copy(
+                        file_count =
+                            Optional.present(
+                                IntCriterionInput(
+                                    modifier = CriterionModifier.GREATER_THAN,
+                                    value = 0,
+                                ),
+                            ),
+                    )
+                } else {
+                    // TODO it is possible the filter includes scenes without a file which will crash
+                    objectFilter
+                }
+            _filterArgs.value = filter.copy(objectFilter = newObjectFilter)
+        } else {
+            _filterArgs.value = filter
+        }
+    }
 }


### PR DESCRIPTION
Fixes several bugs when using "Play All" and the filter includes scenes that have no files (eg cannot be played) where duplicate scenes would be added to the playlist and the playlist list clicks would play the wrong item.

Also fixes a possible race condition if you click next very, very fast where duplicate scenes could be added to the playlist.