### PR TITLE
Fix playback activity not being tracked

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/StashExoPlayer.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashExoPlayer.kt
@@ -117,6 +117,8 @@ class StashExoPlayer private constructor() {
         fun addListener(listener: Player.Listener) {
             if (instance == null) {
                 Log.w(TAG, "Cannot add listener to null instance")
+            } else if (listeners.contains(listener)) {
+                Log.w(TAG, "Listener already added")
             } else {
                 listeners.add(listener)
                 instance?.addListener(listener)
@@ -128,6 +130,14 @@ class StashExoPlayer private constructor() {
                 instance?.removeListener(it)
             }
             listeners.clear()
+        }
+
+        fun removeListener(listener: Player.Listener) {
+            if (listeners.remove(listener)) {
+                instance?.removeListener(listener)
+            } else {
+                Log.w(TAG, "Listener was not added previously")
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
@@ -48,7 +48,6 @@ import com.github.damontecres.stashapp.util.OCounterLongClickCallBack
 import com.github.damontecres.stashapp.util.SkipParams
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashPreviewLoader
-import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.animateToInvisible
 import com.github.damontecres.stashapp.util.animateToVisible
 import com.github.damontecres.stashapp.util.getDataType
@@ -697,22 +696,22 @@ abstract class PlaybackFragment(
         }
     }
 
-    protected fun maybeAddActivityTracking(exoPlayer: Player) {
+    protected fun maybeAddActivityTracking(scene: Scene) {
         val appTracking =
             PreferenceManager
                 .getDefaultSharedPreferences(requireContext())
                 .getBoolean(getString(R.string.pref_key_playback_track_activity), true)
-        val server = StashServer.requireCurrentServer()
-        if (appTracking && server.serverPreferences.trackActivity && currentScene != null) {
+        val server = serverViewModel.requireServer()
+        if (appTracking && server.serverPreferences.trackActivity) {
             Log.v(TAG, "Adding TrackActivityPlaybackListener")
             trackActivityListener =
                 TrackActivityPlaybackListener(
                     context = requireContext(),
-                    mutationEngine = MutationEngine(server),
-                    scene = currentScene!!,
+                    server = server,
+                    scene = scene,
                     getCurrentPosition = ::currentVideoPosition,
                 )
-            exoPlayer.addListener(trackActivityListener!!)
+            StashExoPlayer.addListener(trackActivityListener!!)
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
@@ -32,8 +32,9 @@ class PlaybackSceneFragment : PlaybackFragment() {
 
     @OptIn(UnstableApi::class)
     override fun Player.postSetupPlayer() {
-        maybeAddActivityTracking(this)
-
+        currentScene?.let {
+            maybeAddActivityTracking(it)
+        }
         val finishedBehavior =
             PreferenceManager
                 .getDefaultSharedPreferences(requireContext())
@@ -91,10 +92,10 @@ class PlaybackSceneFragment : PlaybackFragment() {
 
         viewModel.scene.observe(viewLifecycleOwner) { scene ->
             currentScene = scene
-
             if (scene == null) {
                 return@observe
             }
+            maybeAddActivityTracking(scene)
             val position =
                 if (playbackPosition >= 0) {
                     playbackPosition

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistFragment.kt
@@ -1,5 +1,6 @@
 package com.github.damontecres.stashapp.playback
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -19,7 +20,6 @@ import com.apollographql.apollo.api.Query
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.StashExoPlayer
 import com.github.damontecres.stashapp.api.fragment.StashData
-import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.navigation.Destination
 import com.github.damontecres.stashapp.suppliers.DataSupplierFactory
@@ -109,10 +109,6 @@ abstract class PlaylistFragment<T : Query.Data, D : StashData, C : Query.Data> :
             },
         )
         StashExoPlayer.addListener(PlaylistListener())
-        if (playlistViewModel.filterArgs.value?.dataType == DataType.SCENE) {
-            // Only track activity for scene playback
-            maybeAddActivityTracking(this)
-        }
         repeatMode = Player.REPEAT_MODE_OFF
         if (videoView.controllerShowTimeoutMs > 0) {
             videoView.hideController()
@@ -219,6 +215,7 @@ abstract class PlaylistFragment<T : Query.Data, D : StashData, C : Query.Data> :
      */
     abstract fun builderCallback(item: D): (MediaItem.Builder.() -> Unit)?
 
+    @SuppressLint("SetTextI18n")
     private fun updatePlaylistDebug() {
         debugPlaylistTextView.text =
             "${player?.currentMediaItemIndex?.plus(1)} of ${player?.mediaItemCount} ($totalCount)"
@@ -250,11 +247,11 @@ abstract class PlaylistFragment<T : Query.Data, D : StashData, C : Query.Data> :
                 updatePlaylistDebug()
 
                 // Replace activity tracker
-                if (trackActivityListener != null) {
-                    trackActivityListener?.release()
-                    player!!.removeListener(trackActivityListener!!)
+                trackActivityListener?.let {
+                    it.release()
+                    StashExoPlayer.removeListener(it)
                 }
-                maybeAddActivityTracking(player!!)
+                maybeAddActivityTracking(scene)
             }
             if (hasMorePages) {
                 val count = player!!.mediaItemCount

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/TrackActivityPlaybackListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/TrackActivityPlaybackListener.kt
@@ -9,6 +9,7 @@ import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.util.MutationEngine
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
+import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.toMilliseconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -26,14 +27,15 @@ import kotlin.time.toDuration
 @OptIn(UnstableApi::class)
 class TrackActivityPlaybackListener(
     context: Context,
-    private val mutationEngine: MutationEngine,
+    private val server: StashServer,
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
     private val scene: Scene,
     private val getCurrentPosition: () -> Long,
 ) : Player.Listener {
+    private val mutationEngine = MutationEngine(server)
     private val coroutineScope = CoroutineScope(dispatcher)
     private val timer: Timer
-    private val minimumPlayPercent = mutationEngine.server.serverPreferences.minimumPlayPercent
+    private val minimumPlayPercent = server.serverPreferences.minimumPlayPercent
     private val maxPlayPercent: Int
 
     private var totalPlayDurationSeconds = AtomicInteger(0)
@@ -153,6 +155,24 @@ class TrackActivityPlaybackListener(
                 mutationEngine.saveSceneActivity(scene.id, calcPosition, duration)
             }
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TrackActivityPlaybackListener
+
+        if (server != other.server) return false
+        if (scene != other.scene) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = server.hashCode()
+        result = 31 * result + scene.hashCode()
+        return result
     }
 
     companion object {


### PR DESCRIPTION
Fixes #542 

Fixes the playback activity tracking. Still needs to be enabled server-side and app-side.

The transition to MVVM changed the order for initializing the listener. So this PR refactoring things a bit to set it up and also guard against multiple running.