### PR TITLE
Fix toasts during updates & clean up files

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/navigation/Destination.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/navigation/Destination.kt
@@ -114,7 +114,9 @@ sealed class Destination {
     @Serializable
     data class UpdateApp(
         val release: Release,
-    ) : Destination()
+    ) : Destination() {
+        override fun toString(): String = "UpdateApp(version=${release.version})"
+    }
 
     @Serializable
     data class ManageServers(

--- a/app/src/main/java/com/github/damontecres/stashapp/util/UpdateChecker.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/UpdateChecker.kt
@@ -137,6 +137,7 @@ class UpdateChecker {
             release: Release,
         ) {
             withContext(Dispatchers.IO) {
+                cleanup(activity)
                 val client = OkHttpClient.Builder().build()
                 val request =
                     Request
@@ -176,12 +177,11 @@ class UpdateChecker {
                                 activity.startActivity(intent)
                             } else {
                                 Log.e(TAG, "Resolver URI is null")
-                                Toast
-                                    .makeText(
-                                        activity,
-                                        "There was an error downloading the release",
-                                        Toast.LENGTH_LONG,
-                                    ).show()
+                                showToastOnMain(
+                                    activity,
+                                    "There was an error downloading the release",
+                                    Toast.LENGTH_LONG,
+                                )
                             }
                         } else {
                             if (ContextCompat.checkSelfPermission(
@@ -229,12 +229,11 @@ class UpdateChecker {
                         }
                     } else {
                         Log.v(TAG, "Request failed for ${release.downloadUrl}: ${it.code}")
-                        Toast
-                            .makeText(
-                                activity,
-                                "Error downloading release: ${it.message}",
-                                Toast.LENGTH_LONG,
-                            ).show()
+                        showToastOnMain(
+                            activity,
+                            "Error downloading release: ${it.message}",
+                            Toast.LENGTH_LONG,
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Related to #535 

Ensure error toasts show on the main thread. Also always clean up previous apks before downloading the new one.