### PR TITLE
Improvements to filter creation & validation

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/filter/CreateFilterGuidedStepFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/CreateFilterGuidedStepFragment.kt
@@ -7,7 +7,7 @@ import com.github.damontecres.stashapp.api.type.CriterionModifier
 import com.github.damontecres.stashapp.api.type.StashDataFilter
 import com.github.damontecres.stashapp.views.getString
 
-open class CreateFilterGuidedStepFragment : GuidedStepSupportFragment() {
+abstract class CreateFilterGuidedStepFragment : GuidedStepSupportFragment() {
     protected val viewModel by activityViewModels<CreateFilterViewModel>()
 
     fun nextStep(step: GuidedStepSupportFragment) {
@@ -60,16 +60,20 @@ open class CreateFilterGuidedStepFragment : GuidedStepSupportFragment() {
     protected fun <T : Any> addStandardActions(
         actions: MutableList<GuidedAction>,
         filterOption: FilterOption<StashDataFilter, T>,
+        finishEnabled: Boolean? = null,
     ) {
+        val currVal = viewModel.getValue(filterOption)
+
         actions.add(
             GuidedAction.Builder(requireContext())
                 .id(GuidedAction.ACTION_ID_FINISH)
                 .hasNext(true)
                 .title(getString(com.github.damontecres.stashapp.R.string.stashapp_actions_save))
+                .enabled(finishEnabled ?: (currVal != null))
                 .build(),
         )
 
-        if (viewModel.getValue(filterOption) != null) {
+        if (currVal != null) {
             actions.add(
                 GuidedAction.Builder(requireContext())
                     .id(ACTION_ID_REMOVE)
@@ -89,6 +93,8 @@ open class CreateFilterGuidedStepFragment : GuidedStepSupportFragment() {
     }
 
     fun CriterionModifier.hasTwoValues(): Boolean = this == CriterionModifier.BETWEEN || this == CriterionModifier.NOT_BETWEEN
+
+    fun CriterionModifier.isNullModifier(): Boolean = this == CriterionModifier.IS_NULL || this == CriterionModifier.NOT_NULL
 
     companion object {
         const val MODIFIER_OFFSET = 3_000_000L

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/CreateFilterViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/CreateFilterViewModel.kt
@@ -1,5 +1,6 @@
 package com.github.damontecres.stashapp.filter
 
+import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -74,6 +75,7 @@ class CreateFilterViewModel : ViewModel() {
         filterOption: FilterOption<StashDataFilter, ValueType>,
         newItem: ValueType?,
     ) {
+        Log.v(TAG, "updateFilter: name=${filterOption.name}, value==null: ${newItem == null}")
         val currFilter = objectFilter.value!!
         val newFilter =
             filterOption.setter(
@@ -87,6 +89,7 @@ class CreateFilterViewModel : ViewModel() {
      * Update the [resultCount] using the current [findFilter] & [objectFilter]
      */
     fun updateCount() {
+        resultCount.value = -1
         countJob?.cancel()
         countJob =
             viewModelScope.launch(
@@ -154,5 +157,9 @@ class CreateFilterViewModel : ViewModel() {
      */
     data class NameDescription(val name: String?, val description: String?) {
         constructor(item: StashData) : this(extractTitle(item), extractDescription(item))
+    }
+
+    companion object {
+        private const val TAG = "CreateFilterViewModel"
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/picker/BooleanPickerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/picker/BooleanPickerFragment.kt
@@ -42,13 +42,15 @@ class BooleanPickerFragment(
                 .title(getString(R.string.stashapp_false))
                 .build(),
         )
-        actions.add(
-            GuidedAction.Builder(requireContext())
-                .id(2L)
-                .hasNext(true)
-                .title(getString(R.string.stashapp_actions_remove))
-                .build(),
-        )
+        if (viewModel.getValue(filterOption) != null) {
+            actions.add(
+                GuidedAction.Builder(requireContext())
+                    .id(2L)
+                    .hasNext(true)
+                    .title(getString(R.string.stashapp_actions_remove))
+                    .build(),
+            )
+        }
         actions.add(
             GuidedAction.Builder(requireContext())
                 .id(GuidedAction.ACTION_ID_CANCEL)

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/picker/CircumcisionPickerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/picker/CircumcisionPickerFragment.kt
@@ -88,21 +88,39 @@ class CircumcisionPickerFragment(val filterOption: FilterOption<StashDataFilter,
             currentModifier = CriterionModifier.entries[(action.id - MODIFIER_OFFSET).toInt()]
             findActionById(MODIFIER).description = currentModifier.getString(requireContext())
             notifyActionChanged(findActionPositionById(MODIFIER))
+            setFinish()
         }
         return true
     }
 
     override fun onGuidedActionClicked(action: GuidedAction) {
         if (action.id == GuidedAction.ACTION_ID_FINISH) {
-            val values =
-                actions.filter { it.id >= CIRC_OFFSET && it.isChecked }
-                    .map { CircumisedEnum.entries[(it.id - CIRC_OFFSET).toInt()] }
-                    .ifEmpty { null }
-            val newFilter = CircumcisionCriterionInput(value = Optional.presentIfNotNull(values), modifier = currentModifier)
+            val values = getValues()
+            val newFilter =
+                CircumcisionCriterionInput(
+                    value = Optional.presentIfNotNull(values),
+                    modifier = currentModifier,
+                )
             viewModel.updateFilter(filterOption, newFilter)
             parentFragmentManager.popBackStack()
+        } else if (action.id in CIRC_OFFSET..<MODIFIER_OFFSET) {
+            setFinish()
         } else {
             onStandardActionClicked(action, filterOption)
+        }
+    }
+
+    private fun getValues(): List<CircumisedEnum>? {
+        return actions.filter { it.id >= CIRC_OFFSET && it.isChecked }
+            .map { CircumisedEnum.entries[(it.id - CIRC_OFFSET).toInt()] }
+            .ifEmpty { null }
+    }
+
+    private fun setFinish() {
+        if (currentModifier.isNullModifier() || getValues() != null) {
+            enableFinish(true)
+        } else {
+            enableFinish(false)
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/picker/HierarchicalMultiCriterionFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/picker/HierarchicalMultiCriterionFragment.kt
@@ -176,7 +176,6 @@ class HierarchicalMultiCriterionFragment(
             curVal = curVal.copy(modifier = newModifier)
             findActionById(MODIFIER).description = newModifier.getString(requireContext())
             notifyActionChanged(findActionPositionById(MODIFIER))
-            return true
         } else if (action.id >= EXCLUDE_OFFSET) {
             // Item was clicked, so remove it
             val index = action.id - EXCLUDE_OFFSET
@@ -184,7 +183,6 @@ class HierarchicalMultiCriterionFragment(
             list.removeAt(index.toInt())
             curVal = curVal.copy(excludes = Optional.present(list))
             refreshItemList(list, false)
-            return true
         } else if (action.id >= INCLUDE_OFFSET) {
             // Item was clicked, so remove it
             val index = action.id - INCLUDE_OFFSET
@@ -192,7 +190,6 @@ class HierarchicalMultiCriterionFragment(
             list.removeAt(index.toInt())
             curVal = curVal.copy(value = Optional.present(list))
             refreshItemList(list, true)
-            return true
         } else if (action.id == ADD_INCLUDE_ITEM) {
             // Add a new item
             requireActivity().supportFragmentManager.commit {
@@ -208,6 +205,7 @@ class HierarchicalMultiCriterionFragment(
                             curVal = curVal.copy(value = Optional.present(list))
                             refreshItemList(list, true)
                         }
+                        checkFinish()
                     },
                 )
             }
@@ -226,11 +224,23 @@ class HierarchicalMultiCriterionFragment(
                             curVal = curVal.copy(excludes = Optional.present(list))
                             refreshItemList(list, false)
                         }
+                        checkFinish()
                     },
                 )
             }
         }
-        return false
+        checkFinish()
+        return true
+    }
+
+    private fun checkFinish() {
+        if (curVal.value.getOrNull()?.isNotEmpty() == true ||
+            curVal.excludes.getOrNull()?.isNotEmpty() == true
+        ) {
+            enableFinish(true)
+        } else {
+            enableFinish(false)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/picker/MultiCriterionFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/picker/MultiCriterionFragment.kt
@@ -142,21 +142,18 @@ class MultiCriterionFragment(
             curVal = curVal.copy(modifier = newModifier)
             findActionById(MODIFIER).description = newModifier.getString(requireContext())
             notifyActionChanged(findActionPositionById(MODIFIER))
-            return true
         } else if (action.id >= EXCLUDE_OFFSET) {
             val index = action.id - EXCLUDE_OFFSET
             val list = curVal.excludes.getOrThrow()!!.toMutableList()
             list.removeAt(index.toInt())
             curVal = curVal.copy(excludes = Optional.present(list))
             refreshItemList(list, false)
-            return true
         } else if (action.id >= INCLUDE_OFFSET) {
             val index = action.id - INCLUDE_OFFSET
             val list = curVal.value.getOrThrow()!!.toMutableList()
             list.removeAt(index.toInt())
             curVal = curVal.copy(value = Optional.present(list))
             refreshItemList(list, true)
-            return true
         } else if (action.id == ADD_INCLUDE_ITEM) {
             requireActivity().supportFragmentManager.commit {
                 addToBackStack("picker")
@@ -171,6 +168,7 @@ class MultiCriterionFragment(
                             curVal = curVal.copy(value = Optional.present(list))
                             refreshItemList(list, true)
                         }
+                        checkFinish()
                     },
                 )
             }
@@ -188,11 +186,23 @@ class MultiCriterionFragment(
                             curVal = curVal.copy(excludes = Optional.present(list))
                             refreshItemList(list, false)
                         }
+                        checkFinish()
                     },
                 )
             }
         }
-        return false
+        checkFinish()
+        return true
+    }
+
+    private fun checkFinish() {
+        if (curVal.value.getOrNull()?.isNotEmpty() == true ||
+            curVal.excludes.getOrNull()?.isNotEmpty() == true
+        ) {
+            enableFinish(true)
+        } else {
+            enableFinish(false)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/picker/OrientationPickerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/picker/OrientationPickerFragment.kt
@@ -57,22 +57,22 @@ class OrientationPickerFragment(val filterOption: FilterOption<StashDataFilter, 
     }
 
     override fun onGuidedActionClicked(action: GuidedAction) {
+        val values =
+            actions.filter { it.id >= ORIENTATION_OFFSET && it.isChecked }
+                .map { OrientationEnum.entries[(it.id - ORIENTATION_OFFSET).toInt()] }
         if (action.id == GuidedAction.ACTION_ID_FINISH) {
-            val values =
-                actions.filter { it.id >= ORIENTATION_OFFSET && it.isChecked }
-                    .map { OrientationEnum.entries[(it.id - ORIENTATION_OFFSET).toInt()] }
             val newFilter = OrientationCriterionInput(value = values)
             viewModel.updateFilter(filterOption, newFilter)
             parentFragmentManager.popBackStack()
+        } else if (action.id >= ORIENTATION_OFFSET) {
+            enableFinish(values.isNotEmpty())
         } else {
             onStandardActionClicked(action, filterOption)
         }
     }
 
     companion object {
-        private const val TAG = "HierarchicalMultiCriterionFragment"
-
-        private const val MODIFIER = 1L
+        private const val TAG = "OrientationPickerFragment"
 
         private const val ORIENTATION_OFFSET = 1_000_000L
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/picker/ResolutionPickerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/picker/ResolutionPickerFragment.kt
@@ -54,25 +54,27 @@ class ResolutionPickerFragment(val filterOption: FilterOption<StashDataFilter, R
         )
 
         val options =
-            ResolutionEnum.entries.mapIndexed { index, res ->
-                GuidedAction.Builder(requireContext())
-                    .id(RESOLUTION_OFFSET + index)
-                    .hasNext(false)
-                    .title(resolutionName(res))
-                    .description(resolutionName(curVal.value))
-                    .build()
-            }
+            ResolutionEnum.entries
+                .filter { it != ResolutionEnum.UNKNOWN__ }
+                .mapIndexed { index, res ->
+                    GuidedAction.Builder(requireContext())
+                        .id(RESOLUTION_OFFSET + index)
+                        .hasNext(false)
+                        .title(resolutionName(res))
+                        .build()
+                }
 
         actions.add(
             GuidedAction.Builder(requireContext())
                 .id(RESOLUTION)
                 .hasNext(true)
                 .title(getString(R.string.stashapp_criterion_value))
+                .description(resolutionName(curVal.value))
                 .subActions(options)
                 .build(),
         )
 
-        addStandardActions(actions, filterOption)
+        addStandardActions(actions, filterOption, true)
     }
 
     override fun onSubGuidedActionClicked(action: GuidedAction): Boolean {

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/picker/SearchPickerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/picker/SearchPickerFragment.kt
@@ -25,6 +25,7 @@ import com.github.damontecres.stashapp.api.type.GalleryFilterType
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.api.type.StringCriterionInput
 import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.data.SortOption
 import com.github.damontecres.stashapp.data.StashData
 import com.github.damontecres.stashapp.data.room.RecentSearchItem
 import com.github.damontecres.stashapp.presenters.StashPresenter
@@ -119,14 +120,14 @@ class SearchPickerFragment(
                 val resultsAdapter = ArrayObjectAdapter(StashPresenter.SELECTOR)
                 val sortBy =
                     when (dataType) {
-                        DataType.GALLERY -> "images_count"
-                        else -> "scenes_count"
+                        DataType.GALLERY -> SortOption.IMAGES_COUNT
+                        else -> SortOption.SCENES_COUNT
                     }
                 val filter =
                     FindFilterType(
                         direction = Optional.present(SortDirectionEnum.DESC),
                         per_page = Optional.present(perPage),
-                        sort = Optional.present(sortBy),
+                        sort = Optional.present(sortBy.key),
                     )
                 val results =
                     when (dataType) {

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/picker/StringPickerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/picker/StringPickerFragment.kt
@@ -81,15 +81,25 @@ class StringPickerFragment(
             )
             findActionById(MODIFIER).description = newModifier.getString(requireContext())
             notifyActionChanged(findActionPositionById(MODIFIER))
-            if (newModifier == CriterionModifier.IS_NULL || newModifier == CriterionModifier.NOT_NULL) {
+            if (newModifier.isNullModifier()) {
                 findActionById(VALUE).isEnabled = false
                 notifyActionChanged(findActionPositionById(VALUE))
+                enableFinish(true)
             } else {
-                findActionById(VALUE).isEnabled = true
+                val valueAction = findActionById(VALUE)
+                valueAction.isEnabled = true
                 notifyActionChanged(findActionPositionById(VALUE))
+                enableFinish(valueAction.description.isNotNullOrBlank())
             }
         }
         return true
+    }
+
+    override fun onGuidedActionEditedAndProceed(action: GuidedAction): Long {
+        if (action.id == VALUE) {
+            enableFinish(action.description.isNotNullOrBlank())
+        }
+        return GuidedAction.ACTION_ID_CURRENT
     }
 
     override fun onGuidedActionClicked(action: GuidedAction) {
@@ -97,10 +107,10 @@ class StringPickerFragment(
             val newString = findActionById(VALUE).description?.toString()
             val modifier = curVal?.modifier ?: CriterionModifier.EQUALS
             val newValue =
-                if (newString.isNotNullOrBlank()) {
-                    StringCriterionInput(value = newString, modifier = modifier)
-                } else if (modifier == CriterionModifier.IS_NULL || modifier == CriterionModifier.NOT_NULL) {
+                if (modifier.isNullModifier()) {
                     StringCriterionInput(value = "", modifier = modifier)
+                } else if (newString.isNotNullOrBlank()) {
+                    StringCriterionInput(value = newString, modifier = modifier)
                 } else {
                     null
                 }

--- a/app/src/main/java/com/github/damontecres/stashapp/filter/picker/TwoValuePicker.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/picker/TwoValuePicker.kt
@@ -127,6 +127,11 @@ abstract class TwoValuePicker<T, CriterionInput : Any>(
             val actions = mutableListOf<GuidedAction>()
             createActionList(actions)
             this.actions = actions
+            if (modifier.hasTwoValues() && (value1 == null || value2 == null)) {
+                enableFinish(false)
+            } else {
+                enableFinish(true)
+            }
         }
         return true
     }


### PR DESCRIPTION
Adds better validation when creating filters to prevent adding incorrect/incomplete data.

For example, if using a "between" performer age filter, now the UI will require entering both values to allow adding it.