### PR TITLE
Show parent/sub tags & fix track selected indicator

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/DataSupplierFactory.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/DataSupplierFactory.kt
@@ -148,5 +148,6 @@ sealed interface DataSupplierOverride {
         val type: GroupRelationshipType,
     ) : DataSupplierOverride
 
+    @Serializable
     data object Playlist : DataSupplierOverride
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/ItemDetails.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/ItemDetails.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -45,6 +46,7 @@ fun ItemDetails(
     rating100Click: ((rating100: Int) -> Unit)? = null,
     basicItemInfo: BasicItemInfo? = null,
     tags: List<TagData>? = null,
+    bodyContent: (LazyListScope.() -> Unit)? = null,
 ) {
     Row(
         modifier =
@@ -98,6 +100,9 @@ fun ItemDetails(
             items(tableRows) { row ->
                 TableRowComposable(row)
             }
+
+            bodyContent?.invoke(this)
+
             if (!tags.isNullOrEmpty()) {
                 item {
                     ItemsRow(

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
@@ -390,7 +390,7 @@ fun RightPlaybackButtons(
         Log.v(TAG, "subtitleIndex=$subtitleIndex, options=$options")
         BottomDialog(
             choices = options,
-            currentChoice = if (subtitleIndex != null) options[subtitleIndex] else null,
+            currentChoice = subtitleIndex,
             onDismissRequest = {
                 onControllerInteraction.invoke()
                 showCaptionDialog = false
@@ -423,7 +423,7 @@ fun RightPlaybackButtons(
     if (showAudioDialog) {
         BottomDialog(
             choices = audioOptions,
-            currentChoice = if (audioIndex != null && audioIndex in audioOptions.indices) audioOptions[audioIndex] else null,
+            currentChoice = audioIndex,
             onDismissRequest = {
                 onControllerInteraction.invoke()
                 showAudioDialog = false
@@ -437,7 +437,7 @@ fun RightPlaybackButtons(
     if (showSpeedDialog) {
         BottomDialog(
             choices = speedOptions,
-            currentChoice = playbackSpeed.toString(),
+            currentChoice = speedOptions.indexOf(playbackSpeed.toString()),
             onDismissRequest = {
                 onControllerInteraction.invoke()
                 showSpeedDialog = false
@@ -451,7 +451,7 @@ fun RightPlaybackButtons(
     if (showScaleDialog) {
         BottomDialog(
             choices = playbackScaleOptions.values.toList(),
-            currentChoice = playbackScaleOptions[scale],
+            currentChoice = playbackScaleOptions.keys.toList().indexOf(scale),
             onDismissRequest = {
                 onControllerInteraction.invoke()
                 showScaleDialog = false
@@ -565,7 +565,7 @@ private fun BottomDialog(
     onDismissRequest: () -> Unit,
     onSelectChoice: (Int, String) -> Unit,
     gravity: Int,
-    currentChoice: String? = null,
+    currentChoice: Int? = null,
 ) {
     // TODO enforcing a width ends up ignore the gravity
     Dialog(
@@ -604,13 +604,13 @@ private fun BottomDialog(
                             MaterialTheme.colorScheme.onSurface
                         }
                     ListItem(
-                        selected = choice == currentChoice,
+                        selected = index == currentChoice,
                         onClick = {
                             onDismissRequest()
                             onSelectChoice(index, choice)
                         },
                         leadingContent = {
-                            if (choice == currentChoice) {
+                            if (index == currentChoice) {
                                 Box(
                                     modifier =
                                         Modifier

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/MarkerPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/MarkerPage.kt
@@ -71,6 +71,7 @@ import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.util.titleOrFilename
 import com.github.damontecres.stashapp.views.models.MarkerDetailsViewModel
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
@@ -271,7 +272,8 @@ fun MarkerPageContent(
             ) {
                 TitleValueText(
                     stringResource(R.string.stashapp_resume_time),
-                    marker.seconds.seconds.toString(),
+                    marker.seconds.seconds.inWholeMilliseconds.milliseconds
+                        .toString(),
                 )
                 if (marker.end_seconds != null) {
                     TitleValueText(


### PR DESCRIPTION
Show a tag's parents and subtags on the tag details page tab.

Also fixes some minor bugs like showing multiple subtitle tracking as being active.