### PR TITLE
Test preferring software video decoders

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/StashMediaCodecSelector.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/StashMediaCodecSelector.kt
@@ -1,0 +1,23 @@
+package com.github.damontecres.stashapp.playback
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+
+@UnstableApi
+class StashMediaCodecSelector(
+    private val softwareMimeTypes: Set<String>,
+) : MediaCodecSelector {
+    private val software by lazy { MediaCodecSelector.PREFER_SOFTWARE }
+
+    override fun getDecoderInfos(
+        mimeType: String,
+        requiresSecureDecoder: Boolean,
+        requiresTunnelingDecoder: Boolean,
+    ): MutableList<MediaCodecInfo> =
+        if (mimeType in softwareMimeTypes) {
+            software.getDecoderInfos(mimeType, requiresSecureDecoder, requiresTunnelingDecoder)
+        } else {
+            MediaCodecSelector.DEFAULT.getDecoderInfos(mimeType, requiresSecureDecoder, requiresTunnelingDecoder)
+        }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
@@ -62,6 +62,7 @@ import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.ui.PlayerControlView
 import androidx.media3.ui.SubtitleView
 import androidx.media3.ui.compose.PlayerSurface
@@ -575,6 +576,34 @@ fun PlaybackPageContent(
                                 Toast.LENGTH_LONG,
                             ).show()
                     }
+                }
+            },
+        )
+
+        StashExoPlayer.addListener(
+            object : AnalyticsListener {
+                override fun onAudioDecoderInitialized(
+                    eventTime: AnalyticsListener.EventTime,
+                    decoderName: String,
+                    initializedTimestampMs: Long,
+                    initializationDurationMs: Long,
+                ) {
+                    Log.v(
+                        TAG,
+                        "onAudioDecoderInitialized (id=${currentScene.item.id}): $decoderName",
+                    )
+                }
+
+                override fun onVideoDecoderInitialized(
+                    eventTime: AnalyticsListener.EventTime,
+                    decoderName: String,
+                    initializedTimestampMs: Long,
+                    initializationDurationMs: Long,
+                ) {
+                    Log.v(
+                        TAG,
+                        "onVideoDecoderInitialized (id=${currentScene.item.id}): $decoderName",
+                    )
                 }
             },
         )

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -198,4 +198,28 @@
     </string-array>
     <string name="transcode_options_disabled" translatable="false">Disabled</string>
 
+
+    <string-array name="default_prefer_software" translatable="false"></string-array>
+
+    <string-array name="prefer_software_keys" translatable="false">
+        <item>av1</item>
+        <item>h263</item>
+        <item>h264</item>
+        <item>hevc</item>
+        <item>mpeg2video</item>
+        <item>vp8</item>
+        <item>vp9</item>
+    </string-array>
+
+    <!-- This should be mimetypes, see android.media.MediaFormat -->
+    <string-array name="prefer_software_values" translatable="false">
+        <item>video/av01</item>
+        <item>video/3gpp</item>
+        <item>video/avc</item>
+        <item>video/hevc</item>
+        <item>video/mpeg2</item>
+        <item>video/x-vnd.on2.vp8</item>
+        <item>video/x-vnd.on2.vp9</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -39,6 +39,7 @@
     <string name="pref_key_playback_always_transcode" translatable="false">playback.alwaysTranscode</string>
     <string name="pref_key_captions_on_by_default" translatable="false">playback.captionsOnByDefault</string>
     <string name="pref_key_playback_tunneling" translatable="false">playback.tunneling</string>
+    <string name="pref_key_playback_prefer_software" translatable="false">playback.preferSoftware</string>
 
     <string name="pref_key_ui_performer_tabs" translatable="false">ui.tabs.performer</string>
     <string name="pref_key_ui_gallery_tabs" translatable="false">ui.tabs.gallery</string>

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -255,6 +255,13 @@
             app:summaryOn="Log playback events"
             app:summaryOff="Don't log"
             app:defaultValue="false"/>
+        <MultiSelectListPreference
+            app:key="@string/pref_key_playback_prefer_software"
+            app:title="Prefer software decoding"
+            app:summary="Video codecs which should prefer using software decoding"
+            app:defaultValue="@array/default_prefer_software"
+            app:entries="@array/prefer_software_keys"
+            app:entryValues="@array/prefer_software_values"/>
         <ListPreference
             app:key="@string/pref_key_playback_http_client"
             app:title="Playback Streaming Client"


### PR DESCRIPTION
This is a test PR which may not be merged.

Adds an advanced setting to choose video codecs which should prefer using a software decoder. This is generally not desired behavior, but is useful for testing.

If you want to try this, you can install using the instructions [here](https://github.com/damontecres/StashAppAndroidTV/releases/tag/develop-v-software).