### PR TITLE
Fix clicking on containing/sub groups not working

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/views/StashItemViewClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/StashItemViewClickListener.kt
@@ -119,7 +119,7 @@ class StashItemViewClickListener(
         } else if (item is OCounter) {
             actionListener!!.incrementOCounter(item)
         } else {
-            Log.e(TAG, "Unknown item type: $item")
+            Log.e(TAG, "Unknown item type: ${item.javaClass}")
         }
     }
 


### PR DESCRIPTION
This PR fixes where clicking on a containing or sub group on the group page would do nothing.