### PR TITLE
Update slideshow settings

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsUiFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsUiFragment.kt
@@ -23,18 +23,35 @@ class SettingsUiFragment : LeanbackPreferenceFragmentCompat() {
         val slideshowDurationPref =
             findPreference<SeekBarPreference>(getString(R.string.pref_key_slideshow_duration))!!
         slideshowDurationPref.min = 1
+
+        val slideShowDurationPref =
+            findPreference<SeekBarPreference>(getString(R.string.pref_key_slideshow_duration))!!
+        setVideoDelaySummary(slideShowDurationPref, slideShowDurationPref.value * 1000, 0)
+        slideShowDurationPref.setOnPreferenceChangeListener { _, newValue ->
+            setVideoDelaySummary(slideShowDurationPref, newValue.toString().toInt() * 1000, 0)
+            true
+        }
+
+        val imageClipDelayPref =
+            findPreference<SeekBarPreference>(getString(R.string.pref_key_slideshow_duration_image_clip))!!
+        setVideoDelaySummary(imageClipDelayPref, imageClipDelayPref.value)
+        imageClipDelayPref.setOnPreferenceChangeListener { _, newValue ->
+            setVideoDelaySummary(imageClipDelayPref, newValue, 2)
+            true
+        }
     }
 
     private fun setVideoDelaySummary(
         pref: SeekBarPreference,
         value: Any,
+        decimals: Int = 1,
     ) {
         val newValue = value.toString().toInt()
         pref.summary =
             if (newValue > 0) {
                 String.format(
                     Locale.getDefault(),
-                    "%.1f %s",
+                    "%.${decimals}f %s",
                     newValue / 1000.0,
                     getString(R.string.stashapp_seconds),
                 )

--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageClipFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageClipFragment.kt
@@ -8,12 +8,15 @@ import androidx.fragment.app.viewModels
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.StashApplication
 import com.github.damontecres.stashapp.StashExoPlayer
 import com.github.damontecres.stashapp.playback.StashPlayerView
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.isImageClip
 import com.github.damontecres.stashapp.views.models.ImageViewModel
+import kotlin.properties.Delegates
 
 /**
  * Playback for an image clip (a video)
@@ -29,11 +32,21 @@ class ImageClipFragment :
 
     val isPlaying: Boolean get() = player?.isPlaying == true
 
+    private var delay by Delegates.notNull<Long>()
+
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        delay =
+            PreferenceManager
+                .getDefaultSharedPreferences(StashApplication.getApplication())
+                .getInt(
+                    requireContext().getString(R.string.pref_key_slideshow_duration_image_clip),
+                    resources.getInteger(R.integer.pref_key_slideshow_duration_default_image_clip),
+                ).toLong()
+
         videoView = view.findViewById(R.id.video_view)
         videoView.useController = false
 
@@ -103,7 +116,7 @@ class ImageClipFragment :
 
     override fun onPlaybackStateChanged(playbackState: Int) {
         if (playbackState == Player.STATE_ENDED) {
-            imageViewModel.pulseSlideshow()
+            imageViewModel.pulseSlideshow(delay)
         }
     }
 

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -38,4 +38,6 @@
 
     <string name="pref_key_slideshow_duration" translatable="false">image.slideshow.duration</string>
     <integer name="pref_key_slideshow_duration_default">5</integer>
+    <string name="pref_key_slideshow_duration_image_clip" translatable="false">image.clip.slideshow.duration</string>
+    <integer name="pref_key_slideshow_duration_default_image_clip">250</integer>
 </resources>

--- a/app/src/main/res/xml/ui_preferences.xml
+++ b/app/src/main/res/xml/ui_preferences.xml
@@ -18,11 +18,18 @@
             app:defaultValue="@integer/pref_key_ui_card_overlay_delay_default" />
         <SeekBarPreference
             app:key="@string/pref_key_slideshow_duration"
-            app:title="Slideshow duration (seconds)"
+            app:title="Slideshow duration"
             app:seekBarIncrement="1"
-            app:showSeekBarValue="true"
-            android:max="20"
+            app:showSeekBarValue="false"
+            android:max="60"
             app:defaultValue="@integer/pref_key_slideshow_duration_default" />
+        <SeekBarPreference
+            app:key="@string/pref_key_slideshow_duration_image_clip"
+            app:title="Slideshow pause after image clip"
+            app:seekBarIncrement="250"
+            app:showSeekBarValue="false"
+            android:max="60000"
+            app:defaultValue="@integer/pref_key_slideshow_duration_default_image_clip" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Fixes #554 
Fixes #555 

During a slideshow, makes the delay at the end of image clips configurable.

Also increases the max slideshow duration to 60 seconds.