### PR TITLE
Fixes a crash when binding data to cards

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashPresenter.kt
@@ -58,9 +58,6 @@ abstract class StashPresenter<T>(private val callback: LongClickCallBack<T>? = n
 
             cardView.mainImageView.visibility = View.VISIBLE
             doOnBindViewHolder(viewHolder.view as StashImageCardView, item as T)
-            if (cardView.isSelected) {
-                cardView.isSelected = true
-            }
         }
     }
 


### PR DESCRIPTION
Fixes a crash introduced in #440 when binding a card view but the card hasn't been attached yet.