### PR TITLE
Fix crash when trying to create a marker during playback

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
@@ -338,22 +338,26 @@ abstract class PlaybackFragment(
     }
 
     private fun hideVideoFilterFragment() {
-        childFragmentManager.commit {
-            setCustomAnimations(
-                androidx.leanback.R.anim.abc_slide_in_top,
-                androidx.leanback.R.anim.abc_slide_out_top,
-            )
-            hide(videoFilterFragment)
+        if (!isRemoving) {
+            childFragmentManager.commit {
+                setCustomAnimations(
+                    androidx.leanback.R.anim.abc_slide_in_top,
+                    androidx.leanback.R.anim.abc_slide_out_top,
+                )
+                hide(videoFilterFragment)
+            }
         }
     }
 
     private fun showVideoFilterFragment() {
-        childFragmentManager.commit {
-            setCustomAnimations(
-                androidx.leanback.R.anim.abc_slide_in_top,
-                androidx.leanback.R.anim.abc_slide_out_top,
-            )
-            show(videoFilterFragment)
+        if (!isRemoving) {
+            childFragmentManager.commit {
+                setCustomAnimations(
+                    androidx.leanback.R.anim.abc_slide_in_top,
+                    androidx.leanback.R.anim.abc_slide_out_top,
+                )
+                show(videoFilterFragment)
+            }
         }
     }
 


### PR DESCRIPTION
The app would crash if video filtering is enabled and you click "Create Marker" during playback.