### PR TITLE
Add markers, appears with, & studio scenes to performer page

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,5 +115,6 @@
     <string name="play_from_here">Play from here</string>
     <string name="add_gallery">Add Gallery</string>
     <string name="play_all_markers">Play all markers</string>
+    <string name="scenes_together">View scenes together</string>
 
 </resources>


### PR DESCRIPTION
Adds markers and appears with tabs to a performer's page. Can long click the performers under appears with to view scenes the two performers have in common.

Also adds long clicking the studios on performer's details tab with option to show scenes with for that studio with the performer.