### PR TITLE
Fallback to transcoding for some playback errors

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/StreamUtils.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/StreamUtils.kt
@@ -453,3 +453,19 @@ fun findPossibleTranscodeLabels(
             }
         }
 }
+
+fun switchToTranscode(
+    context: Context,
+    current: MediaItem,
+): MediaItem {
+    val currScene = (current.localConfiguration!!.tag as PlaylistFragment.MediaItemTag).item
+    val format =
+        PreferenceManager
+            .getDefaultSharedPreferences(context)
+            .getString("stream_choice", "HLS")!!
+    val transcodeDecision =
+        getStreamDecision(context, currScene, PlaybackMode.ForcedTranscode(format))
+    return buildMediaItem(context, transcodeDecision, currScene) {
+        setTag(PlaylistFragment.MediaItemTag(currScene, transcodeDecision))
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
@@ -84,10 +84,12 @@ fun PlaybackPage(
                 }
             }
         val playbackScene = remember { Scene.fromFullSceneData(it) }
-        val decision = getStreamDecision(context, playbackScene, playbackMode)
+        val decision = remember { getStreamDecision(context, playbackScene, playbackMode) }
         val media =
-            buildMediaItem(context, decision, playbackScene) {
-                setTag(PlaylistFragment.MediaItemTag(playbackScene, decision))
+            remember {
+                buildMediaItem(context, decision, playbackScene) {
+                    setTag(PlaylistFragment.MediaItemTag(playbackScene, decision))
+                }
             }
 
         PlaybackPageContent(


### PR DESCRIPTION
When direct playing a video, if there are playback errors related to the decoding or exceeds capabilities, then the app will retry playback with transcoding.

This is a more seamless experience when watching.