### PR TITLE
Show captions by default

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/StreamUtils.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/StreamUtils.kt
@@ -136,6 +136,7 @@ fun buildMediaItem(
                     .setMimeType(MimeTypes.TEXT_VTT)
                     .setLabel(it.displayString(context))
                     .setSelectionFlags(C.SELECTION_FLAG_AUTOSELECT)
+                    .setLanguage(it.language_code)
                     .build()
             }
         Log.v(TAG, "Got ${subtitles.size} subtitle options for scene ${scene.id}")

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -37,6 +37,7 @@
     </string-array>
     <string name="pref_key_playback_start_muted" translatable="false">playback.startMuted</string>
     <string name="pref_key_playback_always_transcode" translatable="false">playback.alwaysTranscode</string>
+    <string name="pref_key_captions_on_by_default" translatable="false">playback.captionsOnByDefault</string>
 
     <string name="pref_key_ui_performer_tabs" translatable="false">ui.tabs.performer</string>
     <string name="pref_key_ui_gallery_tabs" translatable="false">ui.tabs.gallery</string>

--- a/app/src/main/res/xml/ui_preferences.xml
+++ b/app/src/main/res/xml/ui_preferences.xml
@@ -120,5 +120,10 @@
             app:summaryOn="Enabled for markers"
             app:summaryOff="Disabled"
             app:defaultValue="false" />
+        <SwitchPreference
+            app:key="@string/pref_key_captions_on_by_default"
+            app:title="Turn captions on by default"
+            app:summary="Whether to turn captions for the device's language on by default"
+            app:defaultValue="true" />
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Turn on the first caption track in the device's language by default during playback.

This can be disabled in Settings->More UI Settings