### PR TITLE
Refactor graphql queries to use 'slim' data to reduce server-side SQL queries

### DIFF
--- a/app/src/main/graphql/FindGalleries.graphql
+++ b/app/src/main/graphql/FindGalleries.graphql
@@ -19,6 +19,24 @@ query FindGallery($id: ID!) {
   }
 }
 
+query FindGalleryPerformers($id: ID!) {
+  findGallery(id: $id) {
+    id
+    performers {
+      ...PerformerData
+    }
+  }
+}
+
+query FindGalleryTags($id: ID!) {
+  findGallery(id: $id) {
+    id
+    tags {
+      ...TagData
+    }
+  }
+}
+
 fragment GalleryData on Gallery {
   id
   title
@@ -37,10 +55,10 @@ fragment GalleryData on Gallery {
     path
   }
   performers {
-    ...PerformerData
+    ...SlimPerformerData
   }
   tags {
-    ...TagData
+    ...SlimTagData
   }
   studio {
     id

--- a/app/src/main/graphql/FindImages.graphql
+++ b/app/src/main/graphql/FindImages.graphql
@@ -44,7 +44,8 @@ fragment ImageData on Image {
     id
   }
   studio {
-    ...StudioData
+    id
+    name
   }
   tags {
     id
@@ -85,5 +86,8 @@ fragment ExtraImageData on Image {
   }
   galleries {
     ...GalleryData
+  }
+  studio {
+    ...StudioData
   }
 }

--- a/app/src/main/graphql/FindPerformers.graphql
+++ b/app/src/main/graphql/FindPerformers.graphql
@@ -93,3 +93,12 @@ fragment PerformerData on Performer {
   weight
   __typename
 }
+
+fragment SlimPerformerData on Performer {
+  id
+  name
+  disambiguation
+  gender
+  birthdate
+  __typename
+}

--- a/app/src/main/graphql/FindSceneMarkers.graphql
+++ b/app/src/main/graphql/FindSceneMarkers.graphql
@@ -15,7 +15,7 @@ query CountMarkers($filter: FindFilterType, $scene_marker_filter: SceneMarkerFil
 
 mutation UpdateMarker($input: SceneMarkerUpdateInput!){
   sceneMarkerUpdate(input: $input){
-    ...MarkerData
+    ...FullMarkerData
   }
 }
 
@@ -45,6 +45,28 @@ fragment VideoSceneData on Scene {
 }
 
 fragment MarkerData on SceneMarker {
+  id
+  title
+  created_at
+  updated_at
+  stream
+  screenshot
+  seconds
+  preview
+  primary_tag {
+    ...SlimTagData
+    __typename
+  }
+  tags {
+    ...SlimTagData
+  }
+  scene {
+    ...VideoSceneData
+  }
+  __typename
+}
+
+fragment FullMarkerData on SceneMarker {
   id
   title
   created_at

--- a/app/src/main/graphql/FindStudios.graphql
+++ b/app/src/main/graphql/FindStudios.graphql
@@ -47,15 +47,15 @@ fragment StudioData on Studio {
   ignore_auto_tag
   image_path
   scene_count
-  scene_count_all: scene_count(depth: -1)
+  #  scene_count_all: scene_count(depth: -1)
   image_count
-  image_count_all: image_count(depth: -1)
+  #  image_count_all: image_count(depth: -1)
   gallery_count
-  gallery_count_all: gallery_count(depth: -1)
+  #  gallery_count_all: gallery_count(depth: -1)
   performer_count
-  performer_count_all: performer_count(depth: -1)
-    group_count
-    group_count_all: group_count(depth: -1)
+  #  performer_count_all: performer_count(depth: -1)
+  group_count
+  #  group_count_all: group_count(depth: -1)
   details
   rating100
   aliases

--- a/app/src/main/graphql/SceneUpdate.graphql
+++ b/app/src/main/graphql/SceneUpdate.graphql
@@ -22,7 +22,7 @@ mutation SceneUpdate($input: SceneUpdateInput!) {
 
 mutation CreateMarker($input: SceneMarkerCreateInput!) {
   sceneMarkerCreate(input: $input) {
-    ...MarkerData
+    ...FullMarkerData
   }
 }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/SceneDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SceneDetailsFragment.kt
@@ -66,6 +66,7 @@ import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashDiffCallback
 import com.github.damontecres.stashapp.util.StashGlide
 import com.github.damontecres.stashapp.util.StashServer
+import com.github.damontecres.stashapp.util.asSlimTagData
 import com.github.damontecres.stashapp.util.asVideoSceneData
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.util.putDataType
@@ -686,9 +687,9 @@ class SceneDetailsFragment : DetailsSupportFragment() {
             screenshot = it.screenshot,
             seconds = it.seconds,
             preview = "",
-            primary_tag = MarkerData.Primary_tag("", it.primary_tag.tagData),
+            primary_tag = MarkerData.Primary_tag("", it.primary_tag.tagData.asSlimTagData),
             scene = MarkerData.Scene(sceneId, sceneData!!.asVideoSceneData),
-            tags = it.tags.map { MarkerData.Tag("", it.tagData) },
+            tags = it.tags.map { MarkerData.Tag("", it.tagData.asSlimTagData) },
             __typename = "",
         )
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/data/Marker.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/Marker.kt
@@ -22,9 +22,9 @@ data class Marker(
     ) : this(
         markerData.id,
         markerData.title,
-        markerData.tags.map { it.tagData.id },
-        markerData.primary_tag.tagData.id,
-        markerData.primary_tag.tagData.name,
+        markerData.tags.map { it.slimTagData.id },
+        markerData.primary_tag.slimTagData.id,
+        markerData.primary_tag.slimTagData.name,
         markerData.screenshot,
         markerData.seconds,
         markerData.scene.videoSceneData.id,

--- a/app/src/main/java/com/github/damontecres/stashapp/data/PlaylistItem.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/PlaylistItem.kt
@@ -22,12 +22,12 @@ data class PlaylistItem(
 fun MarkerData.toPlayListItem(index: Int): PlaylistItem {
     val name =
         title.ifBlank {
-            primary_tag.tagData.name
+            primary_tag.slimTagData.name
         }
     val details =
         buildList {
-            add(primary_tag.tagData.name)
-            addAll(tags.map { it.tagData.name })
+            add(primary_tag.slimTagData.name)
+            addAll(tags.map { it.slimTagData.name })
         }.joinNotNullOrBlank(", ")
     return PlaylistItem(
         index,

--- a/app/src/main/java/com/github/damontecres/stashapp/data/StashFindFilter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/StashFindFilter.kt
@@ -3,6 +3,7 @@ package com.github.damontecres.stashapp.data
 import com.apollographql.apollo.api.Optional
 import com.github.damontecres.stashapp.api.type.FindFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
+import com.github.damontecres.stashapp.util.presentIfNotNullOrBlank
 import kotlinx.serialization.Serializable
 
 /**
@@ -20,8 +21,8 @@ data class StashFindFilter(
         perPage: Int? = null,
     ): FindFilterType =
         FindFilterType(
-            q = Optional.presentIfNotNull(q),
-            sort = Optional.presentIfNotNull(sortAndDirection?.sortKey),
+            q = Optional.presentIfNotNullOrBlank(q),
+            sort = Optional.presentIfNotNullOrBlank(sortAndDirection?.sortKey),
             direction = Optional.presentIfNotNull(sortAndDirection?.direction),
             page = Optional.presentIfNotNull(page),
             per_page = Optional.presentIfNotNull(perPage),

--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
@@ -282,16 +282,16 @@ class ImageDetailsFragment : DetailsSupportFragment() {
                 OCounter(newImage.id, newImage.o_counter ?: 0),
             )
 
-            if (newImage.studio != null) {
-                studioAdapter.setItems(listOf(newImage.studio.studioData))
-            } else {
-                studioAdapter.clear()
-            }
             viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
                 val extraImageData = queryEngine.getImageExtra(newImage.id)
                 tagsRowManager.setItems(extraImageData?.tags?.map { it.tagData }.orEmpty())
                 performersRowManager.setItems(extraImageData?.performers?.map { it.performerData }.orEmpty())
                 galleriesRowManager.setItems(extraImageData?.galleries?.map { it.galleryData }.orEmpty())
+                if (extraImageData?.studio != null) {
+                    studioAdapter.setItems(listOf(extraImageData.studio.studioData))
+                } else {
+                    studioAdapter.clear()
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ImagePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ImagePresenter.kt
@@ -15,7 +15,7 @@ class ImagePresenter(callback: LongClickCallBack<ImageData>? = null) : StashPres
         cardView.titleText = item.title
 
         val details = mutableListOf<String?>()
-        details.add(item.studio?.studioData?.name)
+        details.add(item.studio?.name)
         details.add(item.date)
         cardView.contentText = concatIfNotBlank(" - ", details)
 

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
@@ -23,12 +23,12 @@ class MarkerPresenter(callback: LongClickCallBack<MarkerData>? = null) :
     ) {
         val title =
             item.title.ifBlank {
-                item.primary_tag.tagData.name
+                item.primary_tag.slimTagData.name
             }
         cardView.titleText = "$title - ${item.seconds.toInt().toDuration(DurationUnit.SECONDS)}"
         cardView.contentText =
             listOf(
-                if (item.title.isNotBlank()) item.primary_tag.tagData.name else null,
+                if (item.title.isNotBlank()) item.primary_tag.slimTagData.name else null,
                 item.scene.videoSceneData.titleOrFilename,
             ).joinNotNullOrBlank(" - ")
 

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/GalleryDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/GalleryDataSupplier.kt
@@ -3,7 +3,8 @@ package com.github.damontecres.stashapp.suppliers
 import com.apollographql.apollo.api.Query
 import com.github.damontecres.stashapp.api.CountGalleriesQuery
 import com.github.damontecres.stashapp.api.FindGalleriesQuery
-import com.github.damontecres.stashapp.api.FindGalleryQuery
+import com.github.damontecres.stashapp.api.FindGalleryPerformersQuery
+import com.github.damontecres.stashapp.api.FindGalleryTagsQuery
 import com.github.damontecres.stashapp.api.fragment.GalleryData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.TagData
@@ -49,53 +50,53 @@ class GalleryDataSupplier(
 }
 
 class GalleryPerformerDataSupplier(private val galleryId: String) :
-    StashPagingSource.DataSupplier<FindGalleryQuery.Data, PerformerData, FindGalleryQuery.Data> {
+    StashPagingSource.DataSupplier<FindGalleryPerformersQuery.Data, PerformerData, FindGalleryPerformersQuery.Data> {
     override val dataType: DataType
         get() = DataType.PERFORMER
 
-    override fun createQuery(filter: FindFilterType?): Query<FindGalleryQuery.Data> {
-        return FindGalleryQuery(galleryId)
+    override fun createQuery(filter: FindFilterType?): Query<FindGalleryPerformersQuery.Data> {
+        return FindGalleryPerformersQuery(galleryId)
     }
 
     override fun getDefaultFilter(): FindFilterType {
         return DataType.PERFORMER.asDefaultFindFilterType
     }
 
-    override fun createCountQuery(filter: FindFilterType?): Query<FindGalleryQuery.Data> {
-        return FindGalleryQuery(galleryId)
+    override fun createCountQuery(filter: FindFilterType?): Query<FindGalleryPerformersQuery.Data> {
+        return FindGalleryPerformersQuery(galleryId)
     }
 
-    override fun parseCountQuery(data: FindGalleryQuery.Data): Int {
-        return data.findGallery?.galleryData?.performers?.size ?: 0
+    override fun parseCountQuery(data: FindGalleryPerformersQuery.Data): Int {
+        return data.findGallery?.performers?.size ?: 0
     }
 
-    override fun parseQuery(data: FindGalleryQuery.Data): List<PerformerData> {
-        return data.findGallery?.galleryData?.performers?.map { it.performerData }.orEmpty()
+    override fun parseQuery(data: FindGalleryPerformersQuery.Data): List<PerformerData> {
+        return data.findGallery?.performers?.map { it.performerData }.orEmpty()
     }
 }
 
 class GalleryTagDataSupplier(private val galleryId: String) :
-    StashPagingSource.DataSupplier<FindGalleryQuery.Data, TagData, FindGalleryQuery.Data> {
+    StashPagingSource.DataSupplier<FindGalleryTagsQuery.Data, TagData, FindGalleryTagsQuery.Data> {
     override val dataType: DataType
         get() = DataType.TAG
 
-    override fun createQuery(filter: FindFilterType?): Query<FindGalleryQuery.Data> {
-        return FindGalleryQuery(galleryId)
+    override fun createQuery(filter: FindFilterType?): Query<FindGalleryTagsQuery.Data> {
+        return FindGalleryTagsQuery(galleryId)
     }
 
     override fun getDefaultFilter(): FindFilterType {
         return DataType.TAG.asDefaultFindFilterType
     }
 
-    override fun createCountQuery(filter: FindFilterType?): Query<FindGalleryQuery.Data> {
-        return FindGalleryQuery(galleryId)
+    override fun createCountQuery(filter: FindFilterType?): Query<FindGalleryTagsQuery.Data> {
+        return FindGalleryTagsQuery(galleryId)
     }
 
-    override fun parseCountQuery(data: FindGalleryQuery.Data): Int {
-        return data.findGallery?.galleryData?.performers?.size ?: 0
+    override fun parseCountQuery(data: FindGalleryTagsQuery.Data): Int {
+        return data.findGallery?.tags?.size ?: 0
     }
 
-    override fun parseQuery(data: FindGalleryQuery.Data): List<TagData> {
-        return data.findGallery?.galleryData?.tags?.map { it.tagData }.orEmpty()
+    override fun parseQuery(data: FindGalleryTagsQuery.Data): List<TagData> {
+        return data.findGallery?.tags?.map { it.tagData }.orEmpty()
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/StashPagingSource.kt
@@ -1,5 +1,6 @@
 package com.github.damontecres.stashapp.suppliers
 
+import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.apollographql.apollo.api.Optional
@@ -97,6 +98,7 @@ class StashPagingSource<T : Query.Data, D : StashData, S : Any, C : Query.Data>(
                     per_page = Optional.present(loadSize),
                     page = Optional.present(page),
                 )
+            Log.v(TAG, "page=$page, loadSize=$loadSize, filter=$filter")
             val query = dataSupplier.createQuery(filter)
             val queryResult = queryEngine.executeQuery(query)
             if (queryResult.data != null) {
@@ -190,6 +192,7 @@ class StashPagingSource<T : Query.Data, D : StashData, S : Any, C : Query.Data>(
     }
 
     companion object {
+        private const val TAG = "StashPagingSource"
         const val INVALID_COUNT = -1
         const val UNSUPPORTED_COUNT = -2
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -22,6 +22,7 @@ import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.Visibility
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloHttpException
 import com.bumptech.glide.load.model.GlideUrl
@@ -778,4 +779,8 @@ fun getUiTabs(
     val defaultValues = context.resources.getStringArray(defaultArrayKey).toSet()
     return PreferenceManager.getDefaultSharedPreferences(context)
         .getStringSet(context.getString(prefKey), defaultValues)!!
+}
+
+fun Optional.Companion.presentIfNotNullOrBlank(value: String?): Optional<String> {
+    return presentIfNotNull(value?.ifBlank { null })
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
@@ -27,8 +27,8 @@ import com.github.damontecres.stashapp.api.UpdateGalleryMutation
 import com.github.damontecres.stashapp.api.UpdateImageMutation
 import com.github.damontecres.stashapp.api.UpdateMarkerMutation
 import com.github.damontecres.stashapp.api.UpdatePerformerMutation
+import com.github.damontecres.stashapp.api.fragment.FullMarkerData
 import com.github.damontecres.stashapp.api.fragment.GroupData
-import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SavedFilterData
 import com.github.damontecres.stashapp.api.fragment.TagData
@@ -209,17 +209,17 @@ class MutationEngine(
         return result.data?.sceneUpdate
     }
 
-    suspend fun updateMarker(input: SceneMarkerUpdateInput): MarkerData? {
+    suspend fun updateMarker(input: SceneMarkerUpdateInput): FullMarkerData? {
         val mutation = UpdateMarkerMutation(input = input)
         val result = executeMutation(mutation)
-        return result.data?.sceneMarkerUpdate?.markerData
+        return result.data?.sceneMarkerUpdate?.fullMarkerData
     }
 
     suspend fun setTagsOnMarker(
         markerId: String,
         primaryTagId: String,
         tagIds: List<String>,
-    ): MarkerData? {
+    ): FullMarkerData? {
         Log.v(TAG, "setTagsOnMarker markerId=$markerId, primaryTagId=$primaryTagId, tagIds=$tagIds")
         return updateMarker(
             SceneMarkerUpdateInput(
@@ -286,7 +286,7 @@ class MutationEngine(
         sceneId: String,
         position: Long,
         primaryTagId: String,
-    ): MarkerData? {
+    ): FullMarkerData? {
         val input =
             SceneMarkerCreateInput(
                 title = "",
@@ -297,7 +297,7 @@ class MutationEngine(
             )
         val mutation = CreateMarkerMutation(input)
         val result = executeMutation(mutation)
-        return result.data?.sceneMarkerCreate?.markerData
+        return result.data?.sceneMarkerCreate?.fullMarkerData
     }
 
     suspend fun deleteMarker(id: String): Boolean {


### PR DESCRIPTION
Refactor some of the graphql queries to reduce the number of SQL queries needed server-side.