### PR TITLE
Prevent content showing briefly before PIN screen

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/RootActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/RootActivity.kt
@@ -130,9 +130,12 @@ class RootActivity :
         }
     }
 
-    override fun onRestart() {
-        super.onRestart()
-        Log.v(TAG, "onRestart")
+    override fun onPause() {
+        Log.v(TAG, "onPause")
+        if (appHasPin()) {
+            navigationManager.navigate(Destination.Pin)
+        }
+        super.onPause()
     }
 
     override fun onNavigate(


### PR DESCRIPTION
Previously, when returning to the app, the previous page/content might flash briefly before the PIN screen is shown. This PR switches to the PIN when the app is pausing to prevent this.

Also make sure that if a PIN is added, it is used immediately instead of needing the app to restart before taking effect.