### PR TITLE
Add movement sound effects to new UI

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/ComposeUiConfig.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/ComposeUiConfig.kt
@@ -17,6 +17,7 @@ data class ComposeUiConfig(
     val showTitleDuringPlayback: Boolean,
     val readOnlyModeEnabled: Boolean,
     val showCardProgress: Boolean,
+    val playSoundOnFocus: Boolean,
     val cardSettings: CardUiSettings,
 ) {
     val readOnlyModeDisabled = !readOnlyModeEnabled
@@ -45,6 +46,11 @@ data class ComposeUiConfig(
                 cardSettings = ServerViewModel.createUiSettings(context),
                 showTitleDuringPlayback = prefs.getBoolean("exoShowTitle", true),
                 showCardProgress = !server.serverPreferences.alwaysStartFromBeginning,
+                playSoundOnFocus =
+                    prefs.getBoolean(
+                        context.getString(R.string.pref_key_movement_sounds),
+                        true,
+                    ),
                 readOnlyModeEnabled =
                     prefs.getBoolean(
                         context.getString(R.string.pref_key_read_only_mode),

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/NavDrawerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/NavDrawerFragment.kt
@@ -98,6 +98,8 @@ import com.github.damontecres.stashapp.ui.pages.SearchPage
 import com.github.damontecres.stashapp.ui.pages.StudioPage
 import com.github.damontecres.stashapp.ui.pages.TagPage
 import com.github.damontecres.stashapp.ui.util.ifElse
+import com.github.damontecres.stashapp.ui.util.playOnClickSound
+import com.github.damontecres.stashapp.ui.util.playSoundOnFocus
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.views.models.ServerViewModel
@@ -222,6 +224,8 @@ class NavDrawerFragment : Fragment(R.layout.compose_frame) {
                                         }
                                     },
                                     modifier = Modifier.background(MaterialTheme.colorScheme.background),
+                                    // TODO could use onKeyEvent here to make focus/movement sounds everywhere
+                                    // But it wouldn't know if the focus would actually change
                                 )
                             }
                         }
@@ -524,9 +528,14 @@ fun FragmentContent(
                                         Modifier
                                             .onFocusChanged {
                                                 serverFocused = it.isFocused
-                                            },
+                                            }.playSoundOnFocus(composeUiConfig.playSoundOnFocus),
                                     selected = false,
                                     onClick = {
+                                        if (composeUiConfig.playSoundOnFocus) {
+                                            playOnClickSound(
+                                                context,
+                                            )
+                                        }
                                         navigationManager.navigate(
                                             Destination.ManageServers(
                                                 false,
@@ -559,9 +568,15 @@ fun FragmentContent(
                                                 selectedScreen == page,
                                                 Modifier
                                                     .focusRequester(initialFocus),
-                                            ).isElementVisible { visiblePages[page] = it },
+                                            ).isElementVisible { visiblePages[page] = it }
+                                            .playSoundOnFocus(composeUiConfig.playSoundOnFocus),
                                     selected = selectedScreen == page && drawerState.currentValue == DrawerValue.Open,
                                     onClick = {
+                                        if (composeUiConfig.playSoundOnFocus) {
+                                            playOnClickSound(
+                                                context,
+                                            )
+                                        }
                                         val refreshMain =
                                             selectedScreen == DrawerPage.HOME_PAGE && page == DrawerPage.HOME_PAGE
                                         currentScreen = page

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/Cards.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/Cards.kt
@@ -98,6 +98,8 @@ import com.github.damontecres.stashapp.ui.LocalPlayerContext
 import com.github.damontecres.stashapp.ui.components.CircularProgress
 import com.github.damontecres.stashapp.ui.components.LongClicker
 import com.github.damontecres.stashapp.ui.enableMarquee
+import com.github.damontecres.stashapp.ui.util.playOnClickSound
+import com.github.damontecres.stashapp.ui.util.playSoundOnFocus
 import com.github.damontecres.stashapp.util.CreateNew
 import com.github.damontecres.stashapp.util.asSlimeSceneData
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
@@ -344,8 +346,12 @@ fun RootCard(
         imageWidth * (1 + (5f - uiConfig.cardSettings.columns) / uiConfig.cardSettings.columns)
 
     Card(
-        onClick = onClick,
+        onClick = {
+            if (uiConfig.playSoundOnFocus) playOnClickSound(context)
+            onClick.invoke()
+        },
         onLongClick = {
+            if (uiConfig.playSoundOnFocus) playOnClickSound(context)
             item?.let {
                 longClicker.longClick(
                     item,
@@ -356,7 +362,8 @@ fun RootCard(
         modifier =
             modifier
                 .padding(0.dp)
-                .width(width),
+                .width(width)
+                .playSoundOnFocus(uiConfig.playSoundOnFocus),
         interactionSource = interactionSource,
         shape = shape,
         colors = colors,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/Rating.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/Rating.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -62,6 +63,8 @@ import com.github.damontecres.stashapp.ui.AppColors
 import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.tryRequestFocus
+import com.github.damontecres.stashapp.ui.util.playOnClickSound
+import com.github.damontecres.stashapp.ui.util.playSoundOnFocus
 import com.github.damontecres.stashapp.views.getRatingAsDecimalString
 
 enum class StarRatingPrecision {
@@ -100,6 +103,7 @@ fun Rating100(
         uiConfig.ratingAsStars,
         uiConfig.starPrecision,
         enabled && uiConfig.readOnlyModeDisabled,
+        uiConfig.playSoundOnFocus,
         modifier,
         bgColor,
     )
@@ -112,6 +116,7 @@ fun Rating100(
     ratingAsStars: Boolean,
     starPrecision: StarRatingPrecision,
     enabled: Boolean,
+    playSoundOnFocus: Boolean,
     modifier: Modifier = Modifier,
     bgColor: Color = AppColors.TransparentBlack75, // MaterialTheme.colorScheme.background,
 ) {
@@ -121,6 +126,7 @@ fun Rating100(
             onRatingChange = onRatingChange,
             precision = starPrecision,
             enabled = enabled,
+            playSoundOnFocus = playSoundOnFocus,
             modifier = modifier,
             bgColor = bgColor,
         )
@@ -129,6 +135,7 @@ fun Rating100(
             rating100 = rating100,
             onRatingChange = onRatingChange,
             enabled = enabled,
+            playSoundOnFocus = playSoundOnFocus,
             modifier = modifier,
         )
     }
@@ -140,9 +147,11 @@ fun StarRating(
     onRatingChange: (Int) -> Unit,
     precision: StarRatingPrecision,
     enabled: Boolean,
+    playSoundOnFocus: Boolean,
     modifier: Modifier = Modifier,
     bgColor: Color = AppColors.TransparentBlack75, // MaterialTheme.colorScheme.background,
 ) {
+    val context = LocalContext.current
     var tempRating by remember(rating100) { mutableIntStateOf(rating100) }
     val percentage = (if (enabled) tempRating else rating100) / 100f
     val focusRequesters = remember { List(5) { FocusRequester() } }
@@ -221,13 +230,17 @@ fun StarRating(
                                             } else {
                                                 tempRating = rating100
                                             }
-                                        }.focusRequester(focusRequesters[i - 1])
+                                        }.playSoundOnFocus(playSoundOnFocus)
+                                        .focusRequester(focusRequesters[i - 1])
                                         .focusProperties {
-                                            left = if (i == 1)focusRequesters.last() else FocusRequester.Default
-                                            right = if (i == 5)focusRequesters.first() else FocusRequester.Default
+                                            left =
+                                                if (i == 1) focusRequesters.last() else FocusRequester.Default
+                                            right =
+                                                if (i == 5) focusRequesters.first() else FocusRequester.Default
                                         }.selectable(
                                             selected = isRated,
                                             onClick = {
+                                                if (playSoundOnFocus) playOnClickSound(context)
                                                 val newRating100 =
                                                     when (precision) {
                                                         StarRatingPrecision.FULL -> i * 20
@@ -273,6 +286,7 @@ fun DecimalRating(
     rating100: Int,
     onRatingChange: (Int) -> Unit,
     enabled: Boolean,
+    playSoundOnFocus: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -286,6 +300,11 @@ fun DecimalRating(
         } else {
             Color.Unspecified
         }
+    if (playSoundOnFocus) {
+        LaunchedEffect(focused) {
+            if (focused) playOnClickSound(context)
+        }
+    }
     Row(
         modifier =
             modifier
@@ -296,6 +315,7 @@ fun DecimalRating(
                     interactionSource = interactionSource,
                     indication = LocalIndication.current,
                 ) {
+                    if (playSoundOnFocus) playOnClickSound(context)
                     showDialog = true
                 },
         verticalAlignment = Alignment.CenterVertically,
@@ -399,6 +419,7 @@ private fun StarRatingPreview() {
                 precision = StarRatingPrecision.HALF,
                 onRatingChange = { rating = it },
                 enabled = true,
+                playSoundOnFocus = true,
                 bgColor = bgColor,
                 modifier =
                     Modifier
@@ -411,6 +432,7 @@ private fun StarRatingPreview() {
                 precision = StarRatingPrecision.FULL,
                 onRatingChange = { rating2 = it },
                 enabled = true,
+                playSoundOnFocus = true,
                 bgColor = bgColor,
                 modifier = Modifier.height(32.dp),
             )
@@ -419,6 +441,7 @@ private fun StarRatingPreview() {
                 precision = StarRatingPrecision.HALF,
                 onRatingChange = {},
                 enabled = true,
+                playSoundOnFocus = true,
                 bgColor = bgColor,
                 modifier = Modifier.height(32.dp),
             )
@@ -427,6 +450,7 @@ private fun StarRatingPreview() {
                 precision = StarRatingPrecision.HALF,
                 onRatingChange = {},
                 enabled = true,
+                playSoundOnFocus = true,
                 bgColor = bgColor,
                 modifier = Modifier.height(32.dp),
             )
@@ -436,6 +460,7 @@ private fun StarRatingPreview() {
                 starPrecision = StarRatingPrecision.HALF,
                 onRatingChange = {},
                 enabled = true,
+                playSoundOnFocus = true,
                 bgColor = bgColor,
                 modifier = Modifier.height(32.dp),
             )

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/TitleValueText.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/TitleValueText.kt
@@ -25,29 +25,34 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.ui.util.ifElse
+import com.github.damontecres.stashapp.ui.util.playOnClickSound
 
 @Composable
 fun TitleValueText(
     title: String,
     value: String,
     modifier: Modifier = Modifier,
+    playSoundOnFocus: Boolean = false,
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
 ) {
     MaybeClickColumn(
         onClick = onClick,
         onLongClick = onLongClick,
+        playSoundOnFocus = playSoundOnFocus,
         modifier = modifier,
     ) {
         Text(
@@ -67,20 +72,28 @@ fun TitleValueText(
 
 @Composable
 private fun MaybeClickColumn(
+    playSoundOnFocus: Boolean,
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     if (onClick != null || onLongClick != null) {
+        val context = LocalContext.current
         val interactionSource = remember { MutableInteractionSource() }
         val isFocused by interactionSource.collectIsFocusedAsState()
+        if (playSoundOnFocus) {
+            LaunchedEffect(isFocused) {
+                if (isFocused) playOnClickSound(context)
+            }
+        }
         val bgColor =
             if (isFocused) {
                 MaterialTheme.colorScheme.onPrimary.copy(alpha = .75f)
             } else {
                 Color.Unspecified
             }
+
         Column(
             content = content,
             modifier =
@@ -91,8 +104,14 @@ private fun MaybeClickColumn(
                         enabled = true,
                         interactionSource = interactionSource,
                         indication = LocalIndication.current,
-                        onClick = { onClick?.invoke() },
-                        onLongClick = { onLongClick?.invoke() },
+                        onClick = {
+                            if (playSoundOnFocus) playOnClickSound(context)
+                            onClick?.invoke()
+                        },
+                        onLongClick = {
+                            if (playSoundOnFocus) playOnClickSound(context)
+                            onLongClick?.invoke()
+                        },
                     ),
         )
     } else {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageDetailsHeader.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageDetailsHeader.kt
@@ -200,6 +200,7 @@ fun ImageDetailsHeader(
                     TitleValueText(
                         stringResource(R.string.stashapp_studio),
                         image.studio.name,
+                        playSoundOnFocus = uiConfig.playSoundOnFocus,
                         modifier =
                             Modifier.onFocusChanged {
                                 if (it.isFocused) {
@@ -226,6 +227,7 @@ fun ImageDetailsHeader(
                     TitleValueText(
                         stringResource(R.string.stashapp_photographer),
                         image.photographer,
+                        playSoundOnFocus = uiConfig.playSoundOnFocus,
                         modifier =
                             Modifier.onFocusChanged {
                                 if (it.isFocused) {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
@@ -513,6 +513,7 @@ private fun PlaybackOverlayPreview() {
                     showTitleDuringPlayback = true,
                     readOnlyModeEnabled = false,
                     showCardProgress = true,
+                    playSoundOnFocus = true,
                     cardSettings =
                         CardUiSettings(
                             maxSearchResults = 25,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsHeader.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsHeader.kt
@@ -58,6 +58,8 @@ import com.github.damontecres.stashapp.ui.components.LongClicker
 import com.github.damontecres.stashapp.ui.components.Rating100
 import com.github.damontecres.stashapp.ui.components.ScrollableDialog
 import com.github.damontecres.stashapp.ui.components.TitleValueText
+import com.github.damontecres.stashapp.ui.util.playOnClickSound
+import com.github.damontecres.stashapp.ui.util.playSoundOnFocus
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.util.joinNotNullOrBlank
@@ -203,11 +205,15 @@ fun SceneDetailsHeader(
                                         if (it.isFocused) {
                                             scope.launch(StashCoroutineExceptionHandler()) { bringIntoViewRequester.bringIntoView() }
                                         }
-                                    }.clickable(
+                                    }.playSoundOnFocus(uiConfig.playSoundOnFocus)
+                                    .clickable(
                                         enabled = true,
                                         interactionSource = interactionSource,
                                         indication = LocalIndication.current,
-                                    ) { showDetailsDialog = true },
+                                    ) {
+                                        if (uiConfig.playSoundOnFocus) playOnClickSound(context)
+                                        showDetailsDialog = true
+                                    },
                         ) {
                             Text(
                                 text = scene.details,
@@ -271,6 +277,7 @@ fun SceneDetailsHeader(
                             TitleValueText(
                                 stringResource(R.string.stashapp_studio),
                                 studio.name,
+                                playSoundOnFocus = uiConfig.playSoundOnFocus,
                                 modifier =
                                     Modifier.onFocusChanged {
                                         if (it.isFocused) {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PerformerPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PerformerPage.kt
@@ -676,6 +676,7 @@ private fun PerformerDetailsPreview() {
                         showTitleDuringPlayback = true,
                         readOnlyModeEnabled = false,
                         showCardProgress = true,
+                        playSoundOnFocus = true,
                         cardSettings =
                             CardUiSettings(
                                 maxSearchResults = 25,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/util/ModifierUtils.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/util/ModifierUtils.kt
@@ -18,6 +18,8 @@
 
 package com.github.damontecres.stashapp.ui.util
 
+import android.content.Context
+import android.media.AudioManager
 import android.view.KeyEvent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.wrapContentSize
@@ -29,9 +31,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.platform.LocalContext
 import com.github.damontecres.stashapp.api.fragment.ImageData
 import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
@@ -259,4 +263,29 @@ fun getDestinationForItem(
         return Destination.fromStashData(item)
     }
     return null
+}
+
+@Composable
+fun Modifier.playSoundOnFocus(enabled: Boolean): Modifier {
+    if (!enabled) {
+        return this
+    }
+    val context = LocalContext.current
+    val audioManager =
+        remember {
+            context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        }
+    return onFocusChanged {
+        if (it.isFocused) {
+            audioManager.playSoundEffect(AudioManager.FX_FOCUS_NAVIGATION_UP)
+        }
+    }
+}
+
+fun playOnClickSound(
+    context: Context,
+    effectType: Int = AudioManager.FX_KEY_CLICK,
+) {
+    val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    audioManager.playSoundEffect(effectType)
 }

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -75,5 +75,6 @@
     <string name="pref_key_ui_grid_jump_controls" translatable="false">ui.grid.jumpControls</string>
     <string name="pref_key_playback_seek_count" translatable="false">playback.seekIntervals</string>
     <string name="pref_key_playback_show_skip_progress" translatable="false">playback.showSkipProgress</string>
+    <string name="pref_key_movement_sounds" translatable="false">ui.movementSounds</string>
 
 </resources>

--- a/app/src/main/res/xml/ui_preferences.xml
+++ b/app/src/main/res/xml/ui_preferences.xml
@@ -109,5 +109,10 @@
             app:summaryOn="Enabled"
             app:summaryOff="Disabled"
             app:defaultValue="true" />
+        <SwitchPreference
+            app:key="@string/pref_key_movement_sounds"
+            app:title="Play movement sound effects"
+            app:summary="Applies to Compose UI pages only"
+            app:defaultValue="true" />
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Adds movement sound effects when navigating most cards and buttons.

This can be turned off in advanced UI settings, but only for pages that use the new UI (see #592 for a list).