### PR TITLE
Fix how scenes & sub-groups are sorted by default for groups

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/GroupPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/GroupPage.kt
@@ -39,7 +39,11 @@ import com.github.damontecres.stashapp.api.type.GroupFilterType
 import com.github.damontecres.stashapp.api.type.HierarchicalMultiCriterionInput
 import com.github.damontecres.stashapp.api.type.SceneFilterType
 import com.github.damontecres.stashapp.api.type.SceneMarkerFilterType
+import com.github.damontecres.stashapp.api.type.SortDirectionEnum
 import com.github.damontecres.stashapp.data.DataType
+import com.github.damontecres.stashapp.data.SortAndDirection
+import com.github.damontecres.stashapp.data.SortOption
+import com.github.damontecres.stashapp.data.StashFindFilter
 import com.github.damontecres.stashapp.navigation.Destination
 import com.github.damontecres.stashapp.suppliers.DataSupplierOverride
 import com.github.damontecres.stashapp.suppliers.FilterArgs
@@ -151,7 +155,14 @@ fun GroupPage(
             mutableStateOf(
                 FilterArgs(
                     DataType.SCENE,
-                    findFilter = tabFindFilter(server, PageFilterKey.GROUP_SCENES),
+                    findFilter =
+                        tabFindFilter(server, PageFilterKey.GROUP_SCENES)
+                            ?: StashFindFilter(
+                                SortAndDirection(
+                                    SortOption.GroupSceneNumber,
+                                    SortDirectionEnum.ASC,
+                                ),
+                            ),
                     objectFilter = SceneFilterType(groups = groupsFunc(scenesSubTags)),
                 ),
             )


### PR DESCRIPTION
Fixes a copy-paste error where scenes in a group used the wrong default sort.

Also applies the default sort for sub-groups in a group.