### PR TITLE
Hide system bars on playback & image pages

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/RootActivity.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/RootActivity.kt
@@ -11,6 +11,9 @@ import android.widget.ImageView
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.annotation.OptIn
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -134,6 +137,26 @@ class RootActivity :
                             }
                         }
                     }
+                }
+            }
+
+            serverViewModel.destination.observe(this) { destination ->
+                val windowInsetsController =
+                    WindowCompat.getInsetsController(window, window.decorView)
+                if (destination is Destination.Playback ||
+                    destination is Destination.Playlist ||
+                    destination is Destination.Slideshow ||
+                    destination is Destination.UpdateMarker
+                ) {
+                    Log.v(TAG, "Hiding system bars for $destination")
+                    windowInsetsController.systemBarsBehavior =
+                        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                    windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
+                } else {
+                    Log.v(TAG, "Showing system bars for $destination")
+                    windowInsetsController.systemBarsBehavior =
+                        WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+                    windowInsetsController.show(WindowInsetsCompat.Type.systemBars())
                 }
             }
         } else {

--- a/app/src/main/java/com/github/damontecres/stashapp/navigation/NavigationManagerCompose.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/navigation/NavigationManagerCompose.kt
@@ -25,7 +25,7 @@ import dev.olshevski.navigation.reimagined.popUpTo
 
 class NavigationManagerCompose(
     activity: RootActivity,
-    private val serverViewModel: ServerViewModel,
+    val serverViewModel: ServerViewModel,
 ) : NavigationManagerParent(activity) {
     private val navDrawerFragment: NavDrawerFragment
 

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/NavDrawerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/NavDrawerFragment.kt
@@ -368,6 +368,7 @@ fun FragmentContent(
                 server.updateServerPrefs()
                 composeUiConfig = ComposeUiConfig.fromStashServer(context, server)
             }
+            navigationManager.serverViewModel.setCurrentDestination(destination)
         }
 
         if (destination.fullScreen) {


### PR DESCRIPTION
Closes #642 

Hides the system bars (status, notifications, clock, etc) on a few pages including scene playback and image viewing. This doesn't change anything on TV devices, but does make the experience a bit better on phones/tablets.

This change applies to both the new UI and legacy UI.