### PR TITLE
Allow more than 100 items in a playlist

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
@@ -210,11 +210,13 @@ val playbackScaleOptions =
 @Composable
 fun PlaybackPageContent(
     server: StashServer,
+    player: Player,
     playlist: List<MediaItem>,
     startIndex: Int,
     uiConfig: ComposeUiConfig,
     markersEnabled: Boolean,
     playlistPager: ComposePager<StashData>?,
+    onClickPlaylistItem: ((Int) -> Unit)?,
     modifier: Modifier = Modifier,
     controlsEnabled: Boolean = true,
     viewModel: PlaybackViewModel = viewModel(),
@@ -237,13 +239,6 @@ fun PlaybackPageContent(
     var audioOptions by remember { mutableStateOf<List<String>>(listOf()) }
 
     var trackActivityListener = remember<TrackActivityPlaybackListener?>(server) { null }
-    val player =
-        remember {
-            StashExoPlayer.getInstance(context, server).apply {
-                repeatMode = Player.REPEAT_MODE_OFF
-                playWhenReady = true
-            }
-        }
     AmbientPlayerListener(player)
 
     LifecycleStartEffect(Unit) {
@@ -592,13 +587,16 @@ fun PlaybackPageContent(
             dialogTitle = "Create marker at ${createMarkerPosition.milliseconds}?",
             dismissOnClick = false,
         )
-        PlaylistListDialog(
-            show = showPlaylist,
-            onDismiss = { showPlaylist = false },
-            player = player,
-            pager = playlistPager,
-            modifier = Modifier,
-        )
+        if (playlistPager != null && onClickPlaylistItem != null) {
+            PlaylistListDialog(
+                show = showPlaylist,
+                onDismiss = { showPlaylist = false },
+                player = player,
+                pager = playlistPager,
+                onClickPlaylistItem = onClickPlaylistItem,
+                modifier = Modifier,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistList.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistList.kt
@@ -2,6 +2,8 @@ package com.github.damontecres.stashapp.ui.components.playback
 
 import android.util.Log
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -34,6 +36,7 @@ import coil3.compose.AsyncImage
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.data.PlaylistItem
 import com.github.damontecres.stashapp.ui.AppTheme
+import com.github.damontecres.stashapp.ui.enableMarquee
 import com.github.damontecres.stashapp.ui.tryRequestFocus
 import com.github.damontecres.stashapp.ui.util.ifElse
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
@@ -95,9 +98,12 @@ fun PlaylistItemCompose(
     modifier: Modifier = Modifier,
     imageWidth: Dp = 120.dp,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val focused = interactionSource.collectIsFocusedAsState().value
     val textColor = MaterialTheme.colorScheme.onSurfaceVariant
     Card(
         onClick = onClick,
+        interactionSource = interactionSource,
         modifier = modifier,
     ) {
         Row(
@@ -139,6 +145,7 @@ fun PlaylistItemCompose(
                         style = MaterialTheme.typography.bodyLarge,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.enableMarquee(focused),
                     )
                 }
                 if (item.subtitle.isNotNullOrBlank()) {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistListDialog.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistListDialog.kt
@@ -25,10 +25,11 @@ fun PlaylistListDialog(
     show: Boolean,
     onDismiss: () -> Unit,
     player: Player,
-    pager: ComposePager<StashData>?,
+    pager: ComposePager<StashData>,
+    onClickPlaylistItem: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (show && pager != null) {
+    if (show) {
         Dialog(
             onDismissRequest = onDismiss,
             properties = DialogProperties(usePlatformDefaultWidth = true),
@@ -39,9 +40,9 @@ fun PlaylistListDialog(
                 window.setDimAmount(0f)
             }
             PlaylistList(
-                mediaItemCount = player.mediaItemCount,
+                mediaItemCount = pager.size,
                 currentIndex = player.currentMediaItemIndex,
-                mediaItemCountOffset = 0, // TODO
+                mediaItemCountOffset = 0,
                 items =
                     MappedList(pager) { index, item ->
                         when (item) {
@@ -61,7 +62,7 @@ fun PlaylistListDialog(
                     },
                 title = pager.filter.name ?: stringResource(pager.filter.dataType.pluralStringId),
                 onClick = { index ->
-                    player.seekTo(index, 0L)
+                    onClickPlaylistItem.invoke(index)
                     onDismiss.invoke()
                 },
                 modifier =


### PR DESCRIPTION
Playing a playlist will now support as many items as the device memory can handle.

Like the old UI, as you advance in the playlist, new items will be fetched and added to the playlist.

There's no limit, but eventually memory will run out because every item in the playlist needs to be kept in memory.