### PR TITLE
Fix fast scrolling through a grid in new UI jumping to nav drawer

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/FilterViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/FilterViewModel.kt
@@ -31,17 +31,19 @@ class FilterViewModel : ViewModel() {
     fun setFilter(
         server: StashServer,
         filterArgs: FilterArgs,
+        columns: Int,
     ) {
         if (pager.value?.filter != filterArgs || server != this.server) {
             job?.cancel()
-            Log.d("FilterPageViewModel", "filterArgs=$filterArgs")
+            Log.d("FilterPageViewModel", "filterArgs=$filterArgs, columns=$columns")
             this.server = server
             val dataSupplierFactory = DataSupplierFactory(server.version)
             val dataSupplier =
                 dataSupplierFactory.create<Query.Data, StashData, Query.Data>(filterArgs)
             val pagingSource =
                 StashPagingSource(QueryEngine(server), dataSupplier) { _, _, item -> item }
-            val pager = ComposePager(filterArgs, pagingSource, viewModelScope)
+            val pager =
+                ComposePager(filterArgs, pagingSource, viewModelScope, pageSize = columns * 10)
             job =
                 viewModelScope.launch(StashCoroutineExceptionHandler(autoToast = true)) {
                     pager.init()

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/Cards.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/Cards.kt
@@ -95,7 +95,6 @@ import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.FontAwesome
 import com.github.damontecres.stashapp.ui.LocalGlobalContext
 import com.github.damontecres.stashapp.ui.LocalPlayerContext
-import com.github.damontecres.stashapp.ui.components.CircularProgress
 import com.github.damontecres.stashapp.ui.components.LongClicker
 import com.github.damontecres.stashapp.ui.enableMarquee
 import com.github.damontecres.stashapp.ui.util.playOnClickSound
@@ -526,109 +525,110 @@ fun CardImage(
 @Composable
 fun StashCard(
     uiConfig: ComposeUiConfig,
-    item: Any,
+    item: Any?,
     itemOnClick: (item: Any) -> Unit,
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
     modifier: Modifier = Modifier,
 ) {
     when (item) {
-        is SlimSceneData ->
+        is SlimSceneData? ->
             SceneCard(
                 uiConfig,
                 item,
-                onClick = { itemOnClick(item) },
-                longClicker,
-                getFilterAndPosition,
-                modifier,
-            )
-        is FullSceneData ->
-            SceneCard(
-                uiConfig,
-                item.asSlimeSceneData,
-                onClick = { itemOnClick(item) },
+                onClick = { item?.let(itemOnClick) },
                 longClicker,
                 getFilterAndPosition,
                 modifier,
             )
 
-        is PerformerData ->
+        is FullSceneData? ->
+            SceneCard(
+                uiConfig,
+                item?.asSlimeSceneData,
+                onClick = { item?.let(itemOnClick) },
+                longClicker,
+                getFilterAndPosition,
+                modifier,
+            )
+
+        is PerformerData? ->
             PerformerCard(
                 uiConfig,
                 item,
-                onClick = { itemOnClick(item) },
+                onClick = { item?.let(itemOnClick) },
                 longClicker,
                 getFilterAndPosition,
                 modifier,
             )
 
-        is ImageData ->
+        is ImageData? ->
             ImageCard(
                 uiConfig,
                 item,
-                onClick = { itemOnClick(item) },
+                onClick = { item?.let(itemOnClick) },
                 longClicker,
                 getFilterAndPosition,
                 modifier,
             )
 
-        is GalleryData ->
+        is GalleryData? ->
             GalleryCard(
                 uiConfig,
                 item,
-                onClick = { itemOnClick(item) },
+                onClick = { item?.let(itemOnClick) },
                 longClicker,
                 getFilterAndPosition,
                 modifier,
             )
 
-        is MarkerData ->
+        is MarkerData? ->
             MarkerCard(
                 uiConfig,
                 item,
-                onClick = { itemOnClick(item) },
+                onClick = { item?.let(itemOnClick) },
                 longClicker,
                 getFilterAndPosition,
                 modifier,
             )
 
-        is GroupData ->
+        is GroupData? ->
             GroupCard(
                 uiConfig,
                 item,
-                onClick = { itemOnClick(item) },
+                onClick = { item?.let(itemOnClick) },
                 longClicker,
                 getFilterAndPosition,
                 modifier,
             )
 
-        is GroupRelationshipData -> {
+        is GroupRelationshipData? -> {
             GroupCard(
                 uiConfig,
-                item.group,
-                onClick = { itemOnClick(item) },
+                item?.group,
+                onClick = { item?.let(itemOnClick) },
                 longClicker,
                 getFilterAndPosition,
                 modifier,
-                subtitle = item.description,
+                subtitle = item?.description,
             )
         }
 
-        is StudioData ->
+        is StudioData? ->
             StudioCard(
                 uiConfig,
                 item,
-                onClick = { itemOnClick(item) },
+                onClick = { item?.let(itemOnClick) },
                 longClicker,
                 getFilterAndPosition,
                 modifier,
             )
 
-        is TagData ->
+        is TagData? ->
             TagCard(
                 uiConfig,
                 item,
-                onClick = { itemOnClick(item) },
+                onClick = { item?.let(itemOnClick) },
                 longClicker,
                 getFilterAndPosition,
                 modifier,
@@ -667,29 +667,6 @@ fun StashCard(
             )
         }
 
-        else -> throw UnsupportedOperationException("Item with class ${item.javaClass} not supported.")
+        else -> throw UnsupportedOperationException("Item with class ${item?.javaClass} not supported.")
     }
-}
-
-@Composable
-fun LoadingCard(
-    dataType: DataType,
-    uiConfig: ComposeUiConfig,
-    modifier: Modifier = Modifier,
-) {
-    RootCard(
-        item = null,
-        title = "Loading...",
-        subtitle = {},
-        uiConfig = uiConfig,
-        imageWidth = dataTypeImageWidth(dataType).dp / 2,
-        imageHeight = dataTypeImageHeight(dataType).dp / 2,
-        imageContent = {
-            CircularProgress(modifier = Modifier.fillMaxSize(.8f))
-        },
-        onClick = {},
-        longClicker = { _, _ -> },
-        getFilterAndPosition = null,
-        modifier = modifier,
-    )
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/GalleryCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/GalleryCard.kt
@@ -21,24 +21,26 @@ import java.util.EnumMap
 @Composable
 fun GalleryCard(
     uiConfig: ComposeUiConfig,
-    item: GalleryData,
+    item: GalleryData?,
     onClick: (() -> Unit),
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
     modifier: Modifier = Modifier,
 ) {
     val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-    dataTypeMap[DataType.TAG] = item.tags.size
-    dataTypeMap[DataType.PERFORMER] = item.performers.size
-    dataTypeMap[DataType.SCENE] = item.scenes.size
-    dataTypeMap[DataType.IMAGE] = item.image_count
+    item?.let {
+        dataTypeMap[DataType.TAG] = item.tags.size
+        dataTypeMap[DataType.PERFORMER] = item.performers.size
+        dataTypeMap[DataType.SCENE] = item.scenes.size
+        dataTypeMap[DataType.IMAGE] = item.image_count
+    }
 
-    val imageUrl = item.paths.cover
-    val videoUrl = item.paths.preview
+    val imageUrl = item?.paths?.cover
+    val videoUrl = item?.paths?.preview
 
     val details = mutableListOf<String?>()
-    details.add(item.studio?.name)
-    details.add(item.date)
+    details.add(item?.studio?.name)
+    details.add(item?.date)
 
     RootCard(
         item = item,
@@ -54,7 +56,7 @@ fun GalleryCard(
         imageUrl = imageUrl,
         defaultImageDrawableRes = R.drawable.default_gallery,
         videoUrl = videoUrl,
-        title = item.name ?: "",
+        title = item?.name ?: "",
         subtitle = {
             Text(concatIfNotBlank(" - ", details))
         },
@@ -68,7 +70,7 @@ fun GalleryCard(
             )
         },
         imageOverlay = {
-            ImageOverlay(uiConfig.ratingAsStars, rating100 = item.rating100)
+            ImageOverlay(uiConfig.ratingAsStars, rating100 = item?.rating100)
         },
     )
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/GroupCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/GroupCard.kt
@@ -23,7 +23,7 @@ import java.util.EnumMap
 @Composable
 fun GroupCard(
     uiConfig: ComposeUiConfig,
-    item: GroupData,
+    item: GroupData?,
     onClick: (() -> Unit),
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
@@ -31,12 +31,14 @@ fun GroupCard(
     subtitle: String? = null,
 ) {
     val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-    dataTypeMap[DataType.SCENE] = item.scene_count
-    dataTypeMap[DataType.TAG] = item.tags.size
+    item?.let {
+        dataTypeMap[DataType.SCENE] = item.scene_count
+        dataTypeMap[DataType.TAG] = item.tags.size
+    }
 
-    val title = item.name
-    val imageUrl = item.front_image_path
-    val details = subtitle ?: item.date ?: ""
+    val title = item?.name ?: ""
+    val imageUrl = item?.front_image_path
+    val details = subtitle ?: item?.date ?: ""
 
     RootCard(
         item = item,
@@ -56,39 +58,41 @@ fun GroupCard(
         subtitle = {
             Text(details)
         },
-        description = {
-            IconRowText(
-                dataTypeMap,
-                null,
-                Modifier
-                    .enableMarquee(it)
-                    .align(Alignment.Center),
-            ) {
-                if (item.containing_groups.isNotEmpty() || item.sub_group_count > 0) {
-                    if (length > 0) {
-                        append(" ")
-                    }
-                    withStyle(SpanStyle(fontFamily = FontAwesome)) {
-                        append(stringResource(DataType.GROUP.iconStringId))
-                    }
-                    append(" ")
-                    if (item.containing_groups.isNotEmpty()) {
-                        append(item.containing_groups.size.toString())
-                        withStyle(SpanStyle(fontFamily = FontAwesome)) {
-                            append(stringResource(R.string.fa_arrow_up_long))
+        description = { focused ->
+            item?.let {
+                IconRowText(
+                    dataTypeMap,
+                    null,
+                    Modifier
+                        .enableMarquee(focused)
+                        .align(Alignment.Center),
+                ) {
+                    if (item.containing_groups.isNotEmpty() || item.sub_group_count > 0) {
+                        if (length > 0) {
+                            append(" ")
                         }
-                    }
-                    if (item.sub_group_count > 0) {
-                        append(item.sub_group_count.toString())
                         withStyle(SpanStyle(fontFamily = FontAwesome)) {
-                            append(stringResource(R.string.fa_arrow_down_long))
+                            append(stringResource(DataType.GROUP.iconStringId))
+                        }
+                        append(" ")
+                        if (item.containing_groups.isNotEmpty()) {
+                            append(item.containing_groups.size.toString())
+                            withStyle(SpanStyle(fontFamily = FontAwesome)) {
+                                append(stringResource(R.string.fa_arrow_up_long))
+                            }
+                        }
+                        if (item.sub_group_count > 0) {
+                            append(item.sub_group_count.toString())
+                            withStyle(SpanStyle(fontFamily = FontAwesome)) {
+                                append(stringResource(R.string.fa_arrow_down_long))
+                            }
                         }
                     }
                 }
             }
         },
         imageOverlay = {
-            ImageOverlay(uiConfig.ratingAsStars, rating100 = item.rating100)
+            ImageOverlay(uiConfig.ratingAsStars, rating100 = item?.rating100)
         },
     )
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/ImageCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/ImageCard.kt
@@ -23,29 +23,33 @@ import java.util.EnumMap
 @Composable
 fun ImageCard(
     uiConfig: ComposeUiConfig,
-    item: ImageData,
+    item: ImageData?,
     onClick: (() -> Unit),
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
     modifier: Modifier = Modifier,
 ) {
     val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-    dataTypeMap[DataType.TAG] = item.tags.size
-    dataTypeMap[DataType.PERFORMER] = item.performers.size
-    dataTypeMap[DataType.GALLERY] = item.galleries.size
+    item?.let {
+        dataTypeMap[DataType.TAG] = item.tags.size
+        dataTypeMap[DataType.PERFORMER] = item.performers.size
+        dataTypeMap[DataType.GALLERY] = item.galleries.size
+    }
 
     val imageUrl =
-        if (item.paths.thumbnail.isNotNullOrBlank()) {
-            item.paths.thumbnail
-        } else if (item.paths.image.isNotNullOrBlank() && !item.isImageClip) {
-            item.paths.image
-        } else {
-            null
+        item?.let {
+            if (item.paths.thumbnail.isNotNullOrBlank()) {
+                item.paths.thumbnail
+            } else if (item.paths.image.isNotNullOrBlank() && !item.isImageClip) {
+                item.paths.image
+            } else {
+                null
+            }
         }
 
     val details = mutableListOf<String?>()
-    details.add(item.studio?.name)
-    details.add(item.date)
+    details.add(item?.studio?.name)
+    details.add(item?.date)
 
     RootCard(
         item = item,
@@ -60,22 +64,22 @@ fun ImageCard(
         imageHeight = ImagePresenter.CARD_HEIGHT.dp / 2,
         imageUrl = imageUrl,
         defaultImageDrawableRes = R.drawable.default_image,
-        videoUrl = item.paths.preview,
-        title = item.titleOrFilename ?: "",
+        videoUrl = item?.paths?.preview,
+        title = item?.titleOrFilename ?: "",
         subtitle = {
             Text(concatIfNotBlank(" - ", details))
         },
         description = {
             IconRowText(
                 dataTypeMap,
-                item.o_counter ?: -1,
+                item?.o_counter ?: -1,
                 Modifier
                     .enableMarquee(it)
                     .align(Alignment.Center),
             )
         },
         imageOverlay = {
-            ImageOverlay(uiConfig.ratingAsStars, rating100 = item.rating100)
+            ImageOverlay(uiConfig.ratingAsStars, rating100 = item?.rating100)
         },
     )
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/MarkerCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/MarkerCard.kt
@@ -23,33 +23,35 @@ import kotlin.time.toDuration
 @Composable
 fun MarkerCard(
     uiConfig: ComposeUiConfig,
-    item: MarkerData,
+    item: MarkerData?,
     onClick: (() -> Unit),
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
     modifier: Modifier = Modifier,
 ) {
     val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-    dataTypeMap[DataType.TAG] = item.tags.size
+    item?.let { dataTypeMap[DataType.TAG] = item.tags.size }
 
     val title =
-        item.title.ifBlank {
+        item?.title?.ifBlank {
             item.primary_tag.slimTagData.name
-        }
+        } ?: ""
     val startTime =
-        item.seconds
-            .toInt()
-            .toDuration(DurationUnit.SECONDS)
-            .toString()
+        item?.let {
+            item.seconds
+                .toInt()
+                .toDuration(DurationUnit.SECONDS)
+                .toString()
+        }
     val subtitle =
-        if (item.end_seconds != null) {
+        if (item?.end_seconds != null) {
             "$startTime - ${item.end_seconds.toInt().toDuration(DurationUnit.SECONDS)}"
         } else {
             startTime
-        }
+        } ?: ""
 
-    val imageUrl = item.screenshot
-    val videoUrl = item.stream
+    val imageUrl = item?.screenshot
+    val videoUrl = item?.stream
 
     RootCard(
         item = item,
@@ -74,7 +76,7 @@ fun MarkerCard(
                     modifier = Modifier.enableMarquee(it),
                 )
                 Text(
-                    text = item.scene.minimalSceneData.titleOrFilename ?: "",
+                    text = item?.scene?.minimalSceneData?.titleOrFilename ?: "",
                     maxLines = 1,
                     modifier = Modifier.enableMarquee(it),
                 )

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/PerformerCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/PerformerCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
@@ -36,7 +37,7 @@ private const val TAG = "PerformerCard"
 @Composable
 fun PerformerCard(
     uiConfig: ComposeUiConfig,
-    item: PerformerData,
+    item: PerformerData?,
     onClick: (() -> Unit),
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
@@ -45,56 +46,62 @@ fun PerformerCard(
     interactionSource: MutableInteractionSource? = null,
 ) {
     val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-    dataTypeMap[DataType.SCENE] = item.scene_count
-    dataTypeMap[DataType.TAG] = item.tags.size
-    dataTypeMap[DataType.GROUP] = item.group_count
-    dataTypeMap[DataType.IMAGE] = item.image_count
-    dataTypeMap[DataType.GALLERY] = item.gallery_count
+    item?.let {
+        dataTypeMap[DataType.SCENE] = item.scene_count
+        dataTypeMap[DataType.TAG] = item.tags.size
+        dataTypeMap[DataType.GROUP] = item.group_count
+        dataTypeMap[DataType.IMAGE] = item.image_count
+        dataTypeMap[DataType.GALLERY] = item.gallery_count
+    }
 
     val title =
-        buildAnnotatedString {
-            append(item.name)
-            if (item.disambiguation.isNotNullOrBlank()) {
-                withStyle(SpanStyle(fontSize = .75f.em, color = Color.LightGray)) {
-                    append(" (")
-                    append(item.disambiguation)
-                    append(")")
+        item?.let {
+            buildAnnotatedString {
+                append(item.name)
+                if (item.disambiguation.isNotNullOrBlank()) {
+                    withStyle(SpanStyle(fontSize = .75f.em, color = Color.LightGray)) {
+                        append(" (")
+                        append(item.disambiguation)
+                        append(")")
+                    }
                 }
             }
-        }
+        } ?: AnnotatedString("")
 
     val subtitle =
-        if (ageOnDate.isNotNullOrBlank() &&
-            item.birthdate.isNotNullOrBlank() &&
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
-        ) {
-            val ctx = LocalContext.current
-            try {
-                val ageInScene =
-                    Period
-                        .between(
-                            LocalDate.parse(item.birthdate, DateTimeFormatter.ISO_LOCAL_DATE),
-                            LocalDate.parse(ageOnDate, DateTimeFormatter.ISO_LOCAL_DATE),
-                        ).years
-                ctx.getString(
-                    R.string.stashapp_media_info_performer_card_age_context,
-                    ageInScene.toString(),
-                    ctx.getString(R.string.stashapp_years_old),
-                )
-            } catch (ex: Exception) {
-                Log.w(TAG, "Exception calculating age", ex)
+        item?.let {
+            if (ageOnDate.isNotNullOrBlank() &&
+                item.birthdate.isNotNullOrBlank() &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+            ) {
+                val ctx = LocalContext.current
+                try {
+                    val ageInScene =
+                        Period
+                            .between(
+                                LocalDate.parse(item.birthdate, DateTimeFormatter.ISO_LOCAL_DATE),
+                                LocalDate.parse(ageOnDate, DateTimeFormatter.ISO_LOCAL_DATE),
+                            ).years
+                    ctx.getString(
+                        R.string.stashapp_media_info_performer_card_age_context,
+                        ageInScene.toString(),
+                        ctx.getString(R.string.stashapp_years_old),
+                    )
+                } catch (ex: Exception) {
+                    Log.w(TAG, "Exception calculating age", ex)
+                    item.birthdate
+                }
+            } else if (item.birthdate.isNotNullOrBlank() &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+            ) {
+                val yearsOldStr = stringResource(R.string.stashapp_years_old)
+                "${item.ageInYears} $yearsOldStr"
+            } else if (item.birthdate.isNotNullOrBlank()) {
                 item.birthdate
+            } else {
+                ""
             }
-        } else if (item.birthdate.isNotNullOrBlank() &&
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
-        ) {
-            val yearsOldStr = stringResource(R.string.stashapp_years_old)
-            "${item.ageInYears} $yearsOldStr"
-        } else if (item.birthdate.isNotNullOrBlank()) {
-            item.birthdate
-        } else {
-            ""
-        }
+        } ?: ""
 
     RootCard(
         item = item,
@@ -107,24 +114,26 @@ fun PerformerCard(
         uiConfig = uiConfig,
         imageWidth = PerformerPresenter.CARD_WIDTH.dp / 2,
         imageHeight = PerformerPresenter.CARD_HEIGHT.dp / 2,
-        imageUrl = item.image_path,
+        imageUrl = item?.image_path,
         title = title,
         subtitle = { Text(subtitle) },
         description = {
             IconRowText(
                 dataTypeMap,
-                item.o_counter ?: -1,
+                item?.o_counter ?: -1,
                 Modifier
                     .enableMarquee(it)
                     .align(Alignment.Center),
             )
         },
         imageOverlay = {
-            ImageOverlay(
-                uiConfig.ratingAsStars,
-                favorite = item.favorite,
-                rating100 = item.rating100,
-            )
+            item?.let {
+                ImageOverlay(
+                    uiConfig.ratingAsStars,
+                    favorite = item.favorite,
+                    rating100 = item.rating100,
+                )
+            }
         },
     )
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/StudioCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/StudioCard.kt
@@ -20,24 +20,26 @@ import java.util.EnumMap
 @Composable
 fun StudioCard(
     uiConfig: ComposeUiConfig,
-    item: StudioData,
+    item: StudioData?,
     onClick: (() -> Unit),
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
     modifier: Modifier = Modifier,
 ) {
     val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-    dataTypeMap[DataType.SCENE] = item.scene_count
-    dataTypeMap[DataType.PERFORMER] = item.performer_count
-    dataTypeMap[DataType.GROUP] = item.group_count
-    dataTypeMap[DataType.IMAGE] = item.image_count
-    dataTypeMap[DataType.GALLERY] = item.gallery_count
-    dataTypeMap[DataType.TAG] = item.tags.size
+    item?.let {
+        dataTypeMap[DataType.SCENE] = item.scene_count
+        dataTypeMap[DataType.PERFORMER] = item.performer_count
+        dataTypeMap[DataType.GROUP] = item.group_count
+        dataTypeMap[DataType.IMAGE] = item.image_count
+        dataTypeMap[DataType.GALLERY] = item.gallery_count
+        dataTypeMap[DataType.TAG] = item.tags.size
+    }
 
-    val title = item.name
-    val imageUrl = item.image_path
+    val title = item?.name ?: ""
+    val imageUrl = item?.image_path
     val details =
-        if (item.parent_studio != null) {
+        if (item?.parent_studio != null) {
             stringResource(R.string.stashapp_part_of, item.parent_studio.name)
         } else {
             ""
@@ -71,11 +73,13 @@ fun StudioCard(
             )
         },
         imageOverlay = {
-            ImageOverlay(
-                uiConfig.ratingAsStars,
-                favorite = item.favorite,
-                rating100 = item.rating100,
-            )
+            item?.let {
+                ImageOverlay(
+                    uiConfig.ratingAsStars,
+                    favorite = item.favorite,
+                    rating100 = item.rating100,
+                )
+            }
         },
     )
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/TagCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/TagCard.kt
@@ -21,22 +21,24 @@ import java.util.EnumMap
 @Composable
 fun TagCard(
     uiConfig: ComposeUiConfig,
-    item: TagData,
+    item: TagData?,
     onClick: (() -> Unit),
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
     modifier: Modifier = Modifier,
 ) {
     val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
-    dataTypeMap[DataType.SCENE] = item.scene_count
-    dataTypeMap[DataType.PERFORMER] = item.performer_count
-    dataTypeMap[DataType.MARKER] = item.scene_marker_count
-    dataTypeMap[DataType.IMAGE] = item.image_count
-    dataTypeMap[DataType.GALLERY] = item.gallery_count
+    item?.let {
+        dataTypeMap[DataType.SCENE] = item.scene_count
+        dataTypeMap[DataType.PERFORMER] = item.performer_count
+        dataTypeMap[DataType.MARKER] = item.scene_marker_count
+        dataTypeMap[DataType.IMAGE] = item.image_count
+        dataTypeMap[DataType.GALLERY] = item.gallery_count
+    }
 
-    val title = item.name
-    val imageUrl = item.image_path
-    val details = item.description ?: ""
+    val title = item?.name ?: ""
+    val imageUrl = item?.image_path
+    val details = item?.description ?: ""
 
     RootCard(
         item = item,
@@ -70,28 +72,30 @@ fun TagCard(
             )
         },
         imageOverlay = {
-            ImageOverlay(uiConfig.ratingAsStars, favorite = item.favorite) {
-                if (item.child_count > 0) {
-                    val parentText =
-                        stringResource(
-                            R.string.stashapp_parent_of,
-                            item.child_count.toString(),
+            item?.let {
+                ImageOverlay(uiConfig.ratingAsStars, favorite = item.favorite) {
+                    if (item.child_count > 0) {
+                        val parentText =
+                            stringResource(
+                                R.string.stashapp_parent_of,
+                                item.child_count.toString(),
+                            )
+                        Text(
+                            modifier = Modifier.align(Alignment.TopStart),
+                            text = parentText,
                         )
-                    Text(
-                        modifier = Modifier.align(Alignment.TopStart),
-                        text = parentText,
-                    )
-                }
-                if (item.parent_count > 0) {
-                    val childText =
-                        stringResource(
-                            R.string.stashapp_sub_tag_of,
-                            item.parent_count.toString(),
+                    }
+                    if (item.parent_count > 0) {
+                        val childText =
+                            stringResource(
+                                R.string.stashapp_sub_tag_of,
+                                item.parent_count.toString(),
+                            )
+                        Text(
+                            modifier = Modifier.align(Alignment.BottomStart),
+                            text = childText,
                         )
-                    Text(
-                        modifier = Modifier.align(Alignment.BottomStart),
-                        text = childText,
-                    )
+                    }
                 }
             }
         },

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/StashGrid.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/StashGrid.kt
@@ -61,7 +61,6 @@ import com.github.damontecres.stashapp.ui.AppColors
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.FontAwesome
 import com.github.damontecres.stashapp.ui.LocalGlobalContext
-import com.github.damontecres.stashapp.ui.cards.LoadingCard
 import com.github.damontecres.stashapp.ui.cards.StashCard
 import com.github.damontecres.stashapp.ui.components.playback.isBackwardButton
 import com.github.damontecres.stashapp.ui.components.playback.isForwardButton
@@ -541,67 +540,58 @@ fun StashGrid(
                             Modifier
                         }
                     val item = pager[index]
-                    if (item == null) {
-                        // TODO can't focus initially because items will be null
-                        LoadingCard(
-                            dataType = pager.filter.dataType,
-                            uiConfig = uiConfig,
-                            modifier = mod,
-                        )
-                    } else {
-                        if (!hasRequestFocusRun && requestFocus && initialPosition >= 0) {
-                            // On very first composition, if parent wants to focus on the grid, do so
-                            LaunchedEffect(Unit) {
-                                if (DEBUG) {
-                                    Log.d(
-                                        TAG,
-                                        "non-null focus on startPosition=$startPosition, from initialPosition=$initialPosition",
-                                    )
-                                }
-                                // focus on startPosition
-                                gridState.scrollToItem(startPosition, 0)
-                                firstFocus.tryRequestFocus()
-                                hasRequestFocusRun = true
+                    if (!hasRequestFocusRun && requestFocus && initialPosition >= 0) {
+                        // On very first composition, if parent wants to focus on the grid, do so
+                        LaunchedEffect(Unit) {
+                            if (DEBUG) {
+                                Log.d(
+                                    TAG,
+                                    "non-null focus on startPosition=$startPosition, from initialPosition=$initialPosition",
+                                )
                             }
+                            // focus on startPosition
+                            gridState.scrollToItem(startPosition, 0)
+                            firstFocus.tryRequestFocus()
+                            hasRequestFocusRun = true
                         }
-                        StashCard(
-                            modifier =
-                                mod
-                                    .ifElse(index == 0, Modifier.focusRequester(zeroFocus))
-                                    .onFocusChanged { focusState ->
-                                        if (DEBUG) {
-                                            Log.v(
-                                                TAG,
-                                                "$index isFocused=${focusState.isFocused}",
-                                            )
-                                        }
-                                        if (focusState.isFocused) {
-                                            // Focused, so set that up
-                                            focusOn(index)
-                                            positionCallback?.invoke(columns, index)
-                                        } else if (focusedIndex == index) {
-                                            savedFocusedIndex = index
-                                            // Was focused on this, so mark unfocused
-                                            focusedIndex = -1
-                                        }
-                                    },
-                            uiConfig = uiConfig,
-                            item = item,
-                            itemOnClick = {
-                                itemOnClick.onClick(
-                                    it,
-                                    FilterAndPosition(filterArgs, index),
-                                )
-                            },
-                            longClicker = longClicker,
-                            getFilterAndPosition = {
-                                FilterAndPosition(
-                                    filterArgs,
-                                    index,
-                                )
-                            },
-                        )
                     }
+                    StashCard(
+                        modifier =
+                            mod
+                                .ifElse(index == 0, Modifier.focusRequester(zeroFocus))
+                                .onFocusChanged { focusState ->
+                                    if (DEBUG) {
+                                        Log.v(
+                                            TAG,
+                                            "$index isFocused=${focusState.isFocused}",
+                                        )
+                                    }
+                                    if (focusState.isFocused) {
+                                        // Focused, so set that up
+                                        focusOn(index)
+                                        positionCallback?.invoke(columns, index)
+                                    } else if (focusedIndex == index) {
+                                        savedFocusedIndex = index
+                                        // Was focused on this, so mark unfocused
+                                        focusedIndex = -1
+                                    }
+                                },
+                        uiConfig = uiConfig,
+                        item = item,
+                        itemOnClick = {
+                            itemOnClick.onClick(
+                                it,
+                                FilterAndPosition(filterArgs, index),
+                            )
+                        },
+                        longClicker = longClicker,
+                        getFilterAndPosition = {
+                            FilterAndPosition(
+                                filterArgs,
+                                index,
+                            )
+                        },
+                    )
                 }
             }
             if (pager.size == 0) {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/TabPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/TabPage.kt
@@ -197,7 +197,7 @@ fun StashGridTab(
 ) {
     val navigationManager = LocalGlobalContext.current.navigationManager
     LaunchedEffect(server, initialFilter) {
-        viewModel.setFilter(server, initialFilter)
+        viewModel.setFilter(server, initialFilter, composeUiConfig.cardSettings.columns)
     }
     val pager by viewModel.pager.observeAsState()
     pager?.let { newPager ->

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/FilterPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/FilterPage.kt
@@ -44,7 +44,7 @@ fun FilterPage(
     if (viewModel.currentFilter == null) {
         // If the view model is populated, don't do it again
         LaunchedEffect(server, initialFilter) {
-            viewModel.setFilter(server, initialFilter)
+            viewModel.setFilter(server, initialFilter, uiConfig.cardSettings.columns)
         }
     }
     val pager by viewModel.pager.observeAsState()
@@ -101,7 +101,7 @@ fun FilterPage(
                 longClicker = longClicker,
                 initialPosition = initialPosition,
                 updateFilter = {
-                    viewModel.setFilter(server, it)
+                    viewModel.setFilter(server, it, uiConfig.cardSettings.columns)
                 },
                 letterPosition = viewModel::findLetterPosition,
                 requestFocus = true,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
@@ -163,8 +163,8 @@ fun PlaylistPlaybackPage(
 
     LaunchedEffect(server, filterArgs) {
         // TODO switch to single query
-        viewModel.setFilter(server, adjustFilter(filterArgs))
-        playlistViewModel.setFilter(server, filterArgs)
+        viewModel.setFilter(server, adjustFilter(filterArgs), uiConfig.cardSettings.columns)
+        playlistViewModel.setFilter(server, filterArgs, uiConfig.cardSettings.columns)
     }
     val pager by viewModel.pager.observeAsState()
     var playlist by remember(pager) { mutableStateOf<List<MediaItem>>(listOf()) }


### PR DESCRIPTION
Previously if scrolling very fast down the grid, focus might jump over to the nav drawer. This PR fixes this behavior.

This happened because items are lazy loaded from the server and a placeholder card is shown while waiting for the result. This means the user may be focused on a placeholder card when the data is loaded. In that case, the card is replaced with the real card, but focus is not maintained, so the app reverts focus to a default place, ie the nav drawer.

This PR updates the cards to support a null object while waiting a result from the server to replace the item not the card. Thus the same card is used as both a placeholder and real and focus is maintained when the data is loaded.