### PR TITLE
Don't show Create Marker button in read only mode

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/SceneDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SceneDetailsFragment.kt
@@ -659,7 +659,7 @@ class SceneDetailsFragment : DetailsSupportFragment() {
                         }
                 } else {
                     val localPosition = data.getLongExtra(POSITION_RESULT_ARG, -1)
-                    if (localPosition >= 0) {
+                    if (localPosition >= 0 && readOnlyModeDisabled()) {
                         sceneActionsAdapter.set(
                             CREATE_MARKER_POS,
                             CreateMarkerAction(localPosition),


### PR DESCRIPTION
Don't show the "Create Marker" button when returning to scene details in read only mode.