### PR TITLE
Use server provided page sorts for tabs if available

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/GroupFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/GroupFragment.kt
@@ -12,6 +12,7 @@ import com.github.damontecres.stashapp.data.Group
 import com.github.damontecres.stashapp.data.GroupRelationshipType
 import com.github.damontecres.stashapp.suppliers.DataSupplierOverride
 import com.github.damontecres.stashapp.suppliers.FilterArgs
+import com.github.damontecres.stashapp.util.PageFilterKey
 import com.github.damontecres.stashapp.util.StashFragmentPagerAdapter
 import com.github.damontecres.stashapp.util.getParcelable
 import com.github.damontecres.stashapp.util.getUiTabs
@@ -30,7 +31,10 @@ class GroupFragment : TabbedFragment(DataType.GROUP.name) {
     ) {
         super.onViewCreated(view, savedInstanceState)
         viewModel.currentServer.observe(viewLifecycleOwner) { server ->
-            val groupSceneFilter = server.serverPreferences.defaultGroupSceneFilter
+            val groupSceneFilter =
+                server.serverPreferences.getDefaultFilter(PageFilterKey.GROUP_SCENES)
+            val subGroupFilter =
+                server.serverPreferences.getDefaultFilter(PageFilterKey.GROUP_SUB_GROUPS)
             viewModel.tabs.value =
                 listOf(
                     StashFragmentPagerAdapter.PagerEntry(getString(R.string.stashapp_details)) {
@@ -92,6 +96,7 @@ class GroupFragment : TabbedFragment(DataType.GROUP.name) {
                             ),
                         )
                     },
+                    // TODO use subgroup filter
                     StashFragmentPagerAdapter.PagerEntry(getString(R.string.stashapp_sub_groups)) {
                         StashGridFragment(
                             FilterArgs(

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
@@ -28,6 +28,7 @@ import com.github.damontecres.stashapp.presenters.StashPresenter
 import com.github.damontecres.stashapp.presenters.TagPresenter
 import com.github.damontecres.stashapp.suppliers.DataSupplierOverride
 import com.github.damontecres.stashapp.suppliers.FilterArgs
+import com.github.damontecres.stashapp.util.PageFilterKey
 import com.github.damontecres.stashapp.util.StashFragmentPagerAdapter
 import com.github.damontecres.stashapp.util.getParcelable
 import com.github.damontecres.stashapp.util.getUiTabs
@@ -66,83 +67,90 @@ class PerformerFragment : TabbedFragment(DataType.PERFORMER.name) {
                 ),
             )
 
-        viewModel.tabs.value =
-            listOf(
-                StashFragmentPagerAdapter.PagerEntry(getString(R.string.stashapp_details)) {
-                    PerformerDetailsFragment()
-                },
-                StashFragmentPagerAdapter.PagerEntry(DataType.SCENE) {
-                    StashGridFragment(
-                        dataType = DataType.SCENE,
-                        objectFilter = SceneFilterType(performers = performers),
-                    )
-                },
-                StashFragmentPagerAdapter.PagerEntry(DataType.GALLERY) {
-                    StashGridFragment(
-                        dataType = DataType.GALLERY,
-                        objectFilter = GalleryFilterType(performers = performers),
-                    )
-                },
-                StashFragmentPagerAdapter.PagerEntry(DataType.IMAGE) {
-                    StashGridFragment(
-                        dataType = DataType.IMAGE,
-                        objectFilter = ImageFilterType(performers = performers),
-                    ).withImageGridClickListener()
-                },
-                StashFragmentPagerAdapter.PagerEntry(DataType.GROUP) {
-                    StashGridFragment(
-                        dataType = DataType.GROUP,
-                        objectFilter = GroupFilterType(performers = performers),
-                    )
-                },
-                StashFragmentPagerAdapter.PagerEntry(DataType.TAG) {
-                    val presenter =
-                        ClassPresenterSelector()
-                            .addClassPresenter(
-                                TagData::class.java,
-                                TagPresenter(PerformersWithTagLongClickCallback()),
-                            )
-                    val fragment =
+        viewModel.currentServer.observe(viewLifecycleOwner) { server ->
+            viewModel.tabs.value =
+                listOf(
+                    StashFragmentPagerAdapter.PagerEntry(getString(R.string.stashapp_details)) {
+                        PerformerDetailsFragment()
+                    },
+                    StashFragmentPagerAdapter.PagerEntry(DataType.SCENE) {
                         StashGridFragment(
-                            FilterArgs(
-                                dataType = DataType.TAG,
-                                override = DataSupplierOverride.PerformerTags(performer.id),
-                            ),
+                            dataType = DataType.SCENE,
+                            findFilter = server.serverPreferences.getDefaultFilter(PageFilterKey.PERFORMER_SCENES).findFilter,
+                            objectFilter = SceneFilterType(performers = performers),
                         )
-                    fragment.presenterSelector = presenter
-                    fragment
-                },
-                StashFragmentPagerAdapter.PagerEntry(getString(R.string.stashapp_appears_with)) {
-                    val presenter =
-                        ClassPresenterSelector()
-                            .addClassPresenter(
-                                PerformerData::class.java,
-                                PerformerPresenter(PerformTogetherLongClickCallback(performer)),
-                            )
-                    val fragment =
+                    },
+                    StashFragmentPagerAdapter.PagerEntry(DataType.GALLERY) {
                         StashGridFragment(
-                            dataType = DataType.PERFORMER,
-                            objectFilter =
-                                PerformerFilterType(
-                                    performers =
-                                        Optional.present(
-                                            MultiCriterionInput(
-                                                value = Optional.present(listOf(performer.id)),
-                                                modifier = CriterionModifier.INCLUDES_ALL,
-                                            ),
-                                        ),
+                            dataType = DataType.GALLERY,
+                            findFilter = server.serverPreferences.getDefaultFilter(PageFilterKey.PERFORMER_GALLERIES).findFilter,
+                            objectFilter = GalleryFilterType(performers = performers),
+                        )
+                    },
+                    StashFragmentPagerAdapter.PagerEntry(DataType.IMAGE) {
+                        StashGridFragment(
+                            dataType = DataType.IMAGE,
+                            findFilter = server.serverPreferences.getDefaultFilter(PageFilterKey.PERFORMER_IMAGES).findFilter,
+                            objectFilter = ImageFilterType(performers = performers),
+                        ).withImageGridClickListener()
+                    },
+                    StashFragmentPagerAdapter.PagerEntry(DataType.GROUP) {
+                        StashGridFragment(
+                            dataType = DataType.GROUP,
+                            findFilter = server.serverPreferences.getDefaultFilter(PageFilterKey.PERFORMER_GROUPS).findFilter,
+                            objectFilter = GroupFilterType(performers = performers),
+                        )
+                    },
+                    StashFragmentPagerAdapter.PagerEntry(DataType.TAG) {
+                        val presenter =
+                            ClassPresenterSelector()
+                                .addClassPresenter(
+                                    TagData::class.java,
+                                    TagPresenter(PerformersWithTagLongClickCallback()),
+                                )
+                        val fragment =
+                            StashGridFragment(
+                                FilterArgs(
+                                    dataType = DataType.TAG,
+                                    override = DataSupplierOverride.PerformerTags(performer.id),
                                 ),
+                            )
+                        fragment.presenterSelector = presenter
+                        fragment
+                    },
+                    StashFragmentPagerAdapter.PagerEntry(getString(R.string.stashapp_appears_with)) {
+                        val presenter =
+                            ClassPresenterSelector()
+                                .addClassPresenter(
+                                    PerformerData::class.java,
+                                    PerformerPresenter(PerformTogetherLongClickCallback(performer)),
+                                )
+                        val fragment =
+                            StashGridFragment(
+                                dataType = DataType.PERFORMER,
+                                findFilter = server.serverPreferences.getDefaultFilter(PageFilterKey.PERFORMER_APPEARS_WITH).findFilter,
+                                objectFilter =
+                                    PerformerFilterType(
+                                        performers =
+                                            Optional.present(
+                                                MultiCriterionInput(
+                                                    value = Optional.present(listOf(performer.id)),
+                                                    modifier = CriterionModifier.INCLUDES_ALL,
+                                                ),
+                                            ),
+                                    ),
+                            )
+                        fragment.presenterSelector = presenter
+                        fragment
+                    },
+                    StashFragmentPagerAdapter.PagerEntry(DataType.MARKER) {
+                        StashGridFragment(
+                            dataType = DataType.MARKER,
+                            objectFilter = SceneMarkerFilterType(performers = performers),
                         )
-                    fragment.presenterSelector = presenter
-                    fragment
-                },
-                StashFragmentPagerAdapter.PagerEntry(DataType.MARKER) {
-                    StashGridFragment(
-                        dataType = DataType.MARKER,
-                        objectFilter = SceneMarkerFilterType(performers = performers),
-                    )
-                },
-            ).filter { it.title in getUiTabs(requireContext(), DataType.PERFORMER) }
+                    },
+                ).filter { it.title in getUiTabs(requireContext(), DataType.PERFORMER) }
+        }
     }
 
     private class PerformTogetherLongClickCallback(val performer: Performer) :

--- a/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/DataType.kt
@@ -57,7 +57,7 @@ enum class DataType(
         R.string.stashapp_scene,
         R.string.stashapp_scenes,
         R.string.fa_circle_play,
-        SortAndDirection.PATH_ASC,
+        SortAndDirection(SortOption.DATE, SortDirectionEnum.DESC),
         SortOption.SCENE_SORT_OPTIONS,
     ),
     GROUP(

--- a/app/src/main/java/com/github/damontecres/stashapp/util/PageFilterKey.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/PageFilterKey.kt
@@ -1,0 +1,30 @@
+package com.github.damontecres.stashapp.util
+
+import com.github.damontecres.stashapp.data.DataType
+
+enum class PageFilterKey(val dataType: DataType, val prefKey: String) {
+    TAG_MARKERS(DataType.MARKER, "tag_markers"),
+    TAG_GALLERIES(DataType.GALLERY, "tag_galleries"),
+    TAG_SCENES(DataType.SCENE, "tag_scenes"),
+    TAG_IMAGES(DataType.IMAGE, "tag_images"),
+    TAG_PERFORMERS(DataType.PERFORMER, "tag_performers"),
+
+    PERFORMER_SCENES(DataType.SCENE, "performer_scenes"),
+    PERFORMER_GALLERIES(DataType.GALLERY, "performer_galleries"),
+    PERFORMER_IMAGES(DataType.IMAGE, "performer_images"),
+    PERFORMER_GROUPS(DataType.GROUP, "performer_groups"),
+    PERFORMER_APPEARS_WITH(DataType.PERFORMER, "performer_appears_with"),
+
+    STUDIO_GALLERIES(DataType.GALLERY, "studio_galleries"),
+    STUDIO_IMAGES(DataType.IMAGE, "studio_images"),
+
+    GALLERY_IMAGES(DataType.IMAGE, "gallery_images"),
+
+    STUDIO_SCENES(DataType.SCENE, "studio_scenes"),
+    STUDIO_GROUPS(DataType.GROUP, "studio_groups"),
+    STUDIO_PERFORMERS(DataType.PERFORMER, "studio_performers"),
+    STUDIO_CHILDREN(DataType.STUDIO, "studio_children"),
+
+    GROUP_SCENES(DataType.SCENE, "group_scenes"),
+    GROUP_SUB_GROUPS(DataType.GROUP, "group_sub_groups"),
+}


### PR DESCRIPTION
Follow up to #452
Part of #453

If the user has saved a default sort on a data type page (eg a performer's page scene list or a studio's page image list), the app will now use that. The app will fallback to the standard default sort if needed.

For now only sorting is used from the server. A follow up will include other (object) filters.

The list is derived from https://github.com/stashapp/stash/blob/v0.27.2/ui/v2.5/src/components/List/views.ts