### PR TITLE
Make scene & image buttons more consistent

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/OCounterButton.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/OCounterButton.kt
@@ -1,0 +1,40 @@
+package com.github.damontecres.stashapp.ui.components
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.Icon
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.github.damontecres.stashapp.R
+
+@Composable
+fun OCounterButton(
+    oCount: Int,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    Button(
+        onClick = onClick,
+        onLongClick = onLongClick,
+        enabled = enabled,
+        modifier = modifier,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.sweat_drops),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(Modifier.size(8.dp))
+        Text(
+            text = oCount.toString(),
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageControlsOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageControlsOverlay.kt
@@ -1,13 +1,11 @@
 package com.github.damontecres.stashapp.ui.components.image
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.OptIn
 import androidx.annotation.StringRes
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.relocation.BringIntoViewRequester
@@ -25,34 +23,36 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.FontAwesome
+import com.github.damontecres.stashapp.ui.components.OCounterButton
 import com.github.damontecres.stashapp.ui.tryRequestFocus
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import kotlinx.coroutines.launch
 
-@androidx.annotation.OptIn(UnstableApi::class)
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(UnstableApi::class)
 @Composable
 fun ImageControlsOverlay(
-    player: Player,
     isImageClip: Boolean,
     oCount: Int,
     onZoom: (Float) -> Unit,
     onRotate: (Int) -> Unit,
     onReset: () -> Unit,
     moreOnClick: () -> Unit,
+    oCounterEnabled: Boolean,
     oCounterOnClick: () -> Unit,
     oCounterOnLongClick: () -> Unit,
+    isPlaying: Boolean,
+    playPauseOnClick: () -> Unit,
     bringIntoViewRequester: BringIntoViewRequester?,
     modifier: Modifier = Modifier,
 ) {
@@ -67,19 +67,18 @@ fun ImageControlsOverlay(
             scope.launch(StashCoroutineExceptionHandler()) { bringIntoViewRequester.bringIntoView() }
         }
     }
-    val playPauseState = rememberPlayPauseButtonState(player)
+
     LazyRow(
         modifier =
             modifier
-                .focusGroup()
-                .padding(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(20.dp),
+                .focusGroup(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (isImageClip) {
             item {
                 Button(
-                    onClick = playPauseState::onClick,
+                    onClick = playPauseOnClick,
                     modifier =
                         Modifier
                             .focusRequester(focusRequester)
@@ -89,7 +88,7 @@ fun ImageControlsOverlay(
                     Icon(
                         painter =
                             painterResource(
-                                if (playPauseState.showPlay) R.drawable.baseline_play_arrow_24 else R.drawable.baseline_pause_24,
+                                if (isPlaying) R.drawable.baseline_play_arrow_24 else R.drawable.baseline_pause_24,
                             ),
                         contentDescription = null,
                     )
@@ -148,25 +147,13 @@ fun ImageControlsOverlay(
         }
         // O-Counter
         item {
-            Button(
+            OCounterButton(
+                oCount = oCount,
                 onClick = oCounterOnClick,
                 onLongClick = oCounterOnLongClick,
-                modifier =
-                    Modifier
-                        .onFocusChanged(onFocused),
-                contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.sweat_drops),
-                    contentDescription = null,
-                    modifier = Modifier.size(ButtonDefaults.IconSize),
-                )
-                Spacer(Modifier.size(8.dp))
-                Text(
-                    text = oCount.toString(),
-                    style = MaterialTheme.typography.titleSmall,
-                )
-            }
+                modifier = Modifier.onFocusChanged(onFocused),
+                enabled = oCounterEnabled,
+            )
         }
         // More button
         item {
@@ -181,6 +168,7 @@ fun ImageControlsOverlay(
                 Icon(
                     imageVector = Icons.Default.MoreVert,
                     contentDescription = null,
+                    modifier = Modifier.size(24.dp),
                 )
                 Spacer(Modifier.size(8.dp))
                 Text(
@@ -201,7 +189,6 @@ fun ImageControlButton(
 ) {
     Button(
         onClick = onClick,
-        contentPadding = PaddingValues(8.dp),
         modifier = modifier,
     ) {
         if (stringRes != 0) {
@@ -217,5 +204,27 @@ fun ImageControlButton(
                 modifier = Modifier.size(24.dp),
             )
         }
+    }
+}
+
+@Preview(widthDp = 800)
+@Composable
+private fun ImageControlsOverlayPreview() {
+    AppTheme {
+        ImageControlsOverlay(
+            isImageClip = false,
+            oCount = 10,
+            onZoom = {},
+            onRotate = {},
+            onReset = {},
+            moreOnClick = {},
+            oCounterEnabled = true,
+            oCounterOnClick = {},
+            oCounterOnLongClick = {},
+            isPlaying = false,
+            playPauseOnClick = {},
+            bringIntoViewRequester = null,
+            modifier = Modifier,
+        )
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageDetailsHeader.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageDetailsHeader.kt
@@ -1,6 +1,5 @@
 package com.github.damontecres.stashapp.ui.components.image
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -34,6 +33,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.apollographql.apollo.api.Optional
@@ -61,7 +62,7 @@ import com.github.damontecres.stashapp.util.titleOrFilename
 import com.github.damontecres.stashapp.views.durationToString
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class)
+@androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun ImageDetailsHeader(
     player: Player,
@@ -271,8 +272,8 @@ fun ImageDetailsHeader(
                 }
             }
         }
+        val playPauseState = rememberPlayPauseButtonState(player)
         ImageControlsOverlay(
-            player = player,
             isImageClip = image.isImageClip,
             oCount = oCount,
             bringIntoViewRequester = bringIntoViewRequester,
@@ -280,8 +281,11 @@ fun ImageDetailsHeader(
             onRotate = onRotate,
             onReset = onReset,
             moreOnClick = moreOnClick,
+            oCounterEnabled = uiConfig.readOnlyModeDisabled,
             oCounterOnClick = oCounterOnClick,
             oCounterOnLongClick = oCounterOnLongClick,
+            playPauseOnClick = playPauseState::onClick,
+            isPlaying = playPauseState.showPlay,
             modifier =
                 Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsHeader.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsHeader.kt
@@ -62,6 +62,7 @@ import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.util.joinNotNullOrBlank
 import com.github.damontecres.stashapp.util.listOfNotNullOrBlank
 import com.github.damontecres.stashapp.util.resolutionName
+import com.github.damontecres.stashapp.util.resume_position
 import com.github.damontecres.stashapp.util.titleOrFilename
 import com.github.damontecres.stashapp.views.durationToString
 import com.github.damontecres.stashapp.views.formatBytes
@@ -160,7 +161,7 @@ fun SceneDetailsHeader(
             )
             // Playback controls
             PlayButtons(
-                scene = scene,
+                resumePosition = scene.resume_position ?: 0,
                 oCount = oCount,
                 playOnClick = playOnClick,
                 editOnClick = editOnClick,
@@ -175,6 +176,7 @@ fun SceneDetailsHeader(
                 },
                 alwaysStartFromBeginning = alwaysStartFromBeginning,
                 showEditButton = showEditButton,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 24.dp),
             )
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/ScenePlayButton.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/ScenePlayButton.kt
@@ -2,8 +2,8 @@ package com.github.damontecres.stashapp.ui.components.scene
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material.icons.Icons
@@ -21,8 +21,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
@@ -30,14 +30,14 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
-import com.github.damontecres.stashapp.api.fragment.FullSceneData
 import com.github.damontecres.stashapp.playback.PlaybackMode
-import com.github.damontecres.stashapp.util.resume_position
+import com.github.damontecres.stashapp.ui.AppTheme
+import com.github.damontecres.stashapp.ui.components.OCounterButton
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PlayButtons(
-    scene: FullSceneData,
+    resumePosition: Long,
     oCount: Int,
     playOnClick: (position: Long, mode: PlaybackMode) -> Unit,
     editOnClick: () -> Unit,
@@ -51,25 +51,23 @@ fun PlayButtons(
     modifier: Modifier = Modifier,
 ) {
     val firstFocus = remember { FocusRequester() }
-    val resume = scene.resume_position ?: 0
     LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
         modifier =
             modifier
-                .padding(top = 24.dp, bottom = 24.dp)
                 .focusGroup()
-                .focusRestorer { firstFocus },
+                .focusRestorer(firstFocus),
     ) {
-        if (resume > 0 && !alwaysStartFromBeginning) {
+        if (resumePosition > 0 && !alwaysStartFromBeginning) {
             item {
 //                LaunchedEffect(Unit) { firstFocus.tryRequestFocus() }
                 PlayButton(
                     R.string.resume,
-                    resume,
+                    resumePosition,
                     Icons.Default.PlayArrow,
                     PlaybackMode.Choose,
                     playOnClick,
                     Modifier
-                        .padding(start = 8.dp, end = 8.dp)
                         .onFocusChanged(buttonOnFocusChanged)
                         .focusRequester(firstFocus)
                         .focusRequester(focusRequester),
@@ -83,7 +81,6 @@ fun PlayButtons(
                     PlaybackMode.Choose,
                     playOnClick,
                     Modifier
-                        .padding(start = 8.dp, end = 8.dp)
                         .onFocusChanged(buttonOnFocusChanged),
                 )
             }
@@ -97,7 +94,6 @@ fun PlayButtons(
                     PlaybackMode.Choose,
                     playOnClick,
                     Modifier
-                        .padding(start = 8.dp, end = 8.dp)
                         .onFocusChanged(buttonOnFocusChanged)
                         .focusRequester(firstFocus)
                         .focusRequester(focusRequester),
@@ -106,27 +102,15 @@ fun PlayButtons(
         }
         // O-Counter
         item {
-            Button(
+            OCounterButton(
+                oCount = oCount,
                 onClick = oCounterOnClick,
                 onLongClick = oCounterOnLongClick,
-                enabled = showEditButton,
                 modifier =
                     Modifier
-                        .padding(start = 8.dp, end = 8.dp)
                         .onFocusChanged(buttonOnFocusChanged),
-                contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.sweat_drops),
-                    contentDescription = null,
-                    modifier = Modifier.size(ButtonDefaults.IconSize),
-                )
-                Spacer(Modifier.size(8.dp))
-                Text(
-                    text = oCount.toString(),
-                    style = MaterialTheme.typography.titleSmall,
-                )
-            }
+                enabled = showEditButton,
+            )
         }
         // Edit button
         if (showEditButton) {
@@ -136,7 +120,6 @@ fun PlayButtons(
                     onLongClick = {},
                     modifier =
                         Modifier
-                            .padding(start = 8.dp, end = 8.dp)
                             .onFocusChanged(buttonOnFocusChanged),
                     contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
                 ) {
@@ -160,7 +143,6 @@ fun PlayButtons(
                 onLongClick = {},
                 modifier =
                     Modifier
-                        .padding(start = 8.dp, end = 8.dp)
                         .onFocusChanged(buttonOnFocusChanged),
                 contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
             ) {
@@ -200,6 +182,27 @@ fun PlayButton(
         Text(
             text = stringResource(title),
             style = MaterialTheme.typography.titleSmall,
+        )
+    }
+}
+
+@Preview(widthDp = 800)
+@Composable
+private fun PlayButtonsPreview() {
+    AppTheme {
+        PlayButtons(
+            resumePosition = 1000L,
+            oCount = 10,
+            playOnClick = { _, _ -> },
+            editOnClick = {},
+            moreOnClick = { },
+            oCounterOnClick = { },
+            oCounterOnLongClick = {},
+            buttonOnFocusChanged = {},
+            focusRequester = FocusRequester(),
+            alwaysStartFromBeginning = false,
+            showEditButton = true,
+            modifier = Modifier,
         )
     }
 }


### PR DESCRIPTION
Updates the buttons on the scene details and image details overlay to be consistently sized and spaced especially the o-counter button.