### PR TITLE
Fixes when items can't be removed after going back to scene page

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/SceneDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SceneDetailsFragment.kt
@@ -371,15 +371,15 @@ class SceneDetailsFragment : DetailsSupportFragment() {
             )
         }
 
-        configRowManager(viewLifecycleOwner.lifecycleScope, tagsRowManager, ::TagPresenter)
-        configRowManager(viewLifecycleOwner.lifecycleScope, studioRowManager, ::StudioPresenter)
-        configRowManager(viewLifecycleOwner.lifecycleScope, groupsRowManager, ::GroupPresenter)
+        configRowManager({ viewLifecycleOwner.lifecycleScope }, tagsRowManager, ::TagPresenter)
+        configRowManager({ viewLifecycleOwner.lifecycleScope }, studioRowManager, ::StudioPresenter)
+        configRowManager({ viewLifecycleOwner.lifecycleScope }, groupsRowManager, ::GroupPresenter)
 
         markersRowManager.adapter.presenterSelector =
             SinglePresenterSelector(
                 MarkerPresenter(
                     RemoveLongClickListener(
-                        viewLifecycleOwner.lifecycleScope,
+                        { viewLifecycleOwner.lifecycleScope },
                         markersRowManager,
                         listOf(MARKER_DETAILS_POPUP),
                     ) { context, item, popUpItem ->
@@ -415,7 +415,7 @@ class SceneDetailsFragment : DetailsSupportFragment() {
             Log.v(TAG, "sceneData.id=${sceneData.id}")
 
             configRowManager(
-                viewLifecycleOwner.lifecycleScope,
+                { viewLifecycleOwner.lifecycleScope },
                 performersRowManager,
             ) { callback ->
                 PerformerInScenePresenter(sceneData.date, callback)

--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
@@ -248,9 +248,9 @@ class ImageDetailsFragment : DetailsSupportFragment() {
         queryEngine = QueryEngine(server)
         mutationEngine = MutationEngine(server)
 
-        configRowManager(viewLifecycleOwner.lifecycleScope, tagsRowManager, ::TagPresenter)
-        configRowManager(viewLifecycleOwner.lifecycleScope, galleriesRowManager, ::GalleryPresenter)
-        configRowManager(viewLifecycleOwner.lifecycleScope, studioRowManager, ::StudioPresenter)
+        configRowManager({ viewLifecycleOwner.lifecycleScope }, tagsRowManager, ::TagPresenter)
+        configRowManager({ viewLifecycleOwner.lifecycleScope }, galleriesRowManager, ::GalleryPresenter)
+        configRowManager({ viewLifecycleOwner.lifecycleScope }, studioRowManager, ::StudioPresenter)
 
         adapter = mAdapter
 
@@ -366,14 +366,14 @@ class ImageDetailsFragment : DetailsSupportFragment() {
 
             if (newImage.date.isNotNullOrBlank()) {
                 configRowManager(
-                    viewLifecycleOwner.lifecycleScope,
+                    { viewLifecycleOwner.lifecycleScope },
                     performersRowManager,
                 ) { callback ->
                     PerformerInScenePresenter(newImage.date, callback)
                 }
             } else {
                 configRowManager(
-                    viewLifecycleOwner.lifecycleScope,
+                    { viewLifecycleOwner.lifecycleScope },
                     performersRowManager,
                     ::PerformerPresenter,
                 )

--- a/app/src/main/java/com/github/damontecres/stashapp/util/ListRowManager.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/ListRowManager.kt
@@ -140,7 +140,7 @@ class ListRowManager<T : StashData>(
 }
 
 fun <T : StashData> configRowManager(
-    scope: CoroutineScope,
+    scope: () -> CoroutineScope,
     rowManager: ListRowManager<T>,
     presenter: (StashPresenter.LongClickCallBack<T>) -> StashPresenter<T>,
 ) {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/RemoveLongClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/RemoveLongClickListener.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
  * A [StashPresenter.LongClickCallBack] which shows a 'Go To' or 'Remove' popups
  */
 class RemoveLongClickListener<T : StashData>(
-    private val scope: CoroutineScope,
+    private val scope: () -> CoroutineScope,
     private val rowManager: ListRowManager<T>,
     private val extraPopupItems: List<StashPresenter.PopUpItem> = emptyList(),
     private val extraPopupHandler: ((context: Context, item: T, popUpItem: StashPresenter.PopUpItem) -> Unit)? = null,
@@ -43,7 +43,7 @@ class RemoveLongClickListener<T : StashData>(
             }
             StashPresenter.PopUpItem.REMOVE_ID -> {
                 if (readOnlyModeDisabled()) {
-                    scope.launch(StashCoroutineExceptionHandler(autoToast = true)) {
+                    scope.invoke().launch(StashCoroutineExceptionHandler(autoToast = true)) {
                         Log.v(TAG, "Removing id=${item.id} (${item::class.simpleName})")
                         if (rowManager.remove(item)) {
                             val name = extractTitle(item)


### PR DESCRIPTION
`RemoveLongClickListener` takes `CoroutineScope` and the details pages use `viewLifecycleOwner.lifecycleScope` for this.

But once navigating away from the details page, that scope is ended because the view is gone. This PR refactors to use a function to retrieve the scope when needed, so the details fragment can provide the current `viewLifecycleOwner.lifecycleScope`.