### PR TITLE
Better API key input

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/setup/SetupActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/setup/SetupActivity.kt
@@ -34,6 +34,7 @@ class SetupActivity : FragmentActivity(R.layout.frame_layout) {
     companion object {
         const val ACTION_SERVER_URL = 98L
         const val ACTION_SERVER_API_KEY = 99L
+        const val ACTION_PASSWORD_VISIBLE = 100L
     }
 
     open class SimpleGuidedStepSupportFragment : GuidedStepSupportFragment() {

--- a/app/src/main/java/com/github/damontecres/stashapp/setup/SetupStep3ApiKey.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/setup/SetupStep3ApiKey.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.launch
 
 class SetupStep3ApiKey(private val setupState: SetupState) :
     SetupActivity.SimpleGuidedStepSupportFragment() {
+    private var apiKey: String? = null
+
     override fun onCreateGuidance(savedInstanceState: Bundle?): GuidanceStylist.Guidance {
         return GuidanceStylist.Guidance(
             "API Key",
@@ -28,21 +30,21 @@ class SetupStep3ApiKey(private val setupState: SetupState) :
         savedInstanceState: Bundle?,
     ) {
         actions.add(
+            createApiKeyAction(),
+        )
+        actions.add(
             GuidedAction.Builder(requireContext())
-                .id(SetupActivity.ACTION_SERVER_API_KEY)
-                .title("Server API Key")
-                .description("API key not set")
-                .editDescription("")
-                .descriptionEditable(true)
-                .descriptionEditInputType(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD)
-                .hasNext(true)
+                .id(SetupActivity.ACTION_PASSWORD_VISIBLE)
+                .title("API Key visible")
+                .checked(false)
+                .checkSetId(GuidedAction.CHECKBOX_CHECK_SET_ID)
                 .build(),
         )
     }
 
     override fun onGuidedActionEditedAndProceed(action: GuidedAction): Long {
         if (action.id == SetupActivity.ACTION_SERVER_API_KEY) {
-            val apiKey = action.editDescription
+            apiKey = action.editDescription?.toString()
             if (apiKey.isNotNullOrBlank()) {
                 action.description = "API key set"
             } else {
@@ -78,5 +80,45 @@ class SetupStep3ApiKey(private val setupState: SetupState) :
             }
         }
         return GuidedAction.ACTION_ID_CURRENT
+    }
+
+    override fun onGuidedActionClicked(action: GuidedAction) {
+        if (action.id == SetupActivity.ACTION_PASSWORD_VISIBLE) {
+            val newGuidedActionsServerApiKey = createApiKeyAction(action.isChecked)
+            val newActions = listOf(newGuidedActionsServerApiKey, actions[1])
+            setActionsDiffCallback(null)
+            actions = newActions
+        }
+    }
+
+    private fun createApiKeyAction(isChecked: Boolean = false): GuidedAction {
+        val passwordInputType =
+            if (isChecked) {
+                InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+            } else {
+                InputType.TYPE_TEXT_VARIATION_PASSWORD
+            }
+
+        return GuidedAction.Builder(requireContext())
+            .id(SetupActivity.ACTION_SERVER_API_KEY)
+            .title("Stash Server API Key")
+            .description(
+                if (apiKey.isNotNullOrBlank()) {
+                    "API key set"
+                } else {
+                    "API key not set"
+                },
+            )
+            .editDescription(apiKey ?: "")
+            .descriptionEditable(true)
+            .descriptionEditInputType(
+                InputType.TYPE_CLASS_TEXT or
+                    InputType.TYPE_TEXT_FLAG_MULTI_LINE or
+                    passwordInputType,
+            )
+            .multilineDescription(true)
+            .enabled(true)
+            .focusable(true)
+            .build()
     }
 }


### PR DESCRIPTION
Closes #455 

When adding a server (or initial setup), adds a checkbox to make the API key visible.

Also makes the API key input multi-line so its easier to see.

The recommended way to enter the API key is still to use your phone's virtual keyboard though. See also https://github.com/damontecres/StashAppAndroidTV/issues/63#issuecomment-1908428845.