### PR TITLE
Fix pressing d-pad center to show image details while zoomed in

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/KeyIdentifier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/KeyIdentifier.kt
@@ -4,9 +4,8 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.key
 
-fun isDpad(event: KeyEvent): Boolean =
-    event.key == Key.DirectionCenter ||
-        event.key == Key.DirectionUp ||
+fun isDirectionalDpad(event: KeyEvent): Boolean =
+    event.key == Key.DirectionUp ||
         event.key == Key.DirectionDown ||
         event.key == Key.DirectionLeft ||
         event.key == Key.DirectionRight ||
@@ -14,6 +13,8 @@ fun isDpad(event: KeyEvent): Boolean =
         event.key == Key.DirectionUpLeft ||
         event.key == Key.DirectionDownRight ||
         event.key == Key.DirectionDownLeft
+
+fun isDpad(event: KeyEvent): Boolean = event.key == Key.DirectionCenter || isDirectionalDpad(event)
 
 fun isMedia(event: KeyEvent): Boolean =
     event.key == Key.MediaPlay ||

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/ImagePage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/ImagePage.kt
@@ -70,7 +70,7 @@ import com.github.damontecres.stashapp.ui.components.image.ImageDetailsViewModel
 import com.github.damontecres.stashapp.ui.components.image.ImageFilterDialog
 import com.github.damontecres.stashapp.ui.components.image.ImageOverlay
 import com.github.damontecres.stashapp.ui.components.image.SlideshowControls
-import com.github.damontecres.stashapp.ui.components.playback.isDpad
+import com.github.damontecres.stashapp.ui.components.playback.isDirectionalDpad
 import com.github.damontecres.stashapp.ui.tryRequestFocus
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.isImageClip
@@ -227,7 +227,7 @@ fun ImagePage(
                     var result = false
                     if (it.type != KeyEventType.KeyUp) {
                         result = false
-                    } else if (!isOverlayShowing && zoomFactor * 100 > 105 && isDpad(it)) {
+                    } else if (!isOverlayShowing && zoomFactor * 100 > 105 && isDirectionalDpad(it)) {
                         // Image is zoomed in
                         when (it.key) {
                             Key.DirectionLeft -> panX += with(density) { 30.dp.toPx() }


### PR DESCRIPTION
Fixes #669 

Pressing D-Pad will now correctly bring up the image details overlay when zoomed in on the image.