### PR TITLE
Fix restarting scene when fallback transcoding a marker

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
@@ -470,6 +470,9 @@ fun PlaybackPageContent(
                                         viewModel.changeScene(newTag)
                                         player.replaceMediaItem(currentPosition, newMediaItem)
                                         player.prepare()
+                                        if (startPosition != C.TIME_UNSET) {
+                                            player.seekTo(startPosition)
+                                        }
                                         player.play()
                                         false
                                     } else {


### PR DESCRIPTION
If playing a marker that needs transcoding fallback, it would not persist the marker position and would restart the scene. This PR fixes that.