### PR TITLE
Fix a couple default filter bugs for the top nav buttons

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
@@ -57,7 +57,7 @@ enum class DataType(
         R.string.stashapp_scene,
         R.string.stashapp_scenes,
         R.string.fa_circle_play,
-        SortAndDirection(SortOption.DATE, SortDirectionEnum.DESC),
+        SortAndDirection.PATH_ASC,
         SortOption.SCENE_SORT_OPTIONS,
     ),
     GROUP(
@@ -66,14 +66,14 @@ enum class DataType(
         R.string.stashapp_groups,
         R.string.fa_film,
         SortAndDirection.NAME_ASC,
-        SortOption.MOVIE_SORT_OPTIONS,
+        SortOption.GROUP_SORT_OPTIONS,
     ),
     MARKER(
         FilterMode.SCENE_MARKERS,
         R.string.stashapp_markers,
         R.string.stashapp_markers,
         R.string.fa_location_dot,
-        SortAndDirection(SortOption.CREATED_AT, SortDirectionEnum.DESC),
+        SortAndDirection(SortOption.TITLE, SortDirectionEnum.ASC),
         SortOption.MARKER_SORT_OPTIONS,
     ),
     PERFORMER(

--- a/app/src/main/java/com/github/damontecres/stashapp/data/SortOption.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/SortOption.kt
@@ -140,7 +140,7 @@ enum class SortOption(
                 TITLE,
             )
 
-        val MOVIE_SORT_OPTIONS =
+        val GROUP_SORT_OPTIONS =
             listOf(
                 *COMMON_SORT_OPTIONS,
                 DATE,

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -302,7 +302,7 @@ fun <V> Map<*, V>.getCaseInsensitive(k: String?): V? {
     if (k == null) {
         return null
     }
-    return this[k] ?: this[k.lowercase()]
+    return this[k] ?: this[k.lowercase()] ?: this[k.uppercase()]
 }
 
 fun TextView.enableMarquee(selected: Boolean = false) {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/ServerPreferences.kt
@@ -146,19 +146,17 @@ class ServerPreferences(val server: StashServer) {
                 )
 
                 val defaultFilters = ui.getCaseInsensitive("defaultFilters")
-                defaultFilters?.let { refreshDefaultFilters(it as Map<String, *>) }
+                refreshDefaultFilters(defaultFilters as Map<String, *>?)
             }
         }
     }
 
-    private fun refreshDefaultFilters(defaultFilters: Map<String, *>) {
+    private fun refreshDefaultFilters(defaultFilters: Map<String, *>?) {
         val filterParser = FilterParser(serverVersion)
 
         DataType.entries.forEach { dataType ->
             val filterMap =
-                defaultFilters.getCaseInsensitive(
-                    StashApplication.getApplication().getString(dataType.pluralStringId),
-                ) as Map<String, *>?
+                defaultFilters?.getCaseInsensitive(dataType.filterMode.name) as Map<String, *>?
             val filter =
                 if (filterMap != null) {
                     try {


### PR DESCRIPTION
Fixes #432

Always set default filters even if the user's UI configuration contains none. Also fixes a bug where the scene marker default filter was ignored.

Always updates the fallback sorting for a few data types to be more consistent with the server.