### PR TITLE
Fix captions not showing

### DIFF
--- a/app/src/main/graphql/FindSceneMarkers.graphql
+++ b/app/src/main/graphql/FindSceneMarkers.graphql
@@ -56,6 +56,7 @@ fragment VideoSceneData on Scene {
   title
   urls
   date
+  resume_time
   rating100
   o_counter
   created_at

--- a/app/src/main/java/com/github/damontecres/stashapp/data/Scene.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/Scene.kt
@@ -74,7 +74,7 @@ data class Scene(
                 streams = streams,
                 spriteUrl = data.paths.sprite,
                 duration = fileData?.duration,
-                resumeTime = null,
+                resumeTime = data.resume_time,
                 videoCodec = fileData?.video_codec,
                 videoResolution = fileData?.height,
                 audioCodec = fileData?.audio_codec,

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -486,6 +486,7 @@ val FullSceneData.asVideoSceneData: VideoSceneData
             title,
             urls,
             date,
+            resume_time,
             rating100,
             o_counter,
             created_at,


### PR DESCRIPTION
Fixes #590

One of the changes switched to using `VideoSceneData` for playback which wasn't configured to get the caption url info.