### PR TITLE
Add option to show embedded subtitles when direct playing scenes

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
@@ -57,9 +57,8 @@ import androidx.tv.material3.ListItem
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
-import com.github.damontecres.stashapp.api.fragment.Caption
 import com.github.damontecres.stashapp.data.Scene
-import com.github.damontecres.stashapp.playback.displayString
+import com.github.damontecres.stashapp.playback.TrackSupport
 import com.github.damontecres.stashapp.ui.AppColors
 import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.tryRequestFocus
@@ -99,6 +98,7 @@ sealed interface PlaybackAction {
 @Composable
 fun PlaybackControls(
     scene: Scene,
+    captions: List<TrackSupport>,
     oCounter: Int,
     playerControls: PlayerControls,
     controllerViewState: ControllerViewState,
@@ -182,7 +182,7 @@ fun PlaybackControls(
             )
             RightPlaybackButtons(
                 modifier = Modifier,
-                captions = scene.captions,
+                captions = captions,
                 onControllerInteraction = onControllerInteraction,
                 onControllerInteractionForDialog = onControllerInteractionForDialog,
                 onPlaybackActionClick = onPlaybackActionClick,
@@ -339,7 +339,7 @@ private val speedOptions = listOf(".25", ".5", ".75", "1.0", "1.25", "1.5", "2.0
 
 @Composable
 fun RightPlaybackButtons(
-    captions: List<Caption>,
+    captions: List<TrackSupport>,
     onControllerInteraction: () -> Unit,
     onControllerInteractionForDialog: () -> Unit,
     onPlaybackActionClick: (PlaybackAction) -> Unit,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
@@ -59,6 +59,7 @@ import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.playback.StreamDecision
+import com.github.damontecres.stashapp.playback.TrackSupport
 import com.github.damontecres.stashapp.playback.TranscodeDecision
 import com.github.damontecres.stashapp.ui.AppColors
 import com.github.damontecres.stashapp.ui.AppTheme
@@ -126,6 +127,7 @@ class ControllerViewState internal constructor(
 fun PlaybackOverlay(
     uiConfig: ComposeUiConfig,
     scene: Scene,
+    captions: List<TrackSupport>,
     markers: List<BasicMarker>,
     streamDecision: StreamDecision?,
     oCounter: Int,
@@ -229,6 +231,7 @@ fun PlaybackOverlay(
                 PlaybackControls(
                     modifier = Modifier.fillMaxWidth(),
                     scene = scene,
+                    captions = captions,
                     oCounter = oCounter,
                     playerControls = playerControls,
                     onPlaybackActionClick = onPlaybackActionClick,
@@ -553,6 +556,7 @@ private fun PlaybackOverlayPreview() {
                     captionUrl = "",
                     captions = listOf(),
                 ),
+            captions = listOf(),
             markers =
                 List(1) {
                     BasicMarker(

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
@@ -7,10 +7,12 @@ import androidx.annotation.OptIn
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -32,6 +34,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -54,6 +57,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.Tracks
+import androidx.media3.common.text.Cue
 import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
@@ -81,6 +85,7 @@ import com.github.damontecres.stashapp.navigation.NavigationManager
 import com.github.damontecres.stashapp.playback.PlaybackSceneFragment
 import com.github.damontecres.stashapp.playback.PlaylistFragment
 import com.github.damontecres.stashapp.playback.TrackActivityPlaybackListener
+import com.github.damontecres.stashapp.playback.TrackSupport
 import com.github.damontecres.stashapp.playback.TrackSupportReason
 import com.github.damontecres.stashapp.playback.TrackType
 import com.github.damontecres.stashapp.playback.checkForSupport
@@ -233,7 +238,8 @@ fun PlaybackPageContent(
     val markers by viewModel.markers.observeAsState(listOf())
     val oCount by viewModel.oCount.observeAsState(0)
     val spriteImageLoaded by viewModel.spriteImageLoaded.observeAsState(false)
-    var subtitles by remember { mutableStateOf<String?>(null) }
+    var captions by remember { mutableStateOf<List<TrackSupport>>(listOf()) }
+    var subtitles by remember { mutableStateOf<List<Cue>?>(null) }
     var subtitleIndex by remember { mutableStateOf<Int?>(null) }
     var audioIndex by remember { mutableStateOf<Int?>(null) }
     var audioOptions by remember { mutableStateOf<List<String>>(listOf()) }
@@ -306,20 +312,24 @@ fun PlaybackPageContent(
         StashExoPlayer.addListener(
             object : Player.Listener {
                 override fun onCues(cueGroup: CueGroup) {
-                    val cues =
-                        cueGroup.cues
-                            .mapNotNull { it.text }
-                            .joinToString("\n")
+//                    val cues =
+//                        cueGroup.cues
+//                            .mapNotNull { it.text }
+//                            .joinToString("\n")
 //                    Log.v(TAG, "onCues: \n$cues")
-                    subtitles = cues
+                    subtitles = if (cueGroup.cues.isNotEmpty()) cueGroup.cues else null
                 }
 
                 override fun onTracksChanged(tracks: Tracks) {
+                    val trackInfo = checkForSupport(tracks)
                     val audioTracks =
-                        checkForSupport(tracks).filter { it.type == TrackType.AUDIO && it.supported == TrackSupportReason.HANDLED }
+                        trackInfo
+                            .filter { it.type == TrackType.AUDIO && it.supported == TrackSupportReason.HANDLED }
                     audioIndex = audioTracks.indexOfFirstOrNull { it.selected }
                     audioOptions =
                         audioTracks.map { it.labels.joinToString(", ").ifBlank { "Default" } }
+                    captions =
+                        trackInfo.filter { it.type == TrackType.TEXT && it.supported == TrackSupportReason.HANDLED }
                 }
 
                 override fun onMediaItemTransition(
@@ -457,15 +467,26 @@ fun PlaybackPageContent(
 
         if (!controllerViewState.controlsVisible && subtitleIndex != null && skipIndicatorDuration == 0L) {
             // TODO style
-            subtitles?.let { text ->
-                if (text.isNotNullOrBlank()) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .align(Alignment.BottomCenter)
-                                .padding(bottom = 48.dp)
-                                .background(AppColors.TransparentBlack50),
-                    ) {
+            subtitles?.let { cues ->
+                val text = cues.mapNotNull { it.text }.joinToString("\n")
+                val bitmaps =
+                    cues.mapNotNull { cue ->
+                        cue.bitmap?.let { Pair(it, cue.bitmapHeight) }
+                    }
+                val background =
+                    if (text.isNotNullOrBlank()) {
+                        AppColors.TransparentBlack50
+                    } else {
+                        Color.Transparent
+                    }
+                Box(
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 48.dp)
+                            .background(background),
+                ) {
+                    if (text.isNotNullOrBlank()) {
                         Text(
                             text = text,
                             color = Color.White,
@@ -474,6 +495,16 @@ fun PlaybackPageContent(
                             overflow = TextOverflow.Clip,
                             modifier = Modifier.padding(4.dp),
                         )
+                    } else if (bitmaps.isNotEmpty()) {
+                        Column {
+                            bitmaps.forEach {
+                                Image(
+                                    bitmap = it.first.asImageBitmap(),
+                                    contentDescription = null,
+//                                    modifier = Modifier.height(100.dp),
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -493,6 +524,7 @@ fun PlaybackPageContent(
                             .background(Color.Transparent),
                     uiConfig = uiConfig,
                     scene = currentScene.item,
+                    captions = captions,
                     markers = markers,
                     streamDecision = currentScene.streamDecision,
                     oCounter = oCount,
@@ -725,7 +757,7 @@ fun toggleSubtitles(
     index: Int,
 ): Boolean {
     val subtitleTracks =
-        player.currentTracks.groups.filter { it.type == C.TRACK_TYPE_TEXT }
+        player.currentTracks.groups.filter { it.type == C.TRACK_TYPE_TEXT && it.isSupported }
     if (index !in subtitleTracks.indices || subtitleIndex != null && subtitleIndex == index) {
         Log.v(
             TAG,


### PR DESCRIPTION
This PR adds the ability to select subtitle/caption tracks embedded in a scene's file if the file is direct played. They are shown in addition to any "sidecar" captions provided by the server.

Additionally, image subtitles (eg vobsub, pgs) are now supported. Though the UI isn't always great.

As a consequence of this, a bug is fixed where captions may not show when activated when there are embedded subtitles and sidecar captions.