### PR TITLE
Add ability to change audio track, playback speed, & video scaling

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
@@ -141,6 +141,10 @@ fun PlaybackOverlay(
     spriteImageLoaded: Boolean,
     moreButtonOptions: MoreButtonOptions,
     subtitleIndex: Int?,
+    audioIndex: Int?,
+    audioOptions: List<String>,
+    playbackSpeed: Float,
+    scale: ContentScale,
     modifier: Modifier = Modifier,
     seekPreviewPlaceholder: Painter? = null,
     seekBarInteractionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -241,6 +245,10 @@ fun PlaybackOverlay(
                     seekBarInteractionSource = seekBarInteractionSource,
                     moreButtonOptions = moreButtonOptions,
                     subtitleIndex = subtitleIndex,
+                    audioIndex = audioIndex,
+                    audioOptions = audioOptions,
+                    playbackSpeed = playbackSpeed,
+                    scale = scale,
                 )
             }
             if (markers.isNotEmpty()) {
@@ -579,6 +587,10 @@ private fun PlaybackOverlayPreview() {
             modifier =
                 Modifier
                     .fillMaxSize(),
+            audioIndex = null,
+            audioOptions = listOf(),
+            playbackSpeed = 1.0f,
+            scale = ContentScale.Fit,
         )
     }
 }


### PR DESCRIPTION
Enables the playback settings button and adds options for controlling:
- Which audio track to play (or disable current)
- Playback speed from 25% to 200%
- Video scaling/stretching

The dialog UI for these re-using the captions one. It's not great, but works well enough.