### PR TITLE
Fix storing read only as a int

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/setup/readonly/ReadOnlyPinConfigFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/setup/readonly/ReadOnlyPinConfigFragment.kt
@@ -78,10 +78,10 @@ class ReadOnlyPinConfigFragment : GuidedStepSupportFragment() {
             }
         } else if (action.id == ACTION_CONFIRM_PIN) {
             if (action.editDescription.isNotNullOrBlank()) {
-                val pinCode = findActionById(ACTION_PIN).editDescription.toString().toIntOrNull()
-                val confirmPin = action.editDescription.toString().toIntOrNull()
+                val pinCode = findActionById(ACTION_PIN).editDescription.toString().ifBlank { null }
+                val confirmPin = action.editDescription.toString().ifBlank { null }
 
-                if (pinCode != confirmPin) {
+                if (pinCode == null || pinCode != confirmPin) {
                     Toast.makeText(requireContext(), "PINs do not match!", Toast.LENGTH_SHORT)
                         .show()
                     okAction.isEnabled = false
@@ -99,12 +99,12 @@ class ReadOnlyPinConfigFragment : GuidedStepSupportFragment() {
 
     override fun onGuidedActionClicked(action: GuidedAction) {
         if (action.id == GuidedAction.ACTION_ID_OK) {
-            val pin = findActionById(ACTION_PIN).editDescription.toString().toIntOrNull()
+            val pin = findActionById(ACTION_PIN).editDescription.toString().ifBlank { null }
             val confirmPin =
-                findActionById(ACTION_CONFIRM_PIN).editDescription.toString().toIntOrNull()
+                findActionById(ACTION_CONFIRM_PIN).editDescription.toString().ifBlank { null }
             if (pin == confirmPin && pin != null) {
                 PreferenceManager.getDefaultSharedPreferences(requireContext()).edit(true) {
-                    putInt(getString(R.string.pref_key_read_only_mode_pin), pin)
+                    putString(getString(R.string.pref_key_read_only_mode_pin), pin)
                     putBoolean(getString(R.string.pref_key_read_only_mode), true)
                 }
                 parentFragmentManager.popBackStack()

--- a/app/src/main/java/com/github/damontecres/stashapp/setup/readonly/ReadOnlyPinEntryFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/setup/readonly/ReadOnlyPinEntryFragment.kt
@@ -67,9 +67,9 @@ class ReadOnlyPinEntryFragment(private val callback: () -> Unit) : GuidedStepSup
     override fun onGuidedActionClicked(action: GuidedAction) {
         if (action.id == GuidedAction.ACTION_ID_OK) {
             val preferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
-            val enteredPIN = findActionById(ACTION_PIN).editDescription.toString().toIntOrNull()
-            // TODO
-            if (preferences.getInt(getString(R.string.pref_key_read_only_mode_pin), 111) == enteredPIN) {
+            val enteredPIN = findActionById(ACTION_PIN).editDescription.toString().ifBlank { null }
+            val pin = preferences.getString(getString(R.string.pref_key_read_only_mode_pin), null)
+            if (enteredPIN != null && pin == enteredPIN) {
                 callback()
             } else {
                 Toast.makeText(requireContext(), "Incorrect PIN", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/github/damontecres/stashapp/util/AppUpgradeHandler.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/AppUpgradeHandler.kt
@@ -81,6 +81,17 @@ class AppUpgradeHandler(
                 ),
             )
         }
+        if (previousVersion == Version.fromString("v0.5.2-8-gc2c5e6f")) {
+            val key = context.getString(R.string.pref_key_read_only_mode_pin)
+            val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+            val readOnlyPin = preferences.getInt(key, -1)
+            if (readOnlyPin >= 0) {
+                preferences.edit(true) {
+                    remove(key)
+                    putString(key, readOnlyPin.toString())
+                }
+            }
+        }
     }
 
     private fun SharedPreferences.ensureSetHas(


### PR DESCRIPTION
#456 stored the PIN as an integer which meant if it started with zeros, they would be removed. It also had test code left in that should have been removed.

This PR fixes it to store as a String instead.