### PR TITLE
Ensure fragments are passing key events down the stack

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/StashGridControlsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashGridControlsFragment.kt
@@ -26,7 +26,7 @@ import com.github.damontecres.stashapp.presenters.NullPresenter
 import com.github.damontecres.stashapp.presenters.NullPresenterSelector
 import com.github.damontecres.stashapp.presenters.StashPresenter
 import com.github.damontecres.stashapp.suppliers.FilterArgs
-import com.github.damontecres.stashapp.util.DefaultKeyEventCallback
+import com.github.damontecres.stashapp.util.DelegateKeyEventCallback
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.addExtraGridLongClicks
 import com.github.damontecres.stashapp.util.getFilterArgs
@@ -44,7 +44,7 @@ import com.google.android.material.switchmaterial.SwitchMaterial
  */
 class StashGridControlsFragment() :
     Fragment(),
-    DefaultKeyEventCallback {
+    DelegateKeyEventCallback {
     private val serverViewModel: ServerViewModel by activityViewModels()
     private val viewModel: StashGridViewModel by viewModels()
 
@@ -60,6 +60,9 @@ class StashGridControlsFragment() :
     private lateinit var searchEditText: SearchEditText
 
     private lateinit var fragment: StashDataGridFragment
+
+    override val keyEventDelegate: KeyEvent.Callback?
+        get() = if (this::fragment.isInitialized) fragment else null
 
     private var remoteButtonPaging: Boolean = true
 
@@ -297,11 +300,6 @@ class StashGridControlsFragment() :
         gridHeaderTransitionHelper.showTitle(show)
         headerVisibilityListener?.onHeaderVisibilityChanged(this, show)
     }
-
-    override fun onKeyUp(
-        keyCode: Int,
-        event: KeyEvent,
-    ): Boolean = fragment.onKeyUp(keyCode, event) || super.onKeyUp(keyCode, event)
 
     companion object {
         private const val TAG = "StashGridControlsFragment"

--- a/app/src/main/java/com/github/damontecres/stashapp/TabbedFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/TabbedFragment.kt
@@ -12,7 +12,7 @@ import androidx.fragment.app.viewModels
 import androidx.leanback.tab.LeanbackTabLayout
 import androidx.leanback.tab.LeanbackViewPager
 import androidx.preference.PreferenceManager
-import com.github.damontecres.stashapp.util.DefaultKeyEventCallback
+import com.github.damontecres.stashapp.util.DelegateKeyEventCallback
 import com.github.damontecres.stashapp.util.StashFragmentPagerAdapter
 import com.github.damontecres.stashapp.util.animateToInvisible
 import com.github.damontecres.stashapp.util.animateToVisible
@@ -26,7 +26,7 @@ import com.google.android.material.tabs.TabLayout
 abstract class TabbedFragment(
     private val tabKey: String,
 ) : Fragment(R.layout.tabbed_grid_view),
-    DefaultKeyEventCallback,
+    DelegateKeyEventCallback,
     StashGridControlsFragment.HeaderVisibilityListener {
     private lateinit var viewPager: LeanbackViewPager
     protected val serverViewModel by activityViewModels<ServerViewModel>()
@@ -120,17 +120,16 @@ abstract class TabbedFragment(
         }
     }
 
-    override fun onKeyUp(
-        keyCode: Int,
-        event: KeyEvent,
-    ): Boolean {
-        val tabIndex = currentTabPosition
-        val fragment = fragments[tabIndex]
-        if (fragment != null && fragment is KeyEvent.Callback && fragment.onKeyUp(keyCode, event)) {
-            return true
+    override val keyEventDelegate: KeyEvent.Callback?
+        get() {
+            val tabIndex = currentTabPosition
+            val fragment = fragments[tabIndex]
+            return if (fragment != null && fragment is KeyEvent.Callback) {
+                fragment
+            } else {
+                null
+            }
         }
-        return super.onKeyUp(keyCode, event)
-    }
 
     override fun onHeaderVisibilityChanged(
         fragment: StashGridControlsFragment,

--- a/app/src/main/java/com/github/damontecres/stashapp/util/DefaultKeyEventCallback.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/DefaultKeyEventCallback.kt
@@ -24,3 +24,28 @@ interface DefaultKeyEventCallback : KeyEvent.Callback {
         event: KeyEvent,
     ): Boolean = false
 }
+
+interface DelegateKeyEventCallback : KeyEvent.Callback {
+    val keyEventDelegate: KeyEvent.Callback?
+
+    override fun onKeyDown(
+        keyCode: Int,
+        event: KeyEvent,
+    ): Boolean = keyEventDelegate?.onKeyDown(keyCode, event) ?: false
+
+    override fun onKeyUp(
+        keyCode: Int,
+        event: KeyEvent,
+    ): Boolean = keyEventDelegate?.onKeyUp(keyCode, event) ?: false
+
+    override fun onKeyLongPress(
+        keyCode: Int,
+        event: KeyEvent,
+    ): Boolean = keyEventDelegate?.onKeyLongPress(keyCode, event) ?: false
+
+    override fun onKeyMultiple(
+        keyCode: Int,
+        count: Int,
+        event: KeyEvent,
+    ): Boolean = keyEventDelegate?.onKeyMultiple(keyCode, count, event) ?: false
+}


### PR DESCRIPTION
This fixes some button presses (play, long-press, etc) not working on some pages.