### PR TITLE
Cleaner loading of initial grid page items

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -587,8 +587,8 @@ class StashGridFragment() :
         val footerLayout = requireView().findViewById<View>(R.id.footer_layout)
 
         viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
-            mAdapter.init()
             updateAdapter()
+            mAdapter.init()
             val count = pagingSource.getCount()
             if (count == 0) {
                 positionTextView.text = getString(R.string.zero)


### PR DESCRIPTION
After switching to the new pager (#472), when loading the first page of items on a grid, it would flash and resize awkwardly because the first several items would report null while the actual data is being fetched.

So this PR moves things around so that the grid initially thinks it has zero items. Then the count and first page of data is fetched before notifying the UI that there are items now.