### PR TITLE
Play all of the markers for a scene

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/ItemsRow.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/ItemsRow.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -44,6 +45,7 @@ fun <T : StashData> ItemsRow(
     cardOnFocus: (isFocused: Boolean, index: Int) -> Unit,
     modifier: Modifier = Modifier,
     focusPair: FocusPair? = null,
+    additionalContent: (LazyListScope.() -> Unit)? = null,
 ) = ItemsRow(
     title = stringResource(title),
     items = items,
@@ -63,6 +65,7 @@ fun <T : StashData> ItemsRow(
             modifier = modifier,
         )
     },
+    additionalContent = additionalContent,
 )
 
 @Composable
@@ -73,6 +76,7 @@ fun <T : StashData> ItemsRow(
     itemOnClick: ItemOnClicker<Any>,
     modifier: Modifier = Modifier,
     longClicker: LongClicker<Any>? = null,
+    additionalContent: (LazyListScope.() -> Unit)? = null,
 ) = ItemsRow(
     title = title,
     items = items,
@@ -92,6 +96,7 @@ fun <T : StashData> ItemsRow(
             modifier = modifier,
         )
     },
+    additionalContent = additionalContent,
 )
 
 @Composable
@@ -104,6 +109,7 @@ fun <T : StashData> ItemsRow(
     cardOnFocus: (isFocused: Boolean, index: Int) -> Unit,
     modifier: Modifier = Modifier,
     focusPair: FocusPair? = null,
+    additionalContent: (LazyListScope.() -> Unit)? = null,
     itemContent: @Composable (
         uiConfig: ComposeUiConfig,
         item: T,
@@ -176,6 +182,7 @@ fun <T : StashData> ItemsRow(
                     cardModifier,
                 )
             }
+            additionalContent?.invoke(this)
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/MarkerPlayAll.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/MarkerPlayAll.kt
@@ -1,0 +1,119 @@
+package com.github.damontecres.stashapp.ui.components.scene
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Icon
+import androidx.tv.material3.Text
+import com.apollographql.apollo.api.Optional
+import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.api.fragment.MarkerData
+import com.github.damontecres.stashapp.api.type.CriterionModifier
+import com.github.damontecres.stashapp.api.type.MultiCriterionInput
+import com.github.damontecres.stashapp.api.type.SceneMarkerFilterType
+import com.github.damontecres.stashapp.api.type.SortDirectionEnum
+import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.data.SortAndDirection
+import com.github.damontecres.stashapp.data.SortOption
+import com.github.damontecres.stashapp.data.StashFindFilter
+import com.github.damontecres.stashapp.navigation.Destination
+import com.github.damontecres.stashapp.navigation.NavigationManager
+import com.github.damontecres.stashapp.presenters.MarkerPresenter
+import com.github.damontecres.stashapp.suppliers.FilterArgs
+import com.github.damontecres.stashapp.ui.ComposeUiConfig
+import com.github.damontecres.stashapp.ui.cards.RootCard
+import com.github.damontecres.stashapp.ui.components.MarkerDurationDialog
+
+fun LazyListScope.markerPlayAll(
+    markers: List<MarkerData>,
+    sceneId: String,
+    uiConfig: ComposeUiConfig,
+    navigationManager: NavigationManager,
+    modifier: Modifier = Modifier,
+) {
+    if (markers.size > 1) {
+        fun playAll(durationMs: Long) {
+            val objectFilter =
+                SceneMarkerFilterType(
+                    scenes =
+                        Optional.present(
+                            MultiCriterionInput(
+                                value = Optional.present(listOf(sceneId)),
+                                modifier = CriterionModifier.INCLUDES,
+                            ),
+                        ),
+                )
+            val filterArgs =
+                FilterArgs(
+                    dataType = DataType.MARKER,
+                    objectFilter = objectFilter,
+                    findFilter =
+                        StashFindFilter(
+                            SortAndDirection(
+                                SortOption.Seconds,
+                                SortDirectionEnum.ASC,
+                            ),
+                        ),
+                )
+            val destination =
+                Destination.Playlist(
+                    filterArgs = filterArgs,
+                    position = 0,
+                    duration = durationMs,
+                )
+            navigationManager.navigate(destination)
+        }
+
+        item {
+            var showDialog by remember { mutableStateOf(false) }
+            RootCard(
+                modifier = modifier,
+                item = null,
+                title = stringResource(R.string.play_all),
+                uiConfig = uiConfig,
+                imageWidth = MarkerPresenter.CARD_WIDTH.dp / 2,
+                imageHeight = MarkerPresenter.CARD_HEIGHT.dp / 2,
+                longClicker = { _, _ -> },
+                getFilterAndPosition = null,
+                imageContent = {
+                    Icon(
+                        imageVector = Icons.Default.PlayArrow,
+                        contentDescription = stringResource(R.string.play_all),
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                },
+                subtitle = {
+                    Column {
+                        Text(text = "")
+                        Text(text = "")
+                    }
+                },
+                description = {
+                    Text(text = "")
+                },
+                onClick = {
+                    if (markers.firstOrNull { it.end_seconds == null } != null) {
+                        showDialog = true
+                    } else {
+                        playAll(0)
+                    }
+                },
+            )
+            if (showDialog) {
+                MarkerDurationDialog(
+                    onDismissRequest = { showDialog = false },
+                    onClick = { playAll(it) },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/SceneDetailsPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/SceneDetailsPage.kt
@@ -79,6 +79,7 @@ import com.github.damontecres.stashapp.ui.components.LongClicker
 import com.github.damontecres.stashapp.ui.components.RowColumn
 import com.github.damontecres.stashapp.ui.components.scene.SceneDetailsFooter
 import com.github.damontecres.stashapp.ui.components.scene.SceneDetailsHeader
+import com.github.damontecres.stashapp.ui.components.scene.markerPlayAll
 import com.github.damontecres.stashapp.ui.showAddGallery
 import com.github.damontecres.stashapp.ui.showAddGroup
 import com.github.damontecres.stashapp.ui.showAddMarker
@@ -765,6 +766,14 @@ fun SceneDetails(
                     },
                     focusPair = createFocusPair(0),
                     modifier = Modifier.padding(start = startPadding, bottom = bottomPadding),
+                    additionalContent = {
+                        markerPlayAll(
+                            sceneId = scene.id,
+                            markers = markers,
+                            uiConfig = uiConfig,
+                            navigationManager = navigationManager,
+                        )
+                    },
                 )
             }
         }


### PR DESCRIPTION
This basically lets you play the "highlights" of a scene if you've set up the markers for it!

Adds a card to the end of marker list for a scene if there are 2+ markers.

This will play all of the markers for the scene in order. If at least one marker doesn't have an end time, it will prompt for duration to play markers without end time. Otherwise, it immediately will play each marker for its duration.

Having the play all at the end of the marker list can be annoying if there's a lot of markers though.

Related to #604 