### PR TITLE
Ensure initial app PIN preserves zeros

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/setup/SetupActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/setup/SetupActivity.kt
@@ -45,10 +45,7 @@ class SetupActivity : FragmentActivity(R.layout.frame_layout) {
         fun finishSetup(setupState: SetupState) {
             StashServer.addAndSwitchServer(requireContext(), setupState.stashServer) {
                 if (setupState.pinCode != null) {
-                    it.putString(
-                        getString(R.string.pref_key_pin_code),
-                        setupState.pinCode.toString(),
-                    )
+                    it.putString(getString(R.string.pref_key_pin_code), setupState.pinCode)
                     it.putBoolean(getString(R.string.pref_key_pin_code_auto), true)
                 }
                 it.putBoolean(getString(R.string.pref_key_trust_certs), setupState.trustCerts)

--- a/app/src/main/java/com/github/damontecres/stashapp/setup/SetupState.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/setup/SetupState.kt
@@ -6,7 +6,7 @@ data class SetupState(
     val serverUrl: String,
     val apiKey: String?,
     val trustCerts: Boolean = false,
-    val pinCode: Int? = null,
+    val pinCode: String? = null,
 ) {
     constructor(serverUrl: CharSequence) : this(serverUrl.toString(), null)
 

--- a/app/src/main/java/com/github/damontecres/stashapp/setup/SetupStep4Pin.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/setup/SetupStep4Pin.kt
@@ -102,10 +102,12 @@ class SetupStep4Pin(private val setupState: SetupState) :
 
     override fun onGuidedActionClicked(action: GuidedAction) {
         if (action.id == GuidedAction.ACTION_ID_OK) {
-            val pin = findActionById(ACTION_PIN).editDescription.toString().toIntOrNull()
+            val pin = findActionById(ACTION_PIN).editDescription.ifBlank { null }?.toString()
             val confirmPin =
-                findActionById(ACTION_CONFIRM_PIN).editDescription.toString().toIntOrNull()
-            if (pin == confirmPin) {
+                findActionById(ACTION_CONFIRM_PIN).editDescription.ifBlank { null }?.toString()
+            if (pin != null && pin.toIntOrNull() == null) {
+                Toast.makeText(requireContext(), "PIN must be a number!", Toast.LENGTH_SHORT).show()
+            } else if (pin == confirmPin) {
                 val newState = setupState.copy(pinCode = pin)
                 finishSetup(newState)
             } else {


### PR DESCRIPTION
Similar to #459, ensure that a PIN starting with zeros will keep them.

PINs were correctly stored and updated in settings, so this problem only affected the initial app setup.