### PR TITLE
Add long press popup to play from current item

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/FilterFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/FilterFragment.kt
@@ -30,6 +30,7 @@ import com.github.damontecres.stashapp.util.FilterParser
 import com.github.damontecres.stashapp.util.QueryEngine
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashServer
+import com.github.damontecres.stashapp.util.addExtraGridLongClicks
 import com.github.damontecres.stashapp.util.getDestination
 import com.github.damontecres.stashapp.util.getFilterArgs
 import com.github.damontecres.stashapp.util.getMaxMeasuredWidth
@@ -75,9 +76,17 @@ class FilterFragment :
         dataType = startingFilter.dataType
         Log.d(TAG, "onCreate: dataType=$dataType")
 
+        val presenterSelector = StashPresenter.defaultClassPresenterSelector()
+        addExtraGridLongClicks(presenterSelector, dataType) {
+            FilterAndPosition(
+                stashGridViewModel.filterArgs.value!!,
+                stashGridViewModel.currentPosition.value ?: -1,
+            )
+        }
+
         stashGridViewModel.init(
             NullPresenterSelector(
-                StashPresenter.defaultClassPresenterSelector(),
+                presenterSelector,
                 NullPresenter(dataType),
             ),
         )

--- a/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/PerformerFragment.kt
@@ -1,6 +1,5 @@
 package com.github.damontecres.stashapp
 
-import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import android.text.SpannableString
@@ -117,7 +116,7 @@ class PerformerFragment : TabbedFragment(DataType.PERFORMER.name) {
                                 ClassPresenterSelector()
                                     .addClassPresenter(
                                         TagData::class.java,
-                                        TagPresenter(PerformersWithTagLongClickCallback()),
+                                        TagPresenter(performersWithTagLongClickCallback()),
                                     )
                             val fragment =
                                 StashGridControlsFragment(
@@ -135,7 +134,7 @@ class PerformerFragment : TabbedFragment(DataType.PERFORMER.name) {
                                     .addClassPresenter(
                                         PerformerData::class.java,
                                         PerformerPresenter(
-                                            PerformTogetherLongClickCallback(
+                                            performTogetherLongClickCallback(
                                                 performer,
                                             ),
                                         ),
@@ -173,93 +172,58 @@ class PerformerFragment : TabbedFragment(DataType.PERFORMER.name) {
         }
     }
 
-    private inner class PerformTogetherLongClickCallback(
-        val performer: PerformerData,
-    ) : StashPresenter.LongClickCallBack<PerformerData> {
-        override fun getPopUpItems(
-            context: Context,
-            item: PerformerData,
-        ): List<StashPresenter.PopUpItem> =
-            listOf(
-                StashPresenter.PopUpItem.getDefault(context),
-                StashPresenter.PopUpItem(1, "View scenes together"),
-            )
-
-        override fun onItemLongClick(
-            context: Context,
-            item: PerformerData,
-            popUpItem: StashPresenter.PopUpItem,
-        ) {
-            when (popUpItem.id) {
-                0L -> {
-                    serverViewModel.navigationManager.navigate(Destination.fromStashData(item))
-                }
-
-                1L -> {
-                    val performerIds = listOf(performer.id, item.id)
-                    val name = "${performer.name} & ${item.name}"
-                    val filter =
-                        FilterArgs(
-                            dataType = DataType.SCENE,
-                            name = name,
-                            objectFilter =
-                                SceneFilterType(
-                                    performers =
-                                        Optional.present(
-                                            MultiCriterionInput(
-                                                value = Optional.present(performerIds),
-                                                modifier = CriterionModifier.INCLUDES_ALL,
-                                            ),
+    private fun performTogetherLongClickCallback(performer: PerformerData) =
+        StashPresenter
+            .LongClickCallBack<PerformerData>(
+                StashPresenter.PopUpItem.DEFAULT to StashPresenter.PopUpAction { cardView, _ -> cardView.performClick() },
+            ).addAction(StashPresenter.PopUpItem(1L, "View scenes together")) { _, item ->
+                val performerIds = listOf(performer.id, item.id)
+                val name = "${performer.name} & ${item.name}"
+                val filter =
+                    FilterArgs(
+                        dataType = DataType.SCENE,
+                        name = name,
+                        objectFilter =
+                            SceneFilterType(
+                                performers =
+                                    Optional.present(
+                                        MultiCriterionInput(
+                                            value = Optional.present(performerIds),
+                                            modifier = CriterionModifier.INCLUDES_ALL,
                                         ),
-                                ),
-                        )
-                    serverViewModel.navigationManager.navigate(Destination.Filter(filter))
-                }
+                                    ),
+                            ),
+                    )
+                serverViewModel.navigationManager.navigate(Destination.Filter(filter))
             }
-        }
-    }
 
-    private inner class PerformersWithTagLongClickCallback : StashPresenter.LongClickCallBack<TagData> {
-        override fun getPopUpItems(
-            context: Context,
-            item: TagData,
-        ): List<StashPresenter.PopUpItem> =
-            listOf(
-                StashPresenter.PopUpItem.getDefault(context),
-                StashPresenter.PopUpItem(1, "View performers with this tag"),
-            )
-
-        override fun onItemLongClick(
-            context: Context,
-            item: TagData,
-            popUpItem: StashPresenter.PopUpItem,
-        ) {
-            when (popUpItem.id) {
-                StashPresenter.PopUpItem.DEFAULT_ID -> {
-                    serverViewModel.navigationManager.navigate(Destination.fromStashData(item))
-                }
-
-                1L -> {
-                    val name = "Performers with ${item.name}"
-                    val filter =
-                        FilterArgs(
-                            dataType = DataType.PERFORMER,
-                            name = name,
-                            objectFilter =
-                                PerformerFilterType(
-                                    tags =
-                                        Optional.present(
-                                            HierarchicalMultiCriterionInput(
-                                                value = Optional.present(listOf(item.id)),
-                                                modifier = CriterionModifier.INCLUDES_ALL,
-                                                depth = Optional.absent(),
-                                            ),
+    private fun performersWithTagLongClickCallback() =
+        StashPresenter
+            .LongClickCallBack<TagData>(
+                StashPresenter.PopUpItem.DEFAULT to StashPresenter.PopUpAction { cardView, _ -> cardView.performClick() },
+            ).addAction(
+                StashPresenter.PopUpItem(
+                    1,
+                    "View performers with this tag",
+                ),
+            ) { _, item ->
+                val name = "Performers with ${item.name}"
+                val filter =
+                    FilterArgs(
+                        dataType = DataType.PERFORMER,
+                        name = name,
+                        objectFilter =
+                            PerformerFilterType(
+                                tags =
+                                    Optional.present(
+                                        HierarchicalMultiCriterionInput(
+                                            value = Optional.present(listOf(item.id)),
+                                            modifier = CriterionModifier.INCLUDES_ALL,
+                                            depth = Optional.absent(),
                                         ),
-                                ),
-                        )
-                    serverViewModel.navigationManager.navigate(Destination.Filter(filter))
-                }
+                                    ),
+                            ),
+                    )
+                serverViewModel.navigationManager.navigate(Destination.Filter(filter))
             }
-        }
-    }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/SceneDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SceneDetailsFragment.kt
@@ -59,13 +59,13 @@ import com.github.damontecres.stashapp.presenters.TagPresenter
 import com.github.damontecres.stashapp.util.Constants
 import com.github.damontecres.stashapp.util.ListRowManager
 import com.github.damontecres.stashapp.util.MutationEngine
-import com.github.damontecres.stashapp.util.OCounterLongClickCallBack
 import com.github.damontecres.stashapp.util.QueryEngine
-import com.github.damontecres.stashapp.util.RemoveLongClickListener
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashDiffCallback
 import com.github.damontecres.stashapp.util.StashGlide
 import com.github.damontecres.stashapp.util.configRowManager
+import com.github.damontecres.stashapp.util.createOCounterLongClickCallBack
+import com.github.damontecres.stashapp.util.createRemoveLongClickListener
 import com.github.damontecres.stashapp.util.getDataType
 import com.github.damontecres.stashapp.util.getDestination
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
@@ -172,7 +172,7 @@ class SceneDetailsFragment : DetailsSupportFragment() {
                 ).addClassPresenter(
                     OCounter::class.java,
                     OCounterPresenter(
-                        OCounterLongClickCallBack(
+                        createOCounterLongClickCallBack(
                             DataType.SCENE,
                             sceneId,
                             mutationEngine,
@@ -378,19 +378,16 @@ class SceneDetailsFragment : DetailsSupportFragment() {
         markersRowManager.adapter.presenterSelector =
             SinglePresenterSelector(
                 MarkerPresenter(
-                    RemoveLongClickListener(
+                    createRemoveLongClickListener(
                         { viewLifecycleOwner.lifecycleScope },
                         markersRowManager,
-                        listOf(MARKER_DETAILS_POPUP),
-                    ) { context, item, popUpItem ->
-                        if (popUpItem.id == MARKER_DETAILS_POPUP.id) {
-                            serverViewModel.navigationManager.navigate(
-                                Destination.MarkerDetails(
-                                    item.id,
-                                    item.scene.videoSceneData.id,
-                                ),
-                            )
-                        }
+                    ).addAction(MARKER_DETAILS_POPUP) { _, item ->
+                        serverViewModel.navigationManager.navigate(
+                            Destination.MarkerDetails(
+                                item.id,
+                                item.scene.videoSceneData.id,
+                            ),
+                        )
                     },
                 ),
             )

--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridControlsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridControlsFragment.kt
@@ -21,12 +21,14 @@ import com.github.damontecres.stashapp.data.StashFindFilter
 import com.github.damontecres.stashapp.navigation.Destination
 import com.github.damontecres.stashapp.navigation.FilterAndPosition
 import com.github.damontecres.stashapp.navigation.NavigationOnItemViewClickedListener
+import com.github.damontecres.stashapp.presenters.ClassPresenterSelector
 import com.github.damontecres.stashapp.presenters.NullPresenter
 import com.github.damontecres.stashapp.presenters.NullPresenterSelector
 import com.github.damontecres.stashapp.presenters.StashPresenter
 import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.util.DefaultKeyEventCallback
 import com.github.damontecres.stashapp.util.StashServer
+import com.github.damontecres.stashapp.util.addExtraGridLongClicks
 import com.github.damontecres.stashapp.util.getFilterArgs
 import com.github.damontecres.stashapp.util.putFilterArgs
 import com.github.damontecres.stashapp.views.PlayAllOnClickListener
@@ -245,6 +247,15 @@ class StashGridControlsFragment() :
             playAllButton.visibility = View.VISIBLE
             playAllButton.nextFocusUpId = R.id.tab_layout
             playAllButton.text = getString(R.string.play_slideshow)
+        }
+
+        if (presenterSelector is ClassPresenterSelector) {
+            addExtraGridLongClicks(presenterSelector as ClassPresenterSelector, dataType) {
+                FilterAndPosition(
+                    viewModel.filterArgs.value!!,
+                    viewModel.currentPosition.value ?: -1,
+                )
+            }
         }
 
         filterButton.nextFocusUpId = R.id.tab_layout

--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
@@ -50,11 +50,11 @@ import com.github.damontecres.stashapp.presenters.StudioPresenter
 import com.github.damontecres.stashapp.presenters.TagPresenter
 import com.github.damontecres.stashapp.util.ListRowManager
 import com.github.damontecres.stashapp.util.MutationEngine
-import com.github.damontecres.stashapp.util.OCounterLongClickCallBack
 import com.github.damontecres.stashapp.util.QueryEngine
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.configRowManager
+import com.github.damontecres.stashapp.util.createOCounterLongClickCallBack
 import com.github.damontecres.stashapp.util.getDataType
 import com.github.damontecres.stashapp.util.height
 import com.github.damontecres.stashapp.util.isImageClip
@@ -382,7 +382,7 @@ class ImageDetailsFragment : DetailsSupportFragment() {
             itemPresenter.addClassPresenter(
                 OCounter::class.java,
                 OCounterPresenter(
-                    OCounterLongClickCallBack(
+                    createOCounterLongClickCallBack(
                         DataType.IMAGE,
                         newImage.id,
                         mutationEngine,

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistListFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistListFragment.kt
@@ -1,19 +1,16 @@
 package com.github.damontecres.stashapp.playback
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.leanback.widget.SinglePresenterSelector
 import androidx.leanback.widget.VerticalGridPresenter
 import androidx.lifecycle.lifecycleScope
-import androidx.media3.common.C
 import com.apollographql.apollo.api.Query
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.fragment.MarkerData
@@ -107,36 +104,7 @@ class PlaylistListFragment<T : Query.Data, D : StashData, Count : Query.Data> : 
         mGridPresenter.onBindViewHolder(mGridViewHolder, pagingAdapter)
         mGridPresenter.setOnItemViewClickedListener { itemViewHolder, item, rowViewHolder, row ->
             item as PlaylistItem
-            viewLifecycleOwner.lifecycleScope.launch(StashCoroutineExceptionHandler()) {
-                val player = parent.player!!
-                Log.v(
-                    TAG,
-                    "item.index=${item.index}, player.mediaItemCount=${player.mediaItemCount}",
-                )
-                // The play will ignore requests to play something not in the playlist
-                // So check if the index is out of bounds and add pages until either the item is available or there are not more pages
-                // The latter shouldn't happen until there's a bug
-                while (item.index >= player.mediaItemCount) {
-                    if (!parent.addNextPageToPlaylist()) {
-                        // This condition is most likely a bug
-                        Log.w(
-                            TAG,
-                            "Requested ${item.index} with ${player.mediaItemCount} media items in player, " +
-                                "but addNextPageToPlaylist returned no additional items",
-                        )
-                        Toast
-                            .makeText(
-                                requireContext(),
-                                "Unable to find item to play. This might be a bug!",
-                                Toast.LENGTH_LONG,
-                            ).show()
-                        return@launch
-                    }
-                    Log.v(TAG, "after fetch: player.mediaItemCount=${player.mediaItemCount}")
-                }
-                parent.hidePlaylist()
-                player.seekTo(item.index, C.TIME_UNSET)
-            }
+            parent.playIndex(item.index)
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ClassPresenterSelector.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ClassPresenterSelector.kt
@@ -1,0 +1,78 @@
+package com.github.damontecres.stashapp.presenters
+
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.PresenterSelector
+
+class ClassPresenterSelector : PresenterSelector() {
+    private val mPresenters = ArrayList<Presenter>()
+
+    private val mClassMap = HashMap<Class<*>?, Any>()
+
+    /**
+     * Sets a presenter to be used for the given class.
+     * @param cls The data model class to be rendered.
+     * @param presenter The presenter that renders the objects of the given class.
+     * @return This ClassPresenterSelector object.
+     */
+    fun addClassPresenter(
+        cls: Class<*>,
+        presenter: Presenter,
+    ): ClassPresenterSelector {
+        mClassMap[cls] = presenter
+        if (!mPresenters.contains(presenter)) {
+            mPresenters.add(presenter)
+        }
+        return this
+    }
+
+    /**
+     * Sets a presenter selector to be used for the given class.
+     * @param cls The data model class to be rendered.
+     * @param presenterSelector The presenter selector that finds the right presenter for a given
+     * class.
+     * @return This ClassPresenterSelector object.
+     */
+    fun addClassPresenterSelector(
+        cls: Class<*>,
+        presenterSelector: PresenterSelector,
+    ): ClassPresenterSelector {
+        mClassMap[cls] = presenterSelector
+        val innerPresenters = presenterSelector.presenters
+        for (i in innerPresenters.indices) {
+            if (!mPresenters.contains(innerPresenters[i])) {
+                mPresenters.add(innerPresenters[i])
+            }
+        }
+        return this
+    }
+
+    override fun getPresenter(item: Any): Presenter {
+        var cls: Class<*>? = item.javaClass
+        var presenter: Any? = null
+
+        do {
+            presenter = mClassMap[cls]
+            if (presenter is PresenterSelector) {
+                val innerPresenter = presenter.getPresenter(item)
+                if (innerPresenter != null) {
+                    return innerPresenter
+                }
+            }
+            cls = cls!!.superclass
+        } while (presenter == null && cls != null)
+
+        return presenter as Presenter
+    }
+
+    fun getPresenter(javaClass: Class<*>): Presenter {
+        var cls: Class<*>? = javaClass
+        var presenter: Any?
+        do {
+            presenter = mClassMap[cls]
+            cls = cls!!.superclass
+        } while (presenter == null && cls != null)
+        return presenter as Presenter
+    }
+
+    override fun getPresenters(): Array<Presenter> = mPresenters.toTypedArray<Presenter>()
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/MarkerPresenter.kt
@@ -1,11 +1,11 @@
 package com.github.damontecres.stashapp.presenters
 
-import android.content.Context
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.StashApplication
 import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.navigation.Destination
+import com.github.damontecres.stashapp.presenters.StashPresenter.PopUpAction
 import com.github.damontecres.stashapp.util.joinNotNullOrBlank
 import com.github.damontecres.stashapp.util.titleOrFilename
 import java.util.EnumMap
@@ -39,52 +39,28 @@ class MarkerPresenter(
         cardView.videoUrl = item.stream
     }
 
-    override fun getDefaultLongClickCallBack(cardView: StashImageCardView): LongClickCallBack<MarkerData> =
-        object : LongClickCallBack<MarkerData> {
-            override fun getPopUpItems(
-                context: Context,
-                item: MarkerData,
-            ): List<PopUpItem> =
-                listOf(
-                    PopUpItem(0L, context.getString(R.string.play_scene)),
-                    PopUpItem(1L, context.getString(R.string.go_to_scene)),
-                    PopUpItem(2L, context.getString(R.string.stashapp_details)),
-                )
-
-            override fun onItemLongClick(
-                context: Context,
-                item: MarkerData,
-                popUpItem: PopUpItem,
-            ) {
-                when (popUpItem.id) {
-                    0L -> {
-                        cardView.performClick()
-                    }
-
-                    1L -> {
-                        StashApplication.navigationManager.navigate(
-                            Destination.Item(
-                                DataType.SCENE,
-                                item.scene.videoSceneData.id,
-                            ),
-                        )
-                    }
-
-                    2L -> {
-                        StashApplication.navigationManager.navigate(
-                            Destination.MarkerDetails(
-                                item.id,
-                                item.scene.videoSceneData.id,
-                            ),
-                        )
-                    }
-
-                    else -> {
-                        throw IllegalStateException()
-                    }
-                }
-            }
-        }
+    override fun getDefaultLongClickCallBack(): LongClickCallBack<MarkerData> =
+        LongClickCallBack<MarkerData>(
+            PopUpItem.DEFAULT to PopUpAction { cardView, _ -> cardView.performClick() },
+            PopUpItem(1L, R.string.go_to_scene) to
+                PopUpAction { _, item ->
+                    StashApplication.navigationManager.navigate(
+                        Destination.Item(
+                            DataType.SCENE,
+                            item.scene.videoSceneData.id,
+                        ),
+                    )
+                },
+            PopUpItem(2L, R.string.stashapp_details) to
+                PopUpAction { _, item ->
+                    StashApplication.navigationManager.navigate(
+                        Destination.MarkerDetails(
+                            item.id,
+                            item.scene.videoSceneData.id,
+                        ),
+                    )
+                },
+        )
 
     companion object {
         private const val TAG = "MarkerPresenter"

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ScenePresenter.kt
@@ -1,13 +1,11 @@
 package com.github.damontecres.stashapp.presenters
 
-import android.content.Context
 import android.graphics.Typeface
 import com.github.damontecres.stashapp.StashApplication
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.navigation.Destination
 import com.github.damontecres.stashapp.playback.PlaybackMode
-import com.github.damontecres.stashapp.presenters.StashPresenter.PopUpItem.Companion.DEFAULT_ID
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.concatIfNotBlank
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
@@ -79,64 +77,43 @@ class ScenePresenter(
         }
     }
 
-    override fun getDefaultLongClickCallBack(cardView: StashImageCardView): LongClickCallBack<SlimSceneData> =
-        object : LongClickCallBack<SlimSceneData> {
-            override fun getPopUpItems(
-                context: Context,
-                item: SlimSceneData,
-            ): List<PopUpItem> =
-                if (item.resume_time != null && item.resume_time > 0) {
-                    // Has resume
-                    listOf(
-                        PopUpItem.getDefault(context),
-                        PopUpItem(1, "Resume Scene"),
-                        PopUpItem(2, "Restart Scene"),
-                    )
-                } else {
-                    listOf(
-                        PopUpItem.getDefault(context),
-                        PopUpItem(2, "Play Scene"),
-                    )
-                }
-
-            override fun onItemLongClick(
-                context: Context,
-                item: SlimSceneData,
-                popUpItem: PopUpItem,
-            ) {
-                when (popUpItem.id) {
-                    DEFAULT_ID -> {
-                        cardView.performClick()
-                    }
-
-                    1L -> {
-                        // Resume
-                        StashApplication.navigationManager.navigate(
-                            Destination.Playback(
-                                item.id,
-                                item.resume_position ?: 0L,
-                                PlaybackMode.CHOOSE,
-                            ),
-                        )
-                    }
-
-                    2L -> {
-                        // Restart/Play
-                        StashApplication.navigationManager.navigate(
-                            Destination.Playback(
-                                item.id,
-                                0L,
-                                PlaybackMode.CHOOSE,
-                            ),
-                        )
-                    }
-
-                    else -> {
-                        throw IllegalStateException("ID ${popUpItem.id}")
-                    }
-                }
+    override fun getDefaultLongClickCallBack(): LongClickCallBack<SlimSceneData> =
+        LongClickCallBack<SlimSceneData>()
+            .addAction(PopUpItem.DEFAULT) { cardView, _ -> cardView.performClick() }
+            .addAction(
+                PopUpItem(2, "Play Scene"),
+                { it.resume_position == null || it.resume_position!! <= 0 },
+            ) { _, item ->
+                StashApplication.navigationManager.navigate(
+                    Destination.Playback(
+                        item.id,
+                        0L,
+                        PlaybackMode.CHOOSE,
+                    ),
+                )
+            }.addAction(
+                PopUpItem(3, "Resume Scene"),
+                { it.resume_position != null && it.resume_position!! > 0 },
+            ) { _, item ->
+                StashApplication.navigationManager.navigate(
+                    Destination.Playback(
+                        item.id,
+                        item.resume_position ?: 0L,
+                        PlaybackMode.CHOOSE,
+                    ),
+                )
+            }.addAction(
+                PopUpItem(4, "Restart Scene"),
+                { it.resume_position != null && it.resume_position!! > 0 },
+            ) { _, item ->
+                StashApplication.navigationManager.navigate(
+                    Destination.Playback(
+                        item.id,
+                        0L,
+                        PlaybackMode.CHOOSE,
+                    ),
+                )
             }
-        }
 
     companion object {
         private const val TAG = "ScenePresenter"

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -45,8 +45,14 @@ import com.github.damontecres.stashapp.api.type.SceneFilterType
 import com.github.damontecres.stashapp.api.type.StashDataFilter
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.navigation.Destination
+import com.github.damontecres.stashapp.navigation.FilterAndPosition
 import com.github.damontecres.stashapp.navigation.NavigationManager
 import com.github.damontecres.stashapp.playback.PlaybackMode
+import com.github.damontecres.stashapp.presenters.ClassPresenterSelector
+import com.github.damontecres.stashapp.presenters.ImagePresenter
+import com.github.damontecres.stashapp.presenters.MarkerPresenter
+import com.github.damontecres.stashapp.presenters.ScenePresenter
+import com.github.damontecres.stashapp.presenters.StashPresenter
 import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.util.Constants.STASH_API_HEADER
 import com.github.damontecres.stashapp.views.fileNameFromPath
@@ -866,6 +872,54 @@ fun maybeStartPlayback(
                     PlaybackMode.CHOOSE,
                 ),
             )
+        }
+    }
+}
+
+fun addExtraGridLongClicks(
+    ps: ClassPresenterSelector,
+    dataType: DataType,
+    getFilterPosition: () -> FilterAndPosition,
+) {
+    when (dataType) {
+        DataType.SCENE -> {
+            val current = ps.getPresenter(SlimSceneData::class.java) as ScenePresenter
+            current.longClickCallBack.addAction(StashPresenter.PopUpItem.PLAY_FROM) { _, item ->
+                val (filter, position) = getFilterPosition.invoke()
+                if (position >= 0) {
+                    StashApplication.navigationManager.navigate(
+                        Destination.Playlist(filter, position),
+                    )
+                }
+            }
+        }
+
+        DataType.MARKER -> {
+            val current = ps.getPresenter(MarkerData::class.java) as MarkerPresenter
+            current.longClickCallBack.addAction(StashPresenter.PopUpItem.PLAY_FROM) { _, item ->
+                val (filter, position) = getFilterPosition.invoke()
+                if (position >= 0) {
+                    StashApplication.navigationManager.navigate(
+                        Destination.Playlist(filter, position, 30_000L),
+                    )
+                }
+            }
+        }
+
+        DataType.IMAGE -> {
+            val current = ps.getPresenter(ImageData::class.java) as ImagePresenter
+            current.longClickCallBack.addAction(StashPresenter.PopUpItem.PLAY_FROM) { _, item ->
+                val (filter, position) = getFilterPosition.invoke()
+                if (position >= 0) {
+                    StashApplication.navigationManager.navigate(
+                        Destination.Slideshow(filter, position, true),
+                    )
+                }
+            }
+        }
+
+        else -> {
+            // no-op
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/ListRowManager.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/ListRowManager.kt
@@ -146,6 +146,13 @@ fun <T : StashData> configRowManager(
 ) {
     if (rowManager.adapter.presenterSelector == null) {
         rowManager.adapter.presenterSelector =
-            SinglePresenterSelector(presenter.invoke(RemoveLongClickListener(scope, rowManager)))
+            SinglePresenterSelector(
+                presenter.invoke(
+                    createRemoveLongClickListener(
+                        scope,
+                        rowManager,
+                    ),
+                ),
+            )
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/OCounterLongClickCallBack.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/OCounterLongClickCallBack.kt
@@ -1,6 +1,5 @@
 package com.github.damontecres.stashapp.util
 
-import android.content.Context
 import android.view.View
 import android.view.View.OnClickListener
 import android.view.View.OnLongClickListener
@@ -9,89 +8,106 @@ import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.OCounter
 import com.github.damontecres.stashapp.presenters.PopupOnLongClickListener
+import com.github.damontecres.stashapp.presenters.StashImageCardView
 import com.github.damontecres.stashapp.presenters.StashPresenter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-/**
- * Handles modifying the O-Counter for a scene
- */
-class OCounterLongClickCallBack(
-    private val dataType: DataType,
-    private val id: String,
-    private val mutationEngine: MutationEngine,
-    private val scope: CoroutineScope,
-    private val callBack: (newOCounter: OCounter) -> Unit,
-) : StashPresenter.LongClickCallBack<OCounter>,
-    OnClickListener,
-    OnLongClickListener {
-    override fun getPopUpItems(
-        context: Context,
-        item: OCounter,
-    ): List<StashPresenter.PopUpItem> =
-        listOf(
-            StashPresenter.PopUpItem(1000L, context.getString(R.string.increment)),
-            StashPresenter.PopUpItem(1001L, context.getString(R.string.decrement)),
-            StashPresenter.PopUpItem(1002L, context.getString(R.string.reset)),
-        )
-
-    override fun onItemLongClick(
-        context: Context,
-        item: OCounter,
-        popUpItem: StashPresenter.PopUpItem,
-    ) {
+fun oCounterAction(
+    scope: CoroutineScope,
+    id: String,
+    action: suspend (String) -> Unit,
+): StashPresenter.PopUpAction<OCounter> =
+    StashPresenter.PopUpAction<OCounter> { cardView, item ->
         scope.launch(
             StashCoroutineExceptionHandler(
                 Toast.makeText(
-                    context,
-                    context.getString(R.string.failed_o_counter),
+                    cardView.context,
+                    cardView.context.getString(R.string.failed_o_counter),
                     Toast.LENGTH_SHORT,
                 ),
             ),
         ) {
-            val newOCounter =
-                when (popUpItem.id) {
-                    1000L ->
-                        if (dataType == DataType.SCENE) {
-                            mutationEngine.incrementOCounter(id)
-                        } else {
-                            mutationEngine.incrementImageOCounter(id)
-                        }
-
-                    1001L ->
-                        if (dataType == DataType.SCENE) {
-                            mutationEngine.decrementOCounter(id)
-                        } else {
-                            mutationEngine.decrementImageOCounter(id)
-                        }
-
-                    1002L ->
-                        if (dataType == DataType.SCENE) {
-                            mutationEngine.resetOCounter(id)
-                        } else {
-                            mutationEngine.resetImageOCounter(id)
-                        }
-                    else -> throw IllegalArgumentException("Unknown id ${popUpItem.id}")
-                }
-            callBack(newOCounter)
+            action(id)
         }
     }
 
+fun createOCounterLongClickCallBack(
+    dataType: DataType,
+    id: String,
+    mutationEngine: MutationEngine,
+    scope: CoroutineScope,
+    callBack: (newOCounter: OCounter) -> Unit,
+): StashPresenter.LongClickCallBack<OCounter> =
+    StashPresenter
+        .LongClickCallBack<OCounter>()
+        .addAction(
+            StashPresenter.PopUpItem(1000L, R.string.increment),
+            { readOnlyModeDisabled() },
+            oCounterAction(scope, id) {
+                callBack(
+                    if (dataType == DataType.SCENE) {
+                        mutationEngine.incrementOCounter(id)
+                    } else {
+                        mutationEngine.incrementImageOCounter(id)
+                    },
+                )
+            },
+        ).addAction(
+            StashPresenter.PopUpItem(1001L, R.string.decrement),
+            { readOnlyModeDisabled() },
+            oCounterAction(scope, id) {
+                callBack(
+                    if (dataType == DataType.SCENE) {
+                        mutationEngine.decrementOCounter(id)
+                    } else {
+                        mutationEngine.decrementImageOCounter(id)
+                    },
+                )
+            },
+        ).addAction(
+            StashPresenter.PopUpItem(1002L, R.string.reset),
+            { readOnlyModeDisabled() },
+            oCounterAction(scope, id) {
+                callBack(
+                    if (dataType == DataType.SCENE) {
+                        mutationEngine.resetOCounter(id)
+                    } else {
+                        mutationEngine.resetImageOCounter(id)
+                    },
+                )
+            },
+        )
+
+/**
+ * Handles modifying the O-Counter for a scene/image
+ */
+class OCounterLongClickCallBack(
+    dataType: DataType,
+    id: String,
+    mutationEngine: MutationEngine,
+    scope: CoroutineScope,
+    callBack: (newOCounter: OCounter) -> Unit,
+) : OnClickListener,
+    OnLongClickListener {
+    val longClickCallback =
+        createOCounterLongClickCallBack(dataType, id, mutationEngine, scope, callBack)
+
     override fun onClick(v: View) {
         val fake = OCounter("", 0)
-        val items = getPopUpItems(v.context, fake)
-        onItemLongClick(v.context, fake, items[0])
+        val items = longClickCallback.getPopUpItems(fake)
+        longClickCallback.onItemLongClick(v as StashImageCardView, fake, items[0])
     }
 
     override fun onLongClick(v: View): Boolean {
         val fake = OCounter("", 0)
-        val items = getPopUpItems(v.context, fake)
+        val items = longClickCallback.getPopUpItems(fake)
         PopupOnLongClickListener(
             items.map {
                 it.text
             },
         ) { _, _, position, _ ->
-            onItemLongClick(v.context, fake, items[position])
+            longClickCallback.onItemLongClick(v as StashImageCardView, fake, items[position])
         }.onLongClick(v)
         return true
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/RemoveLongClickListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/RemoveLongClickListener.kt
@@ -1,62 +1,32 @@
 package com.github.damontecres.stashapp.util
 
-import android.content.Context
 import android.util.Log
 import android.widget.Toast
-import com.github.damontecres.stashapp.StashApplication
 import com.github.damontecres.stashapp.api.fragment.StashData
 import com.github.damontecres.stashapp.filter.extractTitle
-import com.github.damontecres.stashapp.navigation.Destination
 import com.github.damontecres.stashapp.presenters.StashPresenter
-import com.github.damontecres.stashapp.presenters.StashPresenter.PopUpItem.Companion.GO_TO_POPUP_ITEM
 import com.github.damontecres.stashapp.presenters.StashPresenter.PopUpItem.Companion.REMOVE_POPUP_ITEM
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-/**
- * A [StashPresenter.LongClickCallBack] which shows a 'Go To' or 'Remove' popups
- */
-class RemoveLongClickListener<T : StashData>(
-    private val scope: () -> CoroutineScope,
-    private val rowManager: ListRowManager<T>,
-    private val extraPopupItems: List<StashPresenter.PopUpItem> = emptyList(),
-    private val extraPopupHandler: ((context: Context, item: T, popUpItem: StashPresenter.PopUpItem) -> Unit)? = null,
-) : StashPresenter.LongClickCallBack<T> {
-    override fun getPopUpItems(
-        context: Context,
-        item: T,
-    ): List<StashPresenter.PopUpItem> =
-        if (readOnlyModeDisabled()) {
-            listOf(GO_TO_POPUP_ITEM, *extraPopupItems.toTypedArray(), REMOVE_POPUP_ITEM)
-        } else {
-            listOf(GO_TO_POPUP_ITEM, *extraPopupItems.toTypedArray())
-        }
-
-    override fun onItemLongClick(
-        context: Context,
-        item: T,
-        popUpItem: StashPresenter.PopUpItem,
-    ) {
-        when (popUpItem.id) {
-            StashPresenter.PopUpItem.DEFAULT_ID -> {
-                StashApplication.navigationManager.navigate(Destination.fromStashData(item))
-            }
-            StashPresenter.PopUpItem.REMOVE_ID -> {
-                if (readOnlyModeDisabled()) {
-                    scope.invoke().launch(StashCoroutineExceptionHandler(autoToast = true)) {
-                        Log.v(TAG, "Removing id=${item.id} (${item::class.simpleName})")
-                        if (rowManager.remove(item)) {
-                            val name = extractTitle(item)
-                            Toast.makeText(context, "Removed '$name'", Toast.LENGTH_SHORT).show()
-                        }
+fun <T : StashData> createRemoveLongClickListener(
+    scope: () -> CoroutineScope,
+    rowManager: ListRowManager<T>,
+): StashPresenter.LongClickCallBack<T> =
+    StashPresenter
+        .LongClickCallBack<T>(
+            StashPresenter.PopUpItem.DEFAULT to StashPresenter.PopUpAction { cardView, _ -> cardView.performClick() },
+        ).addAction(REMOVE_POPUP_ITEM, { readOnlyModeDisabled() }) { cardView, item ->
+            if (readOnlyModeDisabled()) {
+                scope.invoke().launch(StashCoroutineExceptionHandler(autoToast = true)) {
+                    Log.v(
+                        "RemoveLongClickListener",
+                        "Removing id=${item.id} (${item::class.simpleName})",
+                    )
+                    if (rowManager.remove(item)) {
+                        val name = extractTitle(item)
+                        Toast.makeText(cardView.context, "Removed '$name'", Toast.LENGTH_SHORT).show()
                     }
                 }
             }
-            else -> extraPopupHandler!!.invoke(context, item, popUpItem)
         }
-    }
-
-    companion object {
-        private const val TAG = "RemoveLongClickListener"
-    }
-}


### PR DESCRIPTION
Adds a new popup to grid pages for scenes, markers, & images to start a playlist from the selected item.

Behind the scenes, `LongClickCallback` is completely rewritten to allow for dynamically adding new actions to the popup menu.