### PR TITLE
Play images in a slideshow

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterListActivity.kt
@@ -17,6 +17,7 @@ import androidx.appcompat.widget.ListPopupWindow
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
+import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.filter.CreateFilterActivity
 import com.github.damontecres.stashapp.filter.FilterOptions
@@ -30,7 +31,9 @@ import com.github.damontecres.stashapp.util.getFilterArgs
 import com.github.damontecres.stashapp.util.getMaxMeasuredWidth
 import com.github.damontecres.stashapp.util.putDataType
 import com.github.damontecres.stashapp.util.putFilterArgs
+import com.github.damontecres.stashapp.views.ImageAndFilter
 import com.github.damontecres.stashapp.views.PlayAllOnClickListener
+import com.github.damontecres.stashapp.views.SlideshowOnClickListener
 import com.github.damontecres.stashapp.views.SortButtonManager
 import com.github.damontecres.stashapp.views.StashOnFocusChangeListener
 import kotlinx.coroutines.launch
@@ -99,6 +102,17 @@ class FilterListActivity : FragmentActivity(R.layout.filter_list) {
                     val fragment =
                         supportFragmentManager.findFragmentById(R.id.list_fragment) as StashGridFragment
                     fragment.filterArgs
+                },
+            )
+        } else if (startingFilter.dataType == DataType.IMAGE) {
+            playAllButton.visibility = View.VISIBLE
+            playAllButton.text = getString(R.string.play_slideshow)
+            playAllButton.setOnClickListener(
+                SlideshowOnClickListener(this) {
+                    val fragment =
+                        supportFragmentManager.findFragmentById(R.id.list_fragment) as StashGridFragment
+                    val item = fragment.get(0) as ImageData?
+                    ImageAndFilter(0, item, fragment.filterArgs)
                 },
             )
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsUiFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsUiFragment.kt
@@ -19,6 +19,10 @@ class SettingsUiFragment : LeanbackPreferenceFragmentCompat() {
             setVideoDelaySummary(videoDelayPref, newValue)
             true
         }
+
+        val slideshowDurationPref =
+            findPreference<SeekBarPreference>(getString(R.string.pref_key_slideshow_duration))!!
+        slideshowDurationPref.min = 1
     }
 
     private fun setVideoDelaySummary(

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridFragment.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import com.apollographql.apollo.api.Query
 import com.chrynan.parcelable.core.putParcelable
+import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.api.type.StashDataFilter
 import com.github.damontecres.stashapp.data.DataType
@@ -58,8 +59,10 @@ import com.github.damontecres.stashapp.util.getInt
 import com.github.damontecres.stashapp.util.maybeStartPlayback
 import com.github.damontecres.stashapp.util.putDataType
 import com.github.damontecres.stashapp.util.putFilterArgs
+import com.github.damontecres.stashapp.views.ImageAndFilter
 import com.github.damontecres.stashapp.views.ImageGridClickedListener
 import com.github.damontecres.stashapp.views.PlayAllOnClickListener
+import com.github.damontecres.stashapp.views.SlideshowOnClickListener
 import com.github.damontecres.stashapp.views.SortButtonManager
 import com.github.damontecres.stashapp.views.StashItemViewClickListener
 import com.github.damontecres.stashapp.views.StashOnFocusChangeListener
@@ -442,6 +445,16 @@ class StashGridFragment() :
                     filterArgs
                 },
             )
+        } else if (dataType == DataType.IMAGE) {
+            playAllButton.visibility = View.VISIBLE
+            playAllButton.nextFocusUpId = R.id.tab_layout
+            playAllButton.text = getString(R.string.play_slideshow)
+            playAllButton.setOnClickListener(
+                SlideshowOnClickListener(requireContext()) {
+                    val item = mAdapter.get(0) as ImageData?
+                    ImageAndFilter(0, item, filterArgs)
+                },
+            )
         }
         if (filterButtonEnabled) {
             filterButton.visibility = View.VISIBLE
@@ -715,6 +728,8 @@ class StashGridFragment() :
         playAllButtonEnabled = false
         filterButtonEnabled = false
     }
+
+    fun get(index: Int): Any? = mAdapter.get(index)
 
     override fun onKeyUp(
         keyCode: Int,

--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
@@ -16,6 +16,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.commit
 import androidx.leanback.app.DetailsSupportFragment
 import androidx.leanback.app.DetailsSupportFragmentBackgroundController
 import androidx.leanback.widget.AbstractDetailsDescriptionPresenter
@@ -204,6 +205,29 @@ class ImageDetailsFragment : DetailsSupportFragment() {
 
         detailsPresenter.onActionClickedListener =
             OnActionClickedListener { action ->
+                if (action.id.toInt() == R.string.play_slideshow || action.id.toInt() == R.string.stop_slideshow) {
+                    Log.v(TAG, "Clicked play/stop slideshow")
+                    if (viewModel.slideshow.value!!) {
+                        detailsActionsAdapter.replace(
+                            detailsActionsAdapter.size() - 1,
+                            Action(R.string.play_slideshow.toLong()),
+                        )
+                    } else {
+                        // Start slideshow
+                        detailsActionsAdapter.replace(
+                            detailsActionsAdapter.size() - 1,
+                            Action(R.string.stop_slideshow.toLong()),
+                        )
+                        requireActivity().supportFragmentManager.commit {
+                            hide(this@ImageDetailsFragment)
+                        }
+                    }
+                    detailsActionsAdapter.notifyItemRangeChanged(
+                        detailsActionsAdapter.size() - 1,
+                        1,
+                    )
+                    viewModel.slideshow.value = viewModel.slideshow.value!!.not()
+                }
                 val controller = viewModel.imageController
                 if (controller != null) {
                     when (action.id.toInt()) {
@@ -264,6 +288,11 @@ class ImageDetailsFragment : DetailsSupportFragment() {
                 detailsActionsAdapter.add(Action(R.string.fa_magnifying_glass_minus.toLong()))
                 detailsActionsAdapter.add(Action(R.string.fa_arrow_right_arrow_left.toLong()))
                 detailsActionsAdapter.add(Action(R.string.stashapp_effect_filters_reset_transforms.toLong()))
+            }
+            if (viewModel.slideshow.value!!) {
+                detailsActionsAdapter.add(Action(R.string.stop_slideshow.toLong()))
+            } else {
+                detailsActionsAdapter.add(Action(R.string.play_slideshow.toLong()))
             }
             detailsRow.actionsAdapter = detailsActionsAdapter
 
@@ -428,7 +457,13 @@ class ImageDetailsFragment : DetailsSupportFragment() {
             val action = item as Action
             val vh = viewHolder as ActionViewHolder
             vh.mAction = action.id
-            if (action.id.toInt() == R.string.stashapp_effect_filters_reset_transforms) {
+            if (action.id.toInt() in
+                setOf(
+                    R.string.stashapp_effect_filters_reset_transforms,
+                    R.string.play_slideshow,
+                    R.string.stop_slideshow,
+                )
+            ) {
                 vh.mButton.typeface = null
             } else if (vh.mButton.typeface == null) {
                 vh.mButton.typeface = StashApplication.getFont(R.font.fa_solid_900)

--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageViewModel.kt
@@ -25,6 +25,11 @@ class ImageViewModel(
     val imageId: LiveData<String> = state.getLiveData("imageId")
 
     /**
+     * Whether the slideshow is running or not
+     */
+    val slideshow = MutableLiveData(false)
+
+    /**
      * Set the current image to a new one
      */
     fun setImage(newImage: ImageData) {

--- a/app/src/main/java/com/github/damontecres/stashapp/views/SlideshowOnClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/SlideshowOnClickListener.kt
@@ -1,0 +1,37 @@
+package com.github.damontecres.stashapp.views
+
+import android.content.Context
+import android.content.Intent
+import android.view.View
+import android.view.View.OnClickListener
+import com.github.damontecres.stashapp.ImageActivity
+import com.github.damontecres.stashapp.api.fragment.ImageData
+import com.github.damontecres.stashapp.suppliers.FilterArgs
+import com.github.damontecres.stashapp.util.maxFileSize
+import com.github.damontecres.stashapp.util.putFilterArgs
+
+class SlideshowOnClickListener(
+    private val context: Context,
+    private val getImageAndFilter: () -> ImageAndFilter,
+) : OnClickListener {
+    override fun onClick(v: View?) {
+        val intent = Intent(context, ImageActivity::class.java)
+        val (position, item, filterArgs) = getImageAndFilter()
+        if (item != null) {
+            intent
+                .putExtra(ImageActivity.INTENT_IMAGE_ID, item.id)
+                .putExtra(ImageActivity.INTENT_IMAGE_URL, item.paths.image)
+                .putExtra(ImageActivity.INTENT_IMAGE_SIZE, item.maxFileSize)
+                .putExtra(ImageActivity.INTENT_POSITION, position)
+                .putFilterArgs(ImageActivity.INTENT_FILTER_ARGS, filterArgs)
+                .putExtra(ImageActivity.INTENT_IMAGE_SLIDESHOW, true)
+            context.startActivity(intent)
+        }
+    }
+}
+
+data class ImageAndFilter(
+    val position: Int,
+    val image: ImageData?,
+    val filter: FilterArgs,
+)

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -35,4 +35,7 @@
     <string name="pref_key_read_only_mode_pin" translatable="false">readOnlyMode.pinCode</string>
 
     <string name="pref_key_remote_page_buttons" translatable="false">paging.remoteButtons</string>
+
+    <string name="pref_key_slideshow_duration" translatable="false">image.slideshow.duration</string>
+    <integer name="pref_key_slideshow_duration_default">5</integer>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,8 @@
     <string name="force_transcode">Force transcode</string>
     <string name="direct">Direct</string>
     <string name="zero">0</string>
+    <string name="play_slideshow">Play Slideshow</string>
+    <string name="stop_slideshow">Stop Slideshow</string>
 
 
 </resources>

--- a/app/src/main/res/xml/ui_preferences.xml
+++ b/app/src/main/res/xml/ui_preferences.xml
@@ -16,6 +16,13 @@
             app:showSeekBarValue="false"
             android:max="5000"
             app:defaultValue="@integer/pref_key_ui_card_overlay_delay_default" />
+        <SeekBarPreference
+            app:key="@string/pref_key_slideshow_duration"
+            app:title="Slideshow duration (seconds)"
+            app:seekBarIncrement="1"
+            app:showSeekBarValue="true"
+            android:max="20"
+            app:defaultValue="@integer/pref_key_slideshow_duration_default" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Closes #486 

Adds ability to play images in a slideshow format. Each image shows for a configurable amount of time before moving to the next.

The image overlay is showing, the slideshow will pause. You can also start/stop the slideshow in the overlay. Finally, you can also still scroll images manually.