### PR TITLE
Play card video previews when returning to page

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
@@ -152,7 +152,10 @@ class StashImageCardView(context: Context) : ImageCardView(context) {
         sweat.setBounds(0, 0, textSize.toInt(), textSize.toInt())
     }
 
-    override fun setSelected(selected: Boolean) {
+    private fun setSelected(
+        selected: Boolean,
+        overrideDelay: Boolean,
+    ) {
         delayJob?.cancel()
         if (playVideoPreviews && videoUrl.isNotNullOrBlank()) {
             if (selected) {
@@ -167,7 +170,7 @@ class StashImageCardView(context: Context) : ImageCardView(context) {
             }
         }
         if (selected) {
-            if (videoDelay > 0) {
+            if (!overrideDelay && videoDelay > 0) {
                 val scope = findViewTreeLifecycleOwner()?.lifecycleScope
                 if (scope != null) {
                     delayJob =
@@ -191,6 +194,17 @@ class StashImageCardView(context: Context) : ImageCardView(context) {
         }
         updateCardBackgroundColor(this, selected)
         super.setSelected(selected)
+    }
+
+    override fun setSelected(selected: Boolean) {
+        setSelected(selected, false)
+    }
+
+    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
+        super.onWindowFocusChanged(hasWindowFocus)
+        if (hasWindowFocus && isSelected) {
+            setSelected(true, true)
+        }
     }
 
     override fun setMainImageDimensions(


### PR DESCRIPTION
This PR fixes when a card with a video preview is playing is clicked, then pressing back to return, the card would have a black image.

The card views now check when their window focus is restored so they can restart the video preview if needed.