### PR TITLE
Show an indicator during playback when d-pad skipping

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
@@ -55,6 +55,7 @@ import com.github.damontecres.stashapp.util.readOnlyModeDisabled
 import com.github.damontecres.stashapp.util.readOnlyModeEnabled
 import com.github.damontecres.stashapp.util.toMilliseconds
 import com.github.damontecres.stashapp.views.ListPopupWindowBuilder
+import com.github.damontecres.stashapp.views.SkipIndicator
 import com.github.damontecres.stashapp.views.durationToString
 import com.github.damontecres.stashapp.views.models.PlaybackViewModel
 import com.github.damontecres.stashapp.views.models.ServerViewModel
@@ -126,6 +127,7 @@ abstract class PlaybackFragment(
     protected lateinit var oCounterButton: ImageButton
     protected lateinit var oCounterText: TextView
     private lateinit var moreOptionsButton: ImageButton
+    private lateinit var skipIndicator: SkipIndicator
 
     // Track whether the video is playing before calling the resultLauncher
     protected var wasPlayingBeforeResultLauncher: Boolean? = null
@@ -428,10 +430,14 @@ abstract class PlaybackFragment(
             debugView.visibility = View.VISIBLE
         }
 
+        skipIndicator = view.findViewById(R.id.skip_indicator)
         videoView = view.findViewById(R.id.video_view)
         videoView.controllerShowTimeoutMs =
             manager.getInt("controllerShowTimeoutMs", PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS)
         videoView.setControllerVisibilityListener(controllerVisibilityListener)
+        if (manager.getBoolean(getString(R.string.pref_key_show_dpad_skip), true)) {
+            videoView.skipIndicator = skipIndicator
+        }
 
         backCallback =
             requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, false) {

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/StashPlayerView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/StashPlayerView.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.ui.PlayerView
 import androidx.preference.PreferenceManager
+import com.github.damontecres.stashapp.views.SkipIndicator
 
 /**
  * A [PlayerView] which overrides button presses
@@ -26,6 +27,8 @@ class StashPlayerView(
 
     private val dPadSkipEnabled: Boolean =
         PreferenceManager.getDefaultSharedPreferences(context).getBoolean("skipWithDpad", true)
+
+    var skipIndicator: SkipIndicator? = null
 
     @OptIn(UnstableApi::class)
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
@@ -81,12 +84,14 @@ class StashPlayerView(
                 if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
                     if (dPadSkipEnabled) {
                         player!!.seekForward()
+                        skipIndicator?.update(player!!.seekForwardIncrement)
                     } else {
                         fragment.showAndFocusSeekBar()
                     }
                 } else if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
                     if (dPadSkipEnabled) {
                         player!!.seekBack()
+                        skipIndicator?.update(-1 * player!!.seekBackIncrement)
                     } else {
                         fragment.showAndFocusSeekBar()
                     }

--- a/app/src/main/java/com/github/damontecres/stashapp/views/SkipIndicator.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/SkipIndicator.kt
@@ -1,0 +1,72 @@
+package com.github.damontecres.stashapp.views
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.core.content.res.ResourcesCompat
+import com.github.damontecres.stashapp.R
+import kotlin.math.abs
+
+/**
+ * A visual indicator to show when skipping forward/back during a scene
+ */
+class SkipIndicator(
+    context: Context,
+    attrs: AttributeSet?,
+    defStyleAttr: Int,
+) : FrameLayout(context, attrs, defStyleAttr) {
+    constructor(context: Context) : this(context, null, 0)
+    constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
+
+    private val image: ImageView
+    private val text: TextView
+    private val drawable: Drawable
+
+    private var currentSkip = 0L
+
+    init {
+        inflate(context, R.layout.skip_indicator, this)
+        image = findViewById(R.id.duration_image)
+        text = findViewById(R.id.duration_text)
+        drawable = ResourcesCompat.getDrawable(resources, R.drawable.circular_arrow_right, null)!!
+    }
+
+    /**
+     * Update the text duration by an amount and restart the animation's duration
+     */
+    @SuppressLint("SetTextI18n")
+    fun update(delta: Long) {
+        // If switching from fast forward to back (or vice versa), reset the value
+        if (currentSkip > 0 && delta < 0 || currentSkip < 0 && delta > 0) {
+            currentSkip = 0
+        }
+        currentSkip += (delta / 1000)
+
+        val rotation = if (delta > 0) 180f else -180f
+        if (currentSkip > 0) {
+            image.setImageDrawable(drawable)
+            image.scaleX = 1f
+        } else {
+            // Mirror if skipping back
+            image.setImageDrawable(drawable)
+            image.scaleX = -1f
+        }
+        visibility = View.VISIBLE
+        text.text = abs(currentSkip).toString()
+        image
+            .animate()
+            .setDuration(800L)
+            .rotationBy(rotation)
+            .withEndAction {
+                visibility = View.GONE
+                image.setImageDrawable(null)
+                image.rotation = 0f
+                currentSkip = 0
+            }
+    }
+}

--- a/app/src/main/res/drawable/circular_arrow_right.xml
+++ b/app/src/main/res/drawable/circular_arrow_right.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="800dp"
+    android:height="800dp"
+    android:viewportWidth="75.695"
+    android:viewportHeight="75.695">
+    <!-- Modified from https://www.svgrepo.com/svg/168006/circular-arrow-clock under CC0 License -->
+    <path
+        android:pathData="M75.695,37.846c0,20.869 -16.98,37.85 -37.848,37.85C16.981,75.695 0,58.715 0,37.846C0,16.977 16.981,0 37.848,0c7.628,0 15.055,2.331 21.31,6.592l5.816,-5.817l4.679,17.946l-17.949,-4.678l4.069,-4.072c-5.319,-3.422 -11.538,-5.3 -17.929,-5.3c-18.294,0 -33.176,14.882 -33.176,33.174c0,18.294 14.882,33.178 33.176,33.178c18.293,0 33.175,-14.884 33.175,-33.178H75.695z"
+        android:fillColor="#ffffff" />
+</vector>

--- a/app/src/main/res/layout/skip_indicator.xml
+++ b/app/src/main/res/layout/skip_indicator.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:layout_width="55dp"
+    tools:layout_height="55dp"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <ImageView
+        android:id="@+id/duration_image"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@null"
+        android:padding="6dp"
+        tools:rotation="40"
+        tools:src="@drawable/circular_arrow_right" />
+
+    <TextView
+        android:id="@+id/duration_text"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:textColor="@android:color/white"
+        android:textSize="13sp"
+        android:textStyle="bold"
+        tools:text="3000" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/video_playback.xml
+++ b/app/src/main/res/layout/video_playback.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/video_playback_frame"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -24,5 +25,15 @@
         android:id="@+id/video_overlay"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <com.github.damontecres.stashapp.views.SkipIndicator
+        android:id="@+id/skip_indicator"
+        android:layout_width="65dp"
+        android:layout_height="65dp"
+        android:layout_gravity="bottom|center"
+        android:layout_marginBottom="70dp"
+        android:visibility="gone"
+        tools:visibility="visible"
+        tools:background="@color/transparent_black_50" />
 
 </FrameLayout>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -20,6 +20,7 @@
     <string name="pref_key_crop_card_images" translatable="false">card.cropImages</string>
     <string name="pref_key_back_button_scroll" translatable="false">grid_back_button_scroll</string>
     <string name="pref_key_video_filters" translatable="false">playback.videoFilters</string>
+    <string name="pref_key_show_dpad_skip" translatable="false">playback.showDpadSkip</string>
 
     <string name="pref_key_ui_performer_tabs" translatable="false">ui.tabs.performer</string>
     <string name="pref_key_ui_gallery_tabs" translatable="false">ui.tabs.gallery</string>

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -58,6 +58,10 @@
             app:summaryOn="Skip back/forward with D-Pad left/right"
             app:summaryOff="Don't skip back/forward with D-Pad left/right"
             app:defaultValue="true" />
+        <SwitchPreference
+            app:key="@string/pref_key_show_dpad_skip"
+            app:title="Show D-Pad skipping indicator"
+            app:defaultValue="true" />
         <ListPreference
             app:key="stream_choice"
             app:title="Stream Choice"


### PR DESCRIPTION
Closes #237 

When skipping forward/back with D-Pad right/left, show an indicator with the duration of skip. This gives a better visual indication that the skip is occurring.

This can be turned off in advanced settings.