### PR TITLE
Fix two UI issues when returning to a grid page

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterFragment.kt
@@ -103,7 +103,9 @@ class FilterFragment :
             "filterArgs.isInitialized=${stashGridViewModel.filterArgs.isInitialized}, " +
                 "savedInstanceState.isNull=${savedInstanceState == null}",
         )
-        fragment.scrollToNextPage = dest.scrollToNextPage
+        if (!stashGridViewModel.scrollToNextPage.isInitialized) {
+            stashGridViewModel.scrollToNextPage.value = dest.scrollToNextPage
+        }
         fragment.requestFocus = true
         fragment.init(dataType)
 

--- a/app/src/main/java/com/github/damontecres/stashapp/StashDataGridFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashDataGridFragment.kt
@@ -85,9 +85,6 @@ class StashDataGridFragment :
 
     private var remoteButtonPaging: Boolean = true
 
-    // Arguments
-    var scrollToNextPage = false
-
     // State
     private var selectedPosition = -1
 
@@ -333,7 +330,11 @@ class StashDataGridFragment :
         viewModel.loadingStatus.observe(viewLifecycleOwner) { status ->
             when (status) {
                 is StashGridViewModel.LoadingStatus.AdapterReady -> {
-                    Log.v(TAG, "LoadingStatus.AdapterReady")
+                    val scrollToNextPage = viewModel.scrollToNextPage.value ?: false
+                    Log.v(
+                        TAG,
+                        "LoadingStatus.AdapterReady: previousPosition=$previousPosition, scrollToNextPage=$scrollToNextPage",
+                    )
                     pagingAdapter = status.pagingAdapter
                     itemBridgeAdapter.setAdapter(status.pagingAdapter)
                     if (previousPosition > 0) {
@@ -345,7 +346,7 @@ class StashDataGridFragment :
                                 .getInt("maxSearchResults", 25)
                         jumpTo(page)
                         // Only scroll the first time
-                        scrollToNextPage = false
+                        viewModel.scrollToNextPage.value = false
                     }
                     loadingProgressBar.hide()
                     if (requestFocus) {

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridControlsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridControlsFragment.kt
@@ -66,7 +66,6 @@ class StashGridControlsFragment() :
 
     // State
     private lateinit var gridHeaderTransitionHelper: TitleTransitionHelper
-    private var scrollToNextPage = false
 
     // Modifiable properties
 
@@ -123,18 +122,15 @@ class StashGridControlsFragment() :
 
     constructor(
         filterArgs: FilterArgs,
-        scrollToNextPage: Boolean = false,
     ) : this() {
         this.initialFilter = filterArgs
-        this.scrollToNextPage = scrollToNextPage
     }
 
     constructor(
         dataType: DataType,
         findFilter: StashFindFilter? = null,
         objectFilter: StashDataFilter? = null,
-        scrollToNextPage: Boolean = false,
-    ) : this(FilterArgs(dataType, null, findFilter, objectFilter), scrollToNextPage)
+    ) : this(FilterArgs(dataType, null, findFilter, objectFilter))
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -186,7 +182,6 @@ class StashGridControlsFragment() :
 
         fragment =
             childFragmentManager.findFragmentById(R.id.grid_fragment) as StashDataGridFragment
-        fragment.scrollToNextPage = scrollToNextPage
         fragment.init(dataType)
         if (onItemViewClickedListener != null) {
             fragment.onItemViewClickedListener = onItemViewClickedListener

--- a/app/src/main/java/com/github/damontecres/stashapp/views/models/StashGridViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/models/StashGridViewModel.kt
@@ -49,6 +49,8 @@ class StashGridViewModel : ViewModel() {
 
     val searchBarFocus = EqualityMutableLiveData(false)
 
+    val scrollToNextPage = MutableLiveData<Boolean?>(null)
+
     sealed interface LoadingStatus {
         data object NoOp : LoadingStatus
 
@@ -151,17 +153,20 @@ class StashGridViewModel : ViewModel() {
             val newQuery = searchEditText.text.toString().ifBlank { null }
             searchJob?.cancel()
 
-            val currentFilter = filterArgs.value!!
-            val findFilter =
-                currentFilter.findFilter
-                    ?: StashFindFilter(currentFilter.dataType.defaultSort)
-            if (findFilter.q != newQuery) {
-                searchJob =
-                    viewModelScope.launch(StashCoroutineExceptionHandler()) {
-                        delay(searchDelay)
-                        Log.v(TAG, "New query")
-                        setFilter(currentFilter.copy(findFilter = findFilter.copy(q = newQuery)))
-                    }
+            val currentFilter = filterArgs.value
+            if (currentFilter != null) {
+                val findFilter =
+                    currentFilter.findFilter
+                        ?: StashFindFilter(currentFilter.dataType.defaultSort)
+                val oldQuery = findFilter.q?.ifBlank { null }
+                if (oldQuery != newQuery) {
+                    searchJob =
+                        viewModelScope.launch(StashCoroutineExceptionHandler()) {
+                            delay(searchDelay)
+                            Log.v(TAG, "New query")
+                            setFilter(currentFilter.copy(findFilter = findFilter.copy(q = newQuery)))
+                        }
+                }
             }
         }
     }


### PR DESCRIPTION
Fix two issues when returning a filter grid page after scrolling down a lot

1. If originally from a 'View All', the position would jump back up to a page
2. Unnecessary fetch of the same data as if the search had changed