### PR TITLE
Fix marker with negative seconds

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistMarkersFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistMarkersFragment.kt
@@ -30,7 +30,7 @@ class PlaylistMarkersFragment : PlaylistFragment<FindMarkersQuery.Data, MarkerDa
     override fun builderCallback(item: MarkerData): (MediaItem.Builder.() -> Unit) =
         {
             // Clip the media item to a start position & duration
-            val startPos = (item.seconds * 1000).toLong()
+            val startPos = (item.seconds * 1000).toLong().coerceAtLeast(0L)
             val clipConfig =
                 MediaItem.ClippingConfiguration
                     .Builder()


### PR DESCRIPTION
It's possible that markers have a tiny negative fraction for the `seconds` field which will cause playback errors.

This PR forces a minimum value of 0 seconds.