### PR TITLE
Fix image title on server v0.28.0

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/filter/DescriptionExtractors.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/filter/DescriptionExtractors.kt
@@ -62,7 +62,7 @@ fun extractTitle(item: StashData): String? =
         is PerformerData -> item.name
         is StudioData -> item.name
         is GalleryData -> item.name
-        is ImageData -> item.title
+        is ImageData -> item.titleOrFilename
         is MarkerData ->
             item.title.ifBlank {
                 item.primary_tag.slimTagData.name

--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageDetailsFragment.kt
@@ -64,6 +64,7 @@ import com.github.damontecres.stashapp.util.name
 import com.github.damontecres.stashapp.util.readOnlyModeDisabled
 import com.github.damontecres.stashapp.util.readOnlyModeEnabled
 import com.github.damontecres.stashapp.util.showSetRatingToast
+import com.github.damontecres.stashapp.util.titleOrFilename
 import com.github.damontecres.stashapp.util.width
 import com.github.damontecres.stashapp.views.ClassOnItemViewClickedListener
 import com.github.damontecres.stashapp.views.StashOnFocusChangeListener
@@ -449,7 +450,7 @@ class ImageDetailsFragment : DetailsSupportFragment() {
         ) {
             val context = vh.view.context
             val image = item as ImageData
-            vh.title.text = image.title
+            vh.title.text = image.titleOrFilename
             vh.subtitle.text =
                 listOf(
                     image.date,

--- a/app/src/main/java/com/github/damontecres/stashapp/image/ImageViewFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/image/ImageViewFragment.kt
@@ -29,6 +29,7 @@ import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashGlide
 import com.github.damontecres.stashapp.util.height
 import com.github.damontecres.stashapp.util.isImageClip
+import com.github.damontecres.stashapp.util.titleOrFilename
 import com.github.damontecres.stashapp.util.width
 import com.github.damontecres.stashapp.views.StashZoomImageView
 import com.github.damontecres.stashapp.views.models.ImageViewModel
@@ -126,7 +127,7 @@ class ImageViewFragment :
                                 Toast
                                     .makeText(
                                         requireContext(),
-                                        "Error loading ${image.title}!",
+                                        "Error loading ${image.titleOrFilename}!",
                                         Toast.LENGTH_LONG,
                                     ).show()
                                 viewModel.pulseSlideshow()

--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/ImagePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/ImagePresenter.kt
@@ -5,6 +5,7 @@ import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.util.concatIfNotBlank
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
+import com.github.damontecres.stashapp.util.titleOrFilename
 import java.util.EnumMap
 
 class ImagePresenter(
@@ -16,7 +17,7 @@ class ImagePresenter(
     ) {
         cardView.blackImageBackground = false
 
-        cardView.titleText = item.title
+        cardView.titleText = item.titleOrFilename
 
         val details = mutableListOf<String?>()
         details.add(item.studio?.name)

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -411,6 +411,15 @@ val VideoSceneData.titleOrFilename: String?
             title
         }
 
+val ImageData.titleOrFilename: String?
+    get() =
+        if (title.isNullOrBlank()) {
+            val path = visual_files.firstOrNull()?.onBaseFile?.path
+            path?.fileNameFromPath
+        } else {
+            title
+        }
+
 val FullSceneData.asSlimeSceneData: SlimSceneData
     get() =
         SlimSceneData(


### PR DESCRIPTION
Seems that server `v0.28.0` no longer provides the image filename as the title if the user did not specify a title.

So this PR updates to fallback to the filename if no title is provided.