### PR TITLE
Optionally show progress while skipping

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistPlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistPlaybackPageContent.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,9 +25,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -50,6 +54,7 @@ import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
 import androidx.media3.ui.compose.state.rememberPresentationState
 import androidx.media3.ui.compose.state.rememberPreviousButtonState
 import androidx.preference.PreferenceManager
+import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import coil3.SingletonImageLoader
 import coil3.request.CachePolicy
@@ -73,6 +78,7 @@ import com.github.damontecres.stashapp.util.QueryEngine
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
+import com.github.damontecres.stashapp.util.toLongMilliseconds
 import com.github.damontecres.stashapp.views.models.EqualityMutableLiveData
 import kotlinx.coroutines.launch
 import kotlin.properties.Delegates
@@ -255,6 +261,13 @@ fun PlaylistPlaybackPageContent(
             prefs.getBoolean(context.getString(R.string.pref_key_show_playback_debug_info), false),
         )
     }
+    val showSkipProgress =
+        remember {
+            prefs.getBoolean(
+                context.getString(R.string.pref_key_playback_show_skip_progress),
+                true,
+            )
+        }
     val skipWithLeftRight = remember { prefs.getBoolean("skipWithDpad", true) }
 
     LaunchedEffect(server, currentScene, player) {
@@ -299,11 +312,13 @@ fun PlaylistPlaybackPageContent(
             }
         }
     var skipIndicatorDuration by remember { mutableLongStateOf(0L) }
+    var skipPosition by remember { mutableLongStateOf(0L) }
     val updateSkipIndicator = { delta: Long ->
         if (skipIndicatorDuration > 0 && delta < 0 || skipIndicatorDuration < 0 && delta > 0) {
             skipIndicatorDuration = 0
         }
         skipIndicatorDuration += delta
+        skipPosition = player.currentPosition
     }
     val scope = rememberCoroutineScope()
     val playPauseState = rememberPlayPauseButtonState(player)
@@ -355,6 +370,21 @@ fun PlaylistPlaybackPageContent(
                         .align(Alignment.BottomCenter)
                         .padding(bottom = 70.dp),
             )
+            if (showSkipProgress) {
+                currentScene.item.duration?.let {
+                    val percent =
+                        skipPosition.toFloat() / (it.toLongMilliseconds).toFloat()
+                    Box(
+                        modifier =
+                            Modifier
+                                .align(Alignment.BottomStart)
+                                .background(MaterialTheme.colorScheme.border)
+                                .clip(RectangleShape)
+                                .height(3.dp)
+                                .fillMaxWidth(percent),
+                    ) {}
+                }
+            }
         }
 
         if (!controllerViewState.controlsVisible && subtitleIndex != null && skipIndicatorDuration == 0L) {

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -74,5 +74,6 @@
 
     <string name="pref_key_ui_grid_jump_controls" translatable="false">ui.grid.jumpControls</string>
     <string name="pref_key_playback_seek_count" translatable="false">playback.seekIntervals</string>
+    <string name="pref_key_playback_show_skip_progress" translatable="false">playback.showSkipProgress</string>
 
 </resources>

--- a/app/src/main/res/xml/ui_preferences.xml
+++ b/app/src/main/res/xml/ui_preferences.xml
@@ -103,5 +103,11 @@
             app:defaultValue="@string/ui_theme_dark_appearance_choice_dark"
             app:entries="@array/ui_theme_dark_appearance_choices"
             app:entryValues="@array/ui_theme_dark_appearance_choices" />
+        <SwitchPreference
+            app:key="@string/pref_key_playback_show_skip_progress"
+            app:title="Show progress when skipping"
+            app:summaryOn="Enabled"
+            app:summaryOff="Disabled"
+            app:defaultValue="true" />
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Related to #237

On the beta UI, when skipping with left/right or remote buttons, a small progress bar is shown at the bottom indicating the current position.

This can be disabled in advanced UI settings.