### PR TITLE
Always reset player for playback (fix no audio)

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageClipFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageClipFragment.kt
@@ -7,14 +7,10 @@ import androidx.fragment.app.viewModels
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.ExoPlayer
-import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.R
-import com.github.damontecres.stashapp.StashExoPlayer
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.playback.CodecSupport
 import com.github.damontecres.stashapp.playback.PlaybackFragment
-import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.isImageClip
 import com.github.damontecres.stashapp.views.models.ImageViewModel
 
@@ -81,28 +77,14 @@ class ImageClipFragment :
         }
     }
 
-    override fun createPlayer(): ExoPlayer {
-        val skipForward =
-            PreferenceManager
-                .getDefaultSharedPreferences(requireContext())
-                .getInt("skip_forward_time", 30)
-        val skipBack =
-            PreferenceManager
-                .getDefaultSharedPreferences(requireContext())
-                .getInt("skip_back_time", 10)
-        return StashExoPlayer
-            .getInstance(
-                requireContext(),
-                StashServer.requireCurrentServer(),
-                skipForward * 1000L,
-                skipBack * 1000L,
-            )
+    override fun Player.setupPlayer() {
+        // no-op
     }
 
-    override fun postCreatePlayer(player: Player) {
-        player.repeatMode = Player.REPEAT_MODE_ONE
-        player.prepare()
-        player.play()
+    override fun Player.postSetupPlayer() {
+        repeatMode = Player.REPEAT_MODE_ONE
+        prepare()
+        play()
     }
 
     override fun play() {

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
@@ -10,7 +10,6 @@ import androidx.fragment.app.setFragmentResult
 import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.StashApplication
@@ -27,14 +26,13 @@ class PlaybackSceneFragment : PlaybackFragment() {
     override val optionsButtonOptions: OptionsButtonOptions
         get() = OptionsButtonOptions(DataType.SCENE, false)
 
-    override fun createPlayer(): ExoPlayer =
-        StashExoPlayer
-            .getInstance(requireContext(), serverViewModel.requireServer())
-            .also { it.repeatMode = Player.REPEAT_MODE_OFF }
+    override fun Player.setupPlayer() {
+        repeatMode = Player.REPEAT_MODE_OFF
+    }
 
     @OptIn(UnstableApi::class)
-    override fun postCreatePlayer(player: Player) {
-        maybeAddActivityTracking(player)
+    override fun Player.postSetupPlayer() {
+        maybeAddActivityTracking(this)
 
         val finishedBehavior =
             PreferenceManager
@@ -45,7 +43,7 @@ class PlaybackSceneFragment : PlaybackFragment() {
                 )
         when (finishedBehavior) {
             getString(R.string.playback_finished_repeat) -> {
-                player.repeatMode = Player.REPEAT_MODE_ONE
+                repeatMode = Player.REPEAT_MODE_ONE
             }
 
             getString(R.string.playback_finished_return) ->

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistMarkersFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistMarkersFragment.kt
@@ -11,6 +11,7 @@ import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.navigation.Destination
+import com.github.damontecres.stashapp.util.SkipParams
 import com.github.damontecres.stashapp.util.getDestination
 import kotlin.properties.Delegates
 
@@ -51,8 +52,11 @@ class PlaylistMarkersFragment : PlaylistFragment<FindMarkersQuery.Data, MarkerDa
         val skipBack = prefs.getInt("skip_back_time", 10).toLong() * 1000L
 
         // Override the skip forward/back since many users will have default seeking values larger than the duration
-        super.skipForwardOverride = (duration / 4).coerceAtMost(skipForward)
-        super.skipBackOverride = (duration / 4).coerceAtMost(skipBack)
+        super.skipParams =
+            SkipParams.Values(
+                (duration / 4).coerceAtMost(skipForward),
+                (duration / 4).coerceAtMost(skipBack),
+            )
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/SkipParams.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/SkipParams.kt
@@ -1,0 +1,13 @@
+package com.github.damontecres.stashapp.util
+
+sealed class SkipParams(
+    val skipForward: Long,
+    val skipBack: Long,
+) {
+    data object Default : SkipParams(-1, -1)
+
+    class Values(
+        skipForward: Long,
+        skipBack: Long,
+    ) : SkipParams(skipForward, skipBack)
+}


### PR DESCRIPTION
Follow up to #538 

Always recreate the player when starting playback for scenes or markers. This ensures a fresh newly configured player without any of the overrides used for the cards' previews.

Before this PR, if card previews was enabled and card preview audio was disabled, then scene playback would start with audio disabled.

Also refactors to force correct initialization of the player in `PlaybackFragment`.