### PR TITLE
Add ability to disable audio during playback by default

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageClipFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageClipFragment.kt
@@ -13,6 +13,7 @@ import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.StashApplication
 import com.github.damontecres.stashapp.StashExoPlayer
 import com.github.damontecres.stashapp.playback.StashPlayerView
+import com.github.damontecres.stashapp.playback.maybeMuteAudio
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.isImageClip
 import com.github.damontecres.stashapp.util.keepScreenOn
@@ -61,6 +62,7 @@ class ImageClipFragment :
                         .setUri(imageData.paths.image)
                         .build()
                 player?.setMediaItem(mediaItem)
+                maybeMuteAudio(requireContext(), player)
                 player?.prepare()
                 player?.play()
 

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackSceneFragment.kt
@@ -116,6 +116,7 @@ class PlaybackSceneFragment : PlaybackFragment() {
                     )
 
                     exoPlayer.volume = 1f
+                    maybeMuteAudio(requireContext(), exoPlayer)
                     if (videoView.controllerShowTimeoutMs > 0) {
                         videoView.hideController()
                     }

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaylistFragment.kt
@@ -129,6 +129,7 @@ abstract class PlaylistFragment<T : Query.Data, D : StashData, C : Query.Data> :
             )
         addNextPageToPlaylist()
         maybeSetupVideoEffects(player!!)
+        maybeMuteAudio(requireContext(), player!!)
         player!!.prepare()
         if (destination.position > 0) {
             playIndex(destination.position)

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/StreamUtils.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/StreamUtils.kt
@@ -8,12 +8,14 @@ import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
+import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
 import androidx.preference.PreferenceManager
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.fragment.Caption
 import com.github.damontecres.stashapp.data.Scene
+import com.github.damontecres.stashapp.util.getPreference
 import kotlinx.serialization.Serializable
 import java.util.Locale
 
@@ -288,3 +290,23 @@ fun checkForSupport(tracks: Tracks): List<TrackSupport> =
             }
         }
     }
+
+/**
+ * If [R.string.pref_key_playback_start_muted] is true, disable gselection of audio tracks by default on the given [Player]
+ */
+fun maybeMuteAudio(
+    context: Context,
+    player: Player?,
+) {
+    if (getPreference(context, R.string.pref_key_playback_start_muted, false)) {
+        player?.let {
+            if (C.TRACK_TYPE_AUDIO !in it.trackSelectionParameters.disabledTrackTypes) {
+                it.trackSelectionParameters =
+                    it.trackSelectionParameters
+                        .buildUpon()
+                        .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, true)
+                        .build()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/StashImageCardView.kt
@@ -401,7 +401,11 @@ class StashImageCardView(
                     context.getString(R.string.pref_key_ui_card_overlay_delay),
                     context.resources.getInteger(R.integer.pref_key_ui_card_overlay_delay_default),
                 ).toLong()
-        videoPreviewAudio = prefs.getBoolean("videoPreviewAudio", false)
+        videoPreviewAudio = prefs.getBoolean("videoPreviewAudio", false) ||
+            !prefs.getBoolean(
+                context.getString(R.string.pref_key_playback_start_muted),
+                false,
+            )
     }
 
     fun onUnbindViewHolder() {

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -30,6 +30,7 @@
         <item>@string/playback_http_client_default</item>
         <item>@string/playback_http_client_okhttp</item>
     </string-array>
+    <string name="pref_key_playback_start_muted" translatable="false">playback.startMuted</string>
 
     <string name="pref_key_ui_performer_tabs" translatable="false">ui.tabs.performer</string>
     <string name="pref_key_ui_gallery_tabs" translatable="false">ui.tabs.gallery</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,5 +88,6 @@
     <string name="stream_details">Stream Details</string>
     <string name="hours">Hours</string>
     <string name="minutes">Minutes</string>
+    <string name="start_playback_without_audio">Always start playback without audio</string>
 
 </resources>

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -118,6 +118,12 @@
             app:summaryOn="Save if also enabled on server"
             app:summaryOff="Don't save any history"
             app:defaultValue="true" />
+        <SwitchPreference
+            app:key="@string/pref_key_playback_start_muted"
+            app:title="@string/start_playback_without_audio"
+            app:summaryOn="Manually enable audio track"
+            app:summaryOff="Play audio normally"
+            app:defaultValue="false" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Scene Video Filters">


### PR DESCRIPTION
Closes #564 

Adds a setting in advanced to disable audio tracks by default when starting playback. If the setting is enabled, audio can still be manually enabled by selecting a track via the gear icon->Audio on the playback controls.

Limitations when this setting is enabled:
- Only playback audio is affected, system sounds are not (like movement)
- Cannot enable audio on image clips because there's no playback controls