### PR TITLE
Add paging with various remote buttons

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -92,6 +92,8 @@ class StashGridFragment() : Fragment(), DefaultKeyEventCallback {
 
     var titleView: View? = null
 
+    private var remoteButtonPaging: Boolean = true
+
     // Arguments
     private lateinit var _filterArgs: FilterArgs
     private lateinit var _currentSortAndDirection: SortAndDirection
@@ -301,6 +303,10 @@ class StashGridFragment() : Fragment(), DefaultKeyEventCallback {
         val gridPresenter = StashGridPresenter()
         gridPresenter.numberOfColumns = calculatedColumns
         setGridPresenter(gridPresenter)
+
+        remoteButtonPaging =
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getBoolean(getString(R.string.pref_key_remote_page_buttons), true)
     }
 
     override fun onCreateView(
@@ -723,24 +729,24 @@ class StashGridFragment() : Fragment(), DefaultKeyEventCallback {
             } else {
                 return false
             }
-        } else if (keyCode in
+        } else if (remoteButtonPaging && keyCode in
             setOf(
                 KeyEvent.KEYCODE_PAGE_UP,
-                KeyEvent.KEYCODE_MEDIA_NEXT,
-                KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
-                KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD,
                 KeyEvent.KEYCODE_CHANNEL_UP,
+                KeyEvent.KEYCODE_MEDIA_PREVIOUS,
+                KeyEvent.KEYCODE_MEDIA_REWIND,
+                KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD,
             ) && requireActivity().currentFocus is StashImageCardView
         ) {
             jumpButtonLayout[1].callOnClick()
             return true
-        } else if (keyCode in
+        } else if (remoteButtonPaging && keyCode in
             setOf(
                 KeyEvent.KEYCODE_PAGE_DOWN,
-                KeyEvent.KEYCODE_MEDIA_PREVIOUS,
-                KeyEvent.KEYCODE_MEDIA_REWIND,
-                KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD,
                 KeyEvent.KEYCODE_CHANNEL_DOWN,
+                KeyEvent.KEYCODE_MEDIA_NEXT,
+                KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
+                KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD,
             ) && requireActivity().currentFocus is StashImageCardView
         ) {
             jumpButtonLayout[2].callOnClick()

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -31,6 +31,8 @@
     <string name="pref_key_ui_card_overlay_delay" translatable="false">ui.card.delayVideoDuration</string>
     <integer name="pref_key_ui_card_overlay_delay_default">1000</integer>
 
-    <string name="pref_key_read_only_mode">readOnlyMode</string>
-    <string name="pref_key_read_only_mode_pin">readOnlyMode.pinCode</string>
+    <string name="pref_key_read_only_mode" translatable="false">readOnlyMode</string>
+    <string name="pref_key_read_only_mode_pin" translatable="false">readOnlyMode.pinCode</string>
+
+    <string name="pref_key_remote_page_buttons" translatable="false">paging.remoteButtons</string>
 </resources>

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -43,6 +43,12 @@
             app:summaryOn="Crop center"
             app:summaryOff="Don't crop, scale to fit"
             app:defaultValue="true" />
+        <SwitchPreference
+            app:key="@string/pref_key_remote_page_buttons"
+            app:title="Page up/down with remote buttons"
+            app:summaryOn="Fast-forward/rewind/channel buttons will page"
+            app:summaryOff="Disabled"
+            app:defaultValue="true" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Playback">


### PR DESCRIPTION
Adds paging grid pages using remote buttons such as rewind/fast-forward, skip, channel up/down, etc.

There is a new setting to disable this if needed.