### PR TITLE
Add ability to create new studios

### DIFF
--- a/app/src/main/graphql/FindStudios.graphql
+++ b/app/src/main/graphql/FindStudios.graphql
@@ -76,3 +76,9 @@ mutation UpdateStudio($input: StudioUpdateInput!){
     ...StudioData
   }
 }
+
+mutation CreateStudio($input: StudioCreateInput!){
+  studioCreate(input: $input){
+    ...StudioData
+  }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/SearchForFragment.kt
@@ -25,6 +25,7 @@ import com.github.damontecres.stashapp.actions.StashAction
 import com.github.damontecres.stashapp.api.fragment.GroupData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.StashData
+import com.github.damontecres.stashapp.api.fragment.StudioData
 import com.github.damontecres.stashapp.api.fragment.TagData
 import com.github.damontecres.stashapp.api.type.CriterionModifier
 import com.github.damontecres.stashapp.api.type.FindFilterType
@@ -144,6 +145,10 @@ class SearchForFragment :
 
                     DataType.GROUP -> {
                         mutationEngine.createGroup(GroupCreateInput(name = name))
+                    }
+
+                    DataType.STUDIO -> {
+                        mutationEngine.createStudio(name = name)
                     }
 
                     else -> throw IllegalArgumentException("Unsupported datatype $dataType")
@@ -466,9 +471,13 @@ class SearchForFragment :
                     items.none { it.name.lowercase() == q || it.aliases.any { it.lowercase() == q } }
                 }
 
+                DataType.STUDIO -> {
+                    items as List<StudioData>
+                    items.none { it.name.lowercase() == q || it.aliases.any { it.lowercase() == q } }
+                }
+
                 DataType.SCENE -> false
                 DataType.MARKER -> false
-                DataType.STUDIO -> false
                 DataType.IMAGE -> false
                 DataType.GALLERY -> false
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/SearchForPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/SearchForPage.kt
@@ -369,7 +369,14 @@ fun SearchForPage(
                             style = MaterialTheme.typography.titleLarge,
                             color = MaterialTheme.colorScheme.onSurface,
                         )
-                        if (allowCreate && uiConfig.readOnlyModeDisabled) {
+                        if (allowCreate &&
+                            uiConfig.readOnlyModeDisabled &&
+                            SearchForFragment.allowCreate(
+                                dataType,
+                                searchQuery,
+                                listOf(),
+                            )
+                        ) {
                             StashCard(
                                 uiConfig = uiConfig,
                                 item = CreateNew(dataType, searchQuery),
@@ -450,6 +457,10 @@ suspend fun handleCreate(
 
                 DataType.GROUP -> {
                     mutationEngine.createGroup(GroupCreateInput(name = name))
+                }
+
+                DataType.STUDIO -> {
+                    mutationEngine.createStudio(name = name)
                 }
 
                 else -> throw IllegalArgumentException("Unsupported datatype $dataType")

--- a/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/MutationEngine.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo.api.Optional
 import com.github.damontecres.stashapp.api.CreateGroupMutation
 import com.github.damontecres.stashapp.api.CreateMarkerMutation
 import com.github.damontecres.stashapp.api.CreatePerformerMutation
+import com.github.damontecres.stashapp.api.CreateStudioMutation
 import com.github.damontecres.stashapp.api.CreateTagMutation
 import com.github.damontecres.stashapp.api.DeleteMarkerMutation
 import com.github.damontecres.stashapp.api.ImageDecrementOMutation
@@ -51,6 +52,7 @@ import com.github.damontecres.stashapp.api.type.SceneGroupInput
 import com.github.damontecres.stashapp.api.type.SceneMarkerCreateInput
 import com.github.damontecres.stashapp.api.type.SceneMarkerUpdateInput
 import com.github.damontecres.stashapp.api.type.SceneUpdateInput
+import com.github.damontecres.stashapp.api.type.StudioCreateInput
 import com.github.damontecres.stashapp.api.type.StudioUpdateInput
 import com.github.damontecres.stashapp.api.type.TagCreateInput
 import com.github.damontecres.stashapp.api.type.TagUpdateInput
@@ -489,6 +491,12 @@ class MutationEngine(
             )
         val mutation = UpdateStudioMutation(input)
         return executeMutation(mutation).data?.studioUpdate?.studioData
+    }
+
+    suspend fun createStudio(name: String): StudioData? {
+        val input = StudioCreateInput(name = name)
+        val mutation = CreateStudioMutation(input)
+        return executeMutation(mutation).data?.studioCreate?.studioData
     }
 
     suspend fun updateGroup(


### PR DESCRIPTION
When setting the studio for a scene, adds ability to quickly create a studio named as the search query.

Also, in the new UI, the option to create a studio was shown, but would crash the app. So additionally this PR makes it so, when searching, data types that don't support creation are not shown with the option to create (markers, scenes, performers, & galleries).

This works in the new UI and legacy UI.