### PR TITLE
Enables navigation on scene details playback overlay

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/NavDrawerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/NavDrawerFragment.kt
@@ -410,6 +410,8 @@ fun FragmentContent(
                         startPosition = destination.position,
                         playbackMode = destination.mode,
                         uiConfig = composeUiConfig,
+                        itemOnClick = itemOnClick,
+                        modifier = Modifier,
                     )
                 }
 
@@ -420,6 +422,7 @@ fun FragmentContent(
                         filterArgs = destination.filterArgs,
                         startIndex = destination.position,
                         clipDuration = destination.duration?.milliseconds ?: 30.seconds,
+                        itemOnClick = itemOnClick,
                         modifier = Modifier,
                     )
                 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
@@ -104,6 +104,7 @@ import com.github.damontecres.stashapp.playback.switchToTranscode
 import com.github.damontecres.stashapp.ui.AppColors
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.LocalGlobalContext
+import com.github.damontecres.stashapp.ui.components.ItemOnClicker
 import com.github.damontecres.stashapp.ui.components.image.ImageFilterDialog
 import com.github.damontecres.stashapp.ui.indexOfFirstOrNull
 import com.github.damontecres.stashapp.ui.pages.SearchForDialog
@@ -310,6 +311,7 @@ fun PlaybackPageContent(
     markersEnabled: Boolean,
     playlistPager: ComposePager<StashData>?,
     onClickPlaylistItem: ((Int) -> Unit)?,
+    itemOnClick: ItemOnClicker<Any>,
     modifier: Modifier = Modifier,
     controlsEnabled: Boolean = true,
     viewModel: PlaybackViewModel = viewModel(),
@@ -832,6 +834,7 @@ fun PlaybackPageContent(
                         scene = it,
                         performers = performers,
                         uiConfig = uiConfig,
+                        itemOnClick = itemOnClick,
                     )
                 }
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/SceneDetailsOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/SceneDetailsOverlay.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.unit.dp
 import com.github.damontecres.stashapp.api.fragment.FullSceneData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
+import com.github.damontecres.stashapp.ui.LocalGlobalContext
+import com.github.damontecres.stashapp.ui.components.ItemOnClicker
 import com.github.damontecres.stashapp.ui.components.scene.SceneDetailsFooter
 import com.github.damontecres.stashapp.ui.components.scene.SceneDetailsHeaderInfo
 import com.github.damontecres.stashapp.ui.components.scene.sceneDetailsBody
@@ -24,11 +26,18 @@ fun SceneDetailsOverlay(
     scene: FullSceneData,
     performers: List<PerformerData>,
     uiConfig: ComposeUiConfig,
+    itemOnClick: ItemOnClicker<Any>,
     modifier: Modifier = Modifier,
 ) {
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
     val focusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
+    val navigationManager = LocalGlobalContext.current.navigationManager
+    val itemClick =
+        ItemOnClicker<Any> { item, fp ->
+            navigationManager.goBack()
+            itemOnClick.onClick(item, fp)
+        }
     LazyColumn(
         state = listState,
         contentPadding = PaddingValues(top = 16.dp, start = 16.dp, end = 16.dp, bottom = 135.dp),
@@ -41,7 +50,7 @@ fun SceneDetailsOverlay(
                 rating100 = scene.rating100 ?: 0,
                 oCount = scene.o_counter ?: 0,
                 uiConfig = uiConfig.copy(readOnlyModeEnabled = true),
-                itemOnClick = { _, _ -> },
+                itemOnClick = itemClick,
                 playOnClick = { _, _ -> },
                 editOnClick = {},
                 moreOnClick = {},
@@ -66,7 +75,7 @@ fun SceneDetailsOverlay(
             markers = listOf(),
             suggestions = listOf(),
             uiConfig = uiConfig,
-            itemOnClick = { _, _ -> },
+            itemOnClick = itemClick,
             removeLongClicker = { _, _ -> },
             defaultLongClicker = { _, _ -> },
             cardOnFocus = { _, _, _ -> },

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
@@ -40,6 +40,7 @@ import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.FilterViewModel
 import com.github.damontecres.stashapp.ui.components.CircularProgress
+import com.github.damontecres.stashapp.ui.components.ItemOnClicker
 import com.github.damontecres.stashapp.ui.components.playback.PlaybackPageContent
 import com.github.damontecres.stashapp.util.AlphabetSearchUtils
 import com.github.damontecres.stashapp.util.LoggingCoroutineExceptionHandler
@@ -58,6 +59,7 @@ fun PlaybackPage(
     sceneId: String,
     startPosition: Long,
     playbackMode: PlaybackMode,
+    itemOnClick: ItemOnClicker<Any>,
     modifier: Modifier = Modifier,
 ) {
     var scene by remember { mutableStateOf<FullSceneData?>(null) }
@@ -113,6 +115,7 @@ fun PlaybackPage(
             controlsEnabled = true,
             startPosition = startPosition,
             onClickPlaylistItem = null,
+            itemOnClick = itemOnClick,
         )
     }
 }
@@ -158,6 +161,7 @@ fun PlaylistPlaybackPage(
     uiConfig: ComposeUiConfig,
     filterArgs: FilterArgs,
     startIndex: Int,
+    itemOnClick: ItemOnClicker<Any>,
     modifier: Modifier = Modifier,
     clipDuration: Duration = 30.seconds,
     viewModel: FilterViewModel = viewModel(key = "main"),
@@ -240,6 +244,7 @@ fun PlaylistPlaybackPage(
             uiConfig = uiConfig,
             markersEnabled = filterArgs.dataType == DataType.SCENE,
             playlistPager = playlistPager,
+            itemOnClick = itemOnClick,
             onClickPlaylistItem = { index ->
                 if (index < player.mediaItemCount) {
                     player.seekTo(index, C.TIME_UNSET)


### PR DESCRIPTION
Closes #651

Enables navigation on the scene details overlay during playback. It is implemented by ending playback then navigating to the new page.