### PR TITLE
Fix restoring filter when returning to a grid after changing it

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsFragment.kt
@@ -3,6 +3,7 @@ package com.github.damontecres.stashapp
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.DialogInterface
+import android.content.Intent
 import android.os.Bundle
 import android.text.InputType
 import android.util.Log
@@ -296,8 +297,6 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
                     """
                     Want to try the new beta UI based on Android Jetpack Compose?
 
-                    The new UI is looks more modern and performs better on lower memory devices!
-
                     Almost every feature is available in the new UI, but you can always switch back in "More UI Settings".
 
                     See the `StashAppAndroidTV` GitHub for more information and known issues.
@@ -315,7 +314,13 @@ class SettingsFragment : LeanbackSettingsFragmentCompat() {
                         }
                         // Clear coil singleton
                         SingletonImageLoader.reset()
-                        requireActivity().finish()
+//                        requireActivity().finish()
+                        requireActivity().startActivity(
+                            Intent(
+                                requireActivity(),
+                                RootActivity::class.java,
+                            ).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK),
+                        )
                     }
                 }
                 true

--- a/app/src/main/java/com/github/damontecres/stashapp/SettingsUiFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SettingsUiFragment.kt
@@ -1,5 +1,6 @@
 package com.github.damontecres.stashapp
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -67,7 +68,12 @@ class SettingsUiFragment : LeanbackPreferenceFragmentCompat() {
                         composeEnabledPref.isChecked = true
                         // Clear coil singleton
                         SingletonImageLoader.reset()
-                        requireActivity().finish()
+                        requireActivity().startActivity(
+                            Intent(
+                                requireActivity(),
+                                RootActivity::class.java,
+                            ).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK),
+                        )
                     }
                 }
             } else if (newValue == false) {
@@ -80,7 +86,12 @@ class SettingsUiFragment : LeanbackPreferenceFragmentCompat() {
                         composeEnabledPref.isChecked = false
                         // Clear coil singleton
                         SingletonImageLoader.reset()
-                        requireActivity().finish()
+                        requireActivity().startActivity(
+                            Intent(
+                                requireActivity(),
+                                RootActivity::class.java,
+                            ).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK),
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/Extensions.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/Extensions.kt
@@ -1,15 +1,18 @@
 package com.github.damontecres.stashapp.ui
 
 import android.content.Context
+import android.os.Bundle
 import android.util.Log
 import androidx.compose.foundation.MarqueeAnimationMode
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
@@ -19,7 +22,10 @@ import androidx.compose.ui.unit.dp
 import androidx.media3.common.Player
 import com.github.damontecres.stashapp.StashExoPlayer
 import com.github.damontecres.stashapp.navigation.NavigationManager
+import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.util.StashServer
+import com.github.damontecres.stashapp.util.getFilterArgs
+import com.github.damontecres.stashapp.util.putFilterArgs
 
 data class GlobalContext(
     val server: StashServer,
@@ -74,3 +80,13 @@ fun Modifier.isElementVisible(onVisibilityChanged: (Boolean) -> Unit) =
             } ?: false
         }
     }
+
+val filterArgsSaver =
+    Saver<MutableState<FilterArgs>, Any>(
+        save = { value ->
+            Bundle().putFilterArgs("filterArgs", value.value)
+        },
+        restore = { value ->
+            mutableStateOf((value as Bundle).getFilterArgs("filterArgs")!!)
+        },
+    )

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/GroupPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/GroupPage.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -54,6 +55,7 @@ import com.github.damontecres.stashapp.ui.components.TabWithSubItems
 import com.github.damontecres.stashapp.ui.components.TableRow
 import com.github.damontecres.stashapp.ui.components.TableRowComposable
 import com.github.damontecres.stashapp.ui.components.tabFindFilter
+import com.github.damontecres.stashapp.ui.filterArgsSaver
 import com.github.damontecres.stashapp.util.MutationEngine
 import com.github.damontecres.stashapp.util.PageFilterKey
 import com.github.damontecres.stashapp.util.QueryEngine
@@ -170,28 +172,31 @@ fun GroupPage(
                 ),
                 TabProvider
                     (stringResource(DataType.TAG.pluralStringId)) { positionCallback ->
-                        StashGridTab(
-                            name = stringResource(DataType.TAG.pluralStringId),
-                            server = server,
-                            initialFilter =
+                        var filter by rememberSaveable(saver = filterArgsSaver) {
+                            mutableStateOf(
                                 FilterArgs(
                                     dataType = DataType.TAG,
                                     override = DataSupplierOverride.GroupTags(group.id),
                                 ),
+                            )
+                        }
+                        StashGridTab(
+                            name = stringResource(DataType.TAG.pluralStringId),
+                            server = server,
+                            initialFilter = filter,
                             itemOnClick = itemOnClick,
                             longClicker = longClicker,
                             modifier = Modifier,
                             positionCallback = positionCallback,
                             composeUiConfig = uiConfig,
                             subToggleLabel = null,
+                            onFilterChange = { filter = it },
                         )
                     },
                 TabProvider
                     (stringResource(R.string.stashapp_containing_groups)) { positionCallback ->
-                        StashGridTab(
-                            name = stringResource(R.string.stashapp_containing_groups),
-                            server = server,
-                            initialFilter =
+                        var filter by rememberSaveable(saver = filterArgsSaver) {
+                            mutableStateOf(
                                 FilterArgs(
                                     dataType = DataType.GROUP,
                                     override =
@@ -200,20 +205,25 @@ fun GroupPage(
                                             GroupRelationshipType.CONTAINING,
                                         ),
                                 ),
+                            )
+                        }
+                        StashGridTab(
+                            name = stringResource(R.string.stashapp_containing_groups),
+                            server = server,
+                            initialFilter = filter,
                             itemOnClick = itemOnClick,
                             longClicker = longClicker,
                             modifier = Modifier,
                             positionCallback = positionCallback,
                             composeUiConfig = uiConfig,
                             subToggleLabel = null,
+                            onFilterChange = { filter = it },
                         )
                     },
                 TabProvider
                     (stringResource(R.string.stashapp_sub_groups)) { positionCallback ->
-                        StashGridTab(
-                            name = stringResource(R.string.stashapp_sub_groups),
-                            server = server,
-                            initialFilter =
+                        var filter by rememberSaveable(saver = filterArgsSaver) {
+                            mutableStateOf(
                                 FilterArgs(
                                     dataType = DataType.GROUP,
                                     override =
@@ -222,12 +232,24 @@ fun GroupPage(
                                             GroupRelationshipType.SUB,
                                         ),
                                 ),
+                            )
+                        }
+                        StashGridTab(
+                            name = stringResource(R.string.stashapp_sub_groups),
+                            server = server,
+                            initialFilter = filter,
                             itemOnClick = itemOnClick,
                             longClicker = longClicker,
                             composeUiConfig = uiConfig,
                             modifier = Modifier,
                             positionCallback = positionCallback,
-                            if (group.sub_group_count > 0) stringResource(R.string.stashapp_include_sub_group_content) else null,
+                            subToggleLabel =
+                                if (group.sub_group_count > 0) {
+                                    stringResource(R.string.stashapp_include_sub_group_content)
+                                } else {
+                                    null
+                                },
+                            onFilterChange = { filter = it },
                         )
                     },
             ).filter { it.name in uiTabs }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/StudioPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/StudioPage.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -44,6 +45,7 @@ import com.github.damontecres.stashapp.ui.components.TabProvider
 import com.github.damontecres.stashapp.ui.components.TabWithSubItems
 import com.github.damontecres.stashapp.ui.components.TableRow
 import com.github.damontecres.stashapp.ui.components.tabFindFilter
+import com.github.damontecres.stashapp.ui.filterArgsSaver
 import com.github.damontecres.stashapp.util.MutationEngine
 import com.github.damontecres.stashapp.util.PageFilterKey
 import com.github.damontecres.stashapp.util.QueryEngine
@@ -210,27 +212,30 @@ fun StudioPage(
                     includeSubStudios,
                 ),
                 TabProvider(stringResource(DataType.TAG.pluralStringId)) { positionCallback ->
-                    StashGridTab(
-                        name = stringResource(DataType.TAG.pluralStringId),
-                        server = server,
-                        initialFilter =
+                    var filter by rememberSaveable(saver = filterArgsSaver) {
+                        mutableStateOf(
                             FilterArgs(
                                 dataType = DataType.TAG,
                                 override = DataSupplierOverride.StudioTags(studio.id),
                             ),
+                        )
+                    }
+                    StashGridTab(
+                        name = stringResource(DataType.TAG.pluralStringId),
+                        server = server,
+                        initialFilter = filter,
                         itemOnClick = itemOnClick,
                         longClicker = longClicker,
                         modifier = Modifier,
                         positionCallback = positionCallback,
                         composeUiConfig = uiConfig,
                         subToggleLabel = null,
+                        onFilterChange = { filter = it },
                     )
                 },
                 TabProvider(stringResource(R.string.stashapp_subsidiary_studios)) { positionCallback ->
-                    StashGridTab(
-                        name = stringResource(R.string.stashapp_subsidiary_studios),
-                        server = server,
-                        initialFilter =
+                    var filter by rememberSaveable(saver = filterArgsSaver) {
+                        mutableStateOf(
                             FilterArgs(
                                 dataType = DataType.STUDIO,
                                 findFilter = tabFindFilter(server, PageFilterKey.STUDIO_CHILDREN),
@@ -245,6 +250,12 @@ fun StudioPage(
                                             ),
                                     ),
                             ),
+                        )
+                    }
+                    StashGridTab(
+                        name = stringResource(R.string.stashapp_subsidiary_studios),
+                        server = server,
+                        initialFilter = filter,
                         itemOnClick = itemOnClick,
                         longClicker = longClicker,
                         modifier = Modifier,
@@ -258,6 +269,7 @@ fun StudioPage(
                             } else {
                                 null
                             },
+                        onFilterChange = { filter = it },
                     )
                 },
                 TabWithSubItems<SceneMarkerFilterType>(

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/TagPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/TagPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -39,6 +40,7 @@ import com.github.damontecres.stashapp.ui.components.TabProvider
 import com.github.damontecres.stashapp.ui.components.TabWithSubItems
 import com.github.damontecres.stashapp.ui.components.TableRow
 import com.github.damontecres.stashapp.ui.components.tabFindFilter
+import com.github.damontecres.stashapp.ui.filterArgsSaver
 import com.github.damontecres.stashapp.util.MutationEngine
 import com.github.damontecres.stashapp.util.PageFilterKey
 import com.github.damontecres.stashapp.util.QueryEngine
@@ -198,20 +200,25 @@ fun TagPage(
                 ),
                 TabProvider
                     (stringResource(R.string.stashapp_sub_tags)) { positionCallback ->
-                        StashGridTab(
-                            name = stringResource(R.string.stashapp_sub_tags),
-                            server = server,
-                            initialFilter =
+                        var filter by rememberSaveable(saver = filterArgsSaver) {
+                            mutableStateOf(
                                 FilterArgs(
                                     dataType = DataType.TAG,
                                     objectFilter = TagFilterType(parents = tagsFunc(false)),
                                 ),
+                            )
+                        }
+                        StashGridTab(
+                            name = stringResource(R.string.stashapp_sub_tags),
+                            server = server,
+                            initialFilter = filter,
                             itemOnClick = itemOnClick,
                             longClicker = longClicker,
                             modifier = Modifier,
                             positionCallback = positionCallback,
                             composeUiConfig = uiConfig,
                             subToggleLabel = null,
+                            onFilterChange = { filter = it },
                         )
                     },
             ).filter { it.name in uiTabs }

--- a/app/src/main/java/com/github/damontecres/stashapp/views/dialog/ConfirmationDialogFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/dialog/ConfirmationDialogFragment.kt
@@ -23,6 +23,11 @@ class ConfirmationDialogFragment(
             .setNegativeButton(getString(R.string.stashapp_actions_cancel), onClickListener)
             .create()
 
+    override fun onResume() {
+        super.onResume()
+        (dialog as? AlertDialog)?.getButton(DialogInterface.BUTTON_NEGATIVE)?.requestFocus()
+    }
+
     companion object {
         fun show(
             fm: FragmentManager,


### PR DESCRIPTION
Fixes on the beta UI, when changing the filter sort on a tab grid (such as a Performer's scene tab) or if it is random by default, then clicking on a scene and going back, the filter would revert to the original sort.