### PR TITLE
Add toggle for showing sub-tag content on tag page

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/TagFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/TagFragment.kt
@@ -1,5 +1,6 @@
 package com.github.damontecres.stashapp
 
+import android.os.Bundle
 import androidx.fragment.app.FragmentManager
 import com.apollographql.apollo.api.Optional
 import com.github.damontecres.stashapp.api.type.CriterionModifier
@@ -9,6 +10,7 @@ import com.github.damontecres.stashapp.api.type.ImageFilterType
 import com.github.damontecres.stashapp.api.type.PerformerFilterType
 import com.github.damontecres.stashapp.api.type.SceneFilterType
 import com.github.damontecres.stashapp.api.type.SceneMarkerFilterType
+import com.github.damontecres.stashapp.api.type.StashDataFilter
 import com.github.damontecres.stashapp.api.type.StudioFilterType
 import com.github.damontecres.stashapp.api.type.TagFilterType
 import com.github.damontecres.stashapp.data.DataType
@@ -17,77 +19,101 @@ import com.github.damontecres.stashapp.util.StashFragmentPagerAdapter.PagerEntry
 import com.github.damontecres.stashapp.util.getUiTabs
 
 class TagFragment : TabbedFragment(DataType.TAG.name) {
+    private lateinit var tagId: String
+    private var includeSubTags = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        includeSubTags = requireActivity().intent.getBooleanExtra("includeSubTags", false)
+        tagId = requireActivity().intent.getStringExtra("tagId")!!
+    }
+
     override fun getTitleText(): String? {
         return requireActivity().intent.getStringExtra("tagName")
     }
 
     override fun getPagerAdapter(fm: FragmentManager): StashFragmentPagerAdapter {
-        val tagId = requireActivity().intent.getStringExtra("tagId")!!
-        val includeSubTags = requireActivity().intent.getBooleanExtra("includeSubTags", false)
-        val depth = Optional.present(if (includeSubTags) -1 else 0)
-        val tags =
-            Optional.present(
-                HierarchicalMultiCriterionInput(
-                    value = Optional.present(listOf(tagId)),
-                    modifier = CriterionModifier.INCLUDES_ALL,
-                    depth = depth,
-                ),
-            )
         val items =
             listOf(
                 PagerEntry(getString(R.string.stashapp_details)) {
                     TagDetailsFragment()
                 },
                 PagerEntry(DataType.SCENE) {
-                    StashGridFragment(
-                        dataType = DataType.SCENE,
-                        objectFilter = SceneFilterType(tags = tags),
-                    )
+                    createStashGridFragment(dataType = DataType.SCENE) { tags ->
+                        SceneFilterType(tags = tags)
+                    }
                 },
                 PagerEntry(DataType.GALLERY) {
-                    StashGridFragment(
-                        dataType = DataType.GALLERY,
-                        objectFilter = GalleryFilterType(tags = tags),
-                    )
+                    createStashGridFragment(dataType = DataType.GALLERY) { tags ->
+                        GalleryFilterType(tags = tags)
+                    }
                 },
                 PagerEntry(DataType.IMAGE) {
-                    StashGridFragment(
-                        dataType = DataType.IMAGE,
-                        objectFilter = ImageFilterType(tags = tags),
-                    ).withImageGridClickListener()
+                    createStashGridFragment(dataType = DataType.IMAGE) { tags ->
+                        ImageFilterType(tags = tags)
+                    }.withImageGridClickListener()
                 },
                 PagerEntry(DataType.MARKER) {
-                    StashGridFragment(
-                        dataType = DataType.MARKER,
-                        objectFilter = SceneMarkerFilterType(tags = tags),
-                    )
+                    createStashGridFragment(dataType = DataType.MARKER) { tags ->
+                        SceneMarkerFilterType(tags = tags)
+                    }
                 },
                 PagerEntry(DataType.PERFORMER) {
-                    StashGridFragment(
-                        dataType = DataType.PERFORMER,
-                        objectFilter = PerformerFilterType(tags = tags),
-                    )
+                    createStashGridFragment(dataType = DataType.PERFORMER) { tags ->
+                        PerformerFilterType(tags = tags)
+                    }
                 },
                 PagerEntry(DataType.STUDIO) {
-                    StashGridFragment(
-                        dataType = DataType.STUDIO,
-                        objectFilter = StudioFilterType(tags = tags),
-                    )
+                    createStashGridFragment(dataType = DataType.STUDIO) { tags ->
+                        StudioFilterType(tags = tags)
+                    }
                 },
                 PagerEntry(getString(R.string.stashapp_sub_tags)) {
-                    StashGridFragment(
-                        dataType = DataType.TAG,
-                        objectFilter = TagFilterType(parents = tags),
-                    )
+                    createStashGridFragment(dataType = DataType.TAG) { tags ->
+                        TagFilterType(parents = tags)
+                    }
                 },
                 PagerEntry(getString(R.string.stashapp_parent_tags)) {
                     StashGridFragment(
                         dataType = DataType.TAG,
-                        objectFilter = TagFilterType(children = tags),
+                        objectFilter = TagFilterType(children = createCriterionInput(false)),
                     )
                 },
             ).filter { it.title in getUiTabs(requireContext(), DataType.TAG) }
 
         return StashFragmentPagerAdapter(items, fm)
+    }
+
+    private fun createStashGridFragment(
+        dataType: DataType,
+        createObjectFilter: (Optional<HierarchicalMultiCriterionInput>) -> StashDataFilter,
+    ): StashGridFragment {
+        val fragment =
+            StashGridFragment(
+                dataType = dataType,
+                objectFilter = createObjectFilter(createCriterionInput(includeSubTags)),
+            )
+        fragment.subTagSwitchInitialIsChecked = includeSubTags
+        fragment.subTagSwitchCheckedListener = { isChecked ->
+            val newFilter =
+                fragment.filterArgs.copy(
+                    objectFilter =
+                        createObjectFilter(
+                            createCriterionInput(isChecked),
+                        ),
+                )
+            fragment.refresh(newFilter)
+        }
+        return fragment
+    }
+
+    private fun createCriterionInput(subTags: Boolean): Optional.Present<HierarchicalMultiCriterionInput> {
+        return Optional.present(
+            HierarchicalMultiCriterionInput(
+                value = Optional.present(listOf(tagId)),
+                modifier = CriterionModifier.INCLUDES_ALL,
+                depth = Optional.present(if (subTags) -1 else 0),
+            ),
+        )
     }
 }

--- a/app/src/main/res/layout/stash_grid_fragment.xml
+++ b/app/src/main/res/layout/stash_grid_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/browse_dummy"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -50,6 +51,20 @@
             android:textSize="14sp"
             android:background="@drawable/button_selector"
             android:text="@string/stashapp_filter"
+            tools:visibility="visible" />
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/sub_tag_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_margin="8dp"
+            android:minWidth="0dp"
+            android:padding="8dp"
+            android:visibility="gone"
+            android:textSize="14sp"
+            android:background="@drawable/button_selector"
+            android:text="@string/stashapp_include_sub_tag_content"
+            app:switchPadding="8dp"
             tools:visibility="visible" />
     </LinearLayout>
 


### PR DESCRIPTION
Adds a toggle on a tag's page to show sub-tag content. It is off by default and toggled per tab.

Follow up: should be able to adapt for studios too