### PR TITLE
Add more detailed playback debug info

### DIFF
--- a/app/src/main/res/layout/debug_supported_row.xml
+++ b/app/src/main/res/layout/debug_supported_row.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TableRow xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+        <TextView
+            style="@style/DebugInfoOverlayText"
+            tools:text="@string/id" />
+
+        <TextView
+            style="@style/DebugInfoOverlayText"
+            tools:text="@string/stashapp_type" />
+
+        <TextView
+            style="@style/DebugInfoOverlayText"
+            tools:text="@string/selected" />
+
+        <TextView
+            style="@style/DebugInfoOverlayText"
+            tools:text="@string/codec" />
+
+        <TextView
+            style="@style/DebugInfoOverlayText"
+            tools:text="@string/supported" />
+
+        <TextView
+            style="@style/DebugInfoOverlayText"
+            tools:text="@string/labels" />
+
+</TableRow>

--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -19,92 +19,148 @@
     android:layoutDirection="ltr"
     android:orientation="vertical">
 
-    <TableLayout
+    <LinearLayout
         android:id="@+id/playback_debug_info"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="@color/transparent_black_50"
+        android:orientation="horizontal"
         android:layout_margin="4dp"
-        android:padding="4dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         android:visibility="gone"
         tools:visibility="visible">
 
-        <TableRow>
+        <TableLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"
+            android:padding="4dp"
+            android:background="@color/transparent_black_50">
+
+            <TableRow>
+
+                <TextView
+                    style="@style/DebugInfoOverlayText"
+                    android:text="@string/stashapp_scene_id" />
+
+                <TextView
+                    android:id="@+id/debug_scene_id"
+                    style="@style/DebugInfoOverlayText"
+                    tools:text="1234" />
+            </TableRow>
+
+            <TableRow>
+
+                <TextView
+                    style="@style/DebugInfoOverlayText"
+                    android:text="@string/playback" />
+
+                <TextView
+                    android:id="@+id/debug_playback"
+                    style="@style/DebugInfoOverlayText"
+                    tools:text="Direct" />
+            </TableRow>
+
+            <TableRow>
+
+                <TextView
+                    style="@style/DebugInfoOverlayText"
+                    android:text="@string/stashapp_video_codec" />
+
+                <TextView
+                    android:id="@+id/debug_video"
+                    style="@style/DebugInfoOverlayText"
+                    tools:text="h264" />
+            </TableRow>
+
+            <TableRow>
+
+                <TextView
+                    style="@style/DebugInfoOverlayText"
+                    android:text="@string/stashapp_audio_codec" />
+
+                <TextView
+                    android:id="@+id/debug_audio"
+                    style="@style/DebugInfoOverlayText"
+                    tools:text="ac3" />
+            </TableRow>
+
+            <TableRow>
+
+                <TextView
+                    style="@style/DebugInfoOverlayText"
+                    android:text="@string/format" />
+
+                <TextView
+                    android:id="@+id/debug_container_format"
+                    style="@style/DebugInfoOverlayText"
+                    tools:text="mp4" />
+            </TableRow>
+
+            <TableRow>
+
+                <TextView
+                    style="@style/DebugInfoOverlayText"
+                    android:text="Playlist" />
+
+                <TextView
+                    android:id="@+id/debug_playlist"
+                    style="@style/DebugInfoOverlayText"
+                    android:text="N/A"
+                    tools:text="2 of 25 (100)" />
+            </TableRow>
+
+        </TableLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_margin="4dp"
+            android:padding="4dp"
+            android:background="@color/transparent_black_50">
 
             <TextView
-                style="@style/DebugInfoOverlayText"
-                android:text="@string/stashapp_scene_id" />
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/stream_details"
+                android:textSize="14sp"
+                style="@style/DebugInfoOverlayText" />
 
-            <TextView
-                android:id="@+id/debug_scene_id"
-                style="@style/DebugInfoOverlayText"
-                tools:text="1234" />
-        </TableRow>
+            <TableLayout
+                android:id="@+id/debug_supported_table"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
 
-        <TableRow>
+                <TableRow tools:ignore="UselessParent">
 
-            <TextView
-                style="@style/DebugInfoOverlayText"
-                android:text="@string/playback" />
+                    <TextView
+                        style="@style/DebugInfoOverlayText"
+                        android:text="@string/id" />
 
-            <TextView
-                android:id="@+id/debug_playback"
-                style="@style/DebugInfoOverlayText"
-                tools:text="Direct" />
-        </TableRow>
+                    <TextView
+                        style="@style/DebugInfoOverlayText"
+                        android:text="@string/stashapp_type" />
 
-        <TableRow>
+                    <TextView
+                        style="@style/DebugInfoOverlayText"
+                        android:text="@string/selected" />
 
-            <TextView
-                style="@style/DebugInfoOverlayText"
-                android:text="@string/stashapp_video_codec" />
+                    <TextView
+                        style="@style/DebugInfoOverlayText"
+                        android:text="@string/codec" />
 
-            <TextView
-                android:id="@+id/debug_video"
-                style="@style/DebugInfoOverlayText"
-                tools:text="h264" />
-        </TableRow>
+                    <TextView
+                        style="@style/DebugInfoOverlayText"
+                        android:text="@string/supported" />
 
-        <TableRow>
-
-            <TextView
-                style="@style/DebugInfoOverlayText"
-                android:text="@string/stashapp_audio_codec" />
-
-            <TextView
-                android:id="@+id/debug_audio"
-                style="@style/DebugInfoOverlayText"
-                tools:text="ac3" />
-        </TableRow>
-
-        <TableRow>
-
-            <TextView
-                style="@style/DebugInfoOverlayText"
-                android:text="@string/format" />
-
-            <TextView
-                android:id="@+id/debug_container_format"
-                style="@style/DebugInfoOverlayText"
-                tools:text="mp4" />
-        </TableRow>
-
-        <TableRow>
-
-            <TextView
-                style="@style/DebugInfoOverlayText"
-                android:text="Playlist" />
-
-            <TextView
-                android:id="@+id/debug_playlist"
-                style="@style/DebugInfoOverlayText"
-                android:text="N/A"
-                tools:text="2 of 25 (100)" />
-        </TableRow>
-
-    </TableLayout>
+                    <TextView
+                        style="@style/DebugInfoOverlayText"
+                        android:text="@string/labels" />
+                </TableRow>
+            </TableLayout>
+        </LinearLayout>
+    </LinearLayout>
 
     <LinearLayout
         android:id="@id/exo_center_controls"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" translatable="false">StashAppAndroidTV</string>
     <string name="browse_title" translatable="false">Stash</string>
     <string name="play_scene" translatable="false">Play</string>
@@ -81,5 +81,10 @@
     <string name="apply_filters">Apply Filters</string>
     <string name="more_like_this_scene">More like this scene</string>
     <string name="id">ID</string>
+    <string name="selected" tools:override="true">Selected</string>
+    <string name="codec">Codec</string>
+    <string name="supported">Supported</string>
+    <string name="labels">Labels</string>
+    <string name="stream_details">Stream Details</string>
 
 </resources>


### PR DESCRIPTION
Adds a second overlay when playback debug mode is enabled which shows the current stream's detailed information.

**Note:** this shows the _stream's_ details, so if the video is being transcoded, these details will be for the transcoded stream, not the original file!

![video_overlay](https://github.com/user-attachments/assets/9615c02e-6bb0-49d7-9727-ec55656b979d)
