### PR TITLE
Display marker info during playlist playback

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/data/PlaylistItem.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/PlaylistItem.kt
@@ -4,8 +4,8 @@ import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.util.joinNotNullOrBlank
 import com.github.damontecres.stashapp.util.titleOrFilename
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
+import com.github.damontecres.stashapp.views.formatDate
+import com.github.damontecres.stashapp.views.formatSeconds
 
 /**
  * Represents an item in a playlist/queue
@@ -26,15 +26,15 @@ fun MarkerData.toPlayListItem(index: Int): PlaylistItem {
         }
     val details =
         buildList {
-            add(primary_tag.slimTagData.name)
+            if (title.isNotBlank()) add(primary_tag.slimTagData.name)
             addAll(tags.map { it.slimTagData.name })
         }.joinNotNullOrBlank(", ")
     return PlaylistItem(
         index,
-        title = "$name - ${seconds.toInt().toDuration(DurationUnit.SECONDS)}",
+        title = name,
         subtitle = scene.minimalSceneData.titleOrFilename,
-        details1 = details,
-        details2 = scene.minimalSceneData.date,
+        details1 = formatSeconds,
+        details2 = details,
         imageUrl = screenshot,
     )
 }
@@ -45,6 +45,6 @@ fun SlimSceneData.toPlayListItem(index: Int): PlaylistItem =
         title = titleOrFilename,
         subtitle = studio?.name,
         details1 = performers.map { it.name }.joinNotNullOrBlank(", "),
-        details2 = date,
+        details2 = formatDate(date),
         imageUrl = paths.screenshot,
     )

--- a/app/src/main/java/com/github/damontecres/stashapp/data/Scene.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/Scene.kt
@@ -1,15 +1,18 @@
 package com.github.damontecres.stashapp.data
 
 import com.github.damontecres.stashapp.api.fragment.Caption
+import com.github.damontecres.stashapp.api.fragment.FullMarkerData
 import com.github.damontecres.stashapp.api.fragment.FullSceneData
 import com.github.damontecres.stashapp.api.fragment.VideoSceneData
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.util.titleOrFilename
+import com.github.damontecres.stashapp.views.formatDate
+import com.github.damontecres.stashapp.views.formatSeconds
 
 data class Scene(
     val id: String,
     val title: String?,
-    val date: String?,
+    val subtitle: String?,
     val streamUrl: String?,
     val screenshotUrl: String?,
     val streams: Map<String, String>,
@@ -41,7 +44,7 @@ data class Scene(
             return Scene(
                 id = data.id,
                 title = data.titleOrFilename,
-                date = data.date,
+                subtitle = formatDate(data.date),
                 streamUrl = data.paths.stream,
                 screenshotUrl = data.paths.screenshot,
                 streams = streams,
@@ -70,7 +73,7 @@ data class Scene(
             return Scene(
                 id = data.id,
                 title = data.titleOrFilename,
-                date = data.date,
+                subtitle = formatDate(data.date),
                 streamUrl = data.paths.stream,
                 screenshotUrl = data.paths.screenshot,
                 streams = streams,
@@ -85,6 +88,43 @@ data class Scene(
                 oCounter = data.o_counter,
                 captionUrl = data.paths.caption,
                 captions = data.captions?.map { it.caption }.orEmpty(),
+            )
+        }
+
+        fun fromMarkerData(marker: FullMarkerData): Scene {
+            val video = marker.scene.videoSceneData
+            val streams =
+                video.sceneStreams
+                    .filter { it.label != null }
+                    .associate {
+                        Pair(it.label.toString(), it.url)
+                    }
+            val fileData = video.files.firstOrNull()?.videoFile
+            val title = marker.title.ifBlank { marker.primary_tag.tagData.name }
+            val subtitle =
+                if (marker.title.isNotBlank()) {
+                    marker.primary_tag.tagData.name + " - " + video.titleOrFilename
+                } else {
+                    video.titleOrFilename
+                } + " (${marker.formatSeconds})"
+            return Scene(
+                id = video.id,
+                title = title,
+                subtitle = subtitle,
+                streamUrl = video.paths.stream,
+                screenshotUrl = video.paths.screenshot,
+                streams = streams,
+                spriteUrl = video.paths.sprite,
+                duration = fileData?.duration,
+                resumeTime = video.resume_time,
+                videoCodec = fileData?.video_codec,
+                videoWidth = fileData?.width,
+                videoHeight = fileData?.height,
+                audioCodec = fileData?.audio_codec,
+                format = fileData?.format,
+                oCounter = video.o_counter,
+                captionUrl = video.paths.caption,
+                captions = video.captions?.map { it.caption }.orEmpty(),
             )
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
@@ -57,7 +57,6 @@ import com.github.damontecres.stashapp.util.toSeconds
 import com.github.damontecres.stashapp.views.ListPopupWindowBuilder
 import com.github.damontecres.stashapp.views.SkipIndicator
 import com.github.damontecres.stashapp.views.durationToString
-import com.github.damontecres.stashapp.views.formatDate
 import com.github.damontecres.stashapp.views.models.PlaybackViewModel
 import com.github.damontecres.stashapp.views.models.ServerViewModel
 import com.github.rubensousa.previewseekbar.PreviewBar
@@ -260,7 +259,7 @@ abstract class PlaybackFragment(
                 .getBoolean("exoShowTitle", true)
         if (showTitle) {
             titleText.text = scene.title
-            dateText.text = formatDate(scene.date)
+            dateText.text = scene.subtitle
             if (dateText.text.isNullOrBlank()) {
                 dateText.visibility = View.GONE
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
@@ -73,7 +73,6 @@ import com.github.damontecres.stashapp.ui.util.CoilPreviewTransformation
 import com.github.damontecres.stashapp.util.defaultCardHeight
 import com.github.damontecres.stashapp.util.defaultCardWidth
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
-import com.github.damontecres.stashapp.views.formatDate
 import com.github.damontecres.stashapp.views.models.CardUiSettings
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
@@ -180,7 +179,7 @@ fun PlaybackOverlay(
         val listState = rememberLazyListState()
         var height = 208.dp
         if (!uiConfig.showTitleDuringPlayback || scene.title.isNullOrBlank()) height -= 24.dp
-        if (!uiConfig.showTitleDuringPlayback || scene.date.isNullOrBlank()) height -= 24.dp
+        if (!uiConfig.showTitleDuringPlayback || scene.subtitle.isNullOrBlank()) height -= 24.dp
         if (markers.isEmpty()) height -= 24.dp
         LazyColumn(
             state = listState,
@@ -213,9 +212,9 @@ fun PlaybackOverlay(
                                 overflow = TextOverflow.Ellipsis,
                             )
                         }
-                        if (scene.date.isNotNullOrBlank()) {
+                        if (scene.subtitle.isNotNullOrBlank()) {
                             Text(
-                                text = formatDate(scene.date)!!,
+                                text = scene.subtitle,
                                 color = MaterialTheme.colorScheme.onBackground,
                                 style =
                                     MaterialTheme.typography.titleMedium.copy(
@@ -544,7 +543,7 @@ private fun PlaybackOverlayPreview() {
                 Scene(
                     id = "id",
                     title = "The scene title",
-                    date = "2025-01-01",
+                    subtitle = "2025-01-01",
                     streamUrl = "",
                     screenshotUrl = "",
                     streams = mapOf(),

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistList.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistList.kt
@@ -155,6 +155,7 @@ fun PlaylistItemCompose(
                         style = MaterialTheme.typography.bodyMedium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.enableMarquee(focused),
                     )
                 }
                 if (item.details1.isNotNullOrBlank()) {
@@ -164,6 +165,7 @@ fun PlaylistItemCompose(
                         style = MaterialTheme.typography.bodySmall,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.enableMarquee(focused),
                     )
                 }
                 if (item.details2.isNotNullOrBlank()) {
@@ -173,6 +175,7 @@ fun PlaylistItemCompose(
                         style = MaterialTheme.typography.bodySmall,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.enableMarquee(focused),
                     )
                 }
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
@@ -297,7 +297,7 @@ private fun convertToMediaItem(
     } else {
         // Markers
         item as FullMarkerData
-        val scene = Scene.fromVideoSceneData(item.scene.videoSceneData)
+        val scene = Scene.fromMarkerData(item)
         val decision = getStreamDecision(context, scene, PlaybackMode.Choose)
         val mediaItem =
             buildMediaItem(context, decision, scene) {

--- a/app/src/main/java/com/github/damontecres/stashapp/views/Formatting.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/views/Formatting.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.os.Build
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.StashApplication
+import com.github.damontecres.stashapp.api.fragment.FullMarkerData
+import com.github.damontecres.stashapp.api.fragment.MarkerData
 import com.github.damontecres.stashapp.api.type.CircumisedEnum
 import com.github.damontecres.stashapp.api.type.CriterionModifier
 import com.github.damontecres.stashapp.util.StashServer
@@ -12,6 +14,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.util.Locale
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -179,3 +182,21 @@ fun circNameId(circ: CircumisedEnum): Int =
         CircumisedEnum.UNCUT -> R.string.stashapp_circumcised_types_UNCUT
         CircumisedEnum.UNKNOWN__ -> R.string.stashapp_display_mode_unknown
     }
+
+val FullMarkerData.formatSeconds: String
+    get() =
+        if (end_seconds != null) {
+            seconds.toInt().seconds.toString() + " - " +
+                end_seconds.toInt().seconds.toString()
+        } else {
+            seconds.toInt().seconds.toString()
+        }
+
+val MarkerData.formatSeconds: String
+    get() =
+        if (end_seconds != null) {
+            seconds.toInt().seconds.toString() + " - " +
+                end_seconds.toInt().seconds.toString()
+        } else {
+            seconds.toInt().seconds.toString()
+        }


### PR DESCRIPTION
Closes #670

When playing markers in a playlist, instead of showing the scene's info on the player controls overlay, show details about the marker such as its title, primary tag, duration, etc.

Also updates the playlist list items with the same info.

I don't think it makes sense to do the same for clicking a single marker playback (eg not Play All), since that plays the full scene.