### PR TITLE
WIP Use libVLC for playback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -269,6 +269,8 @@ dependencies {
     implementation(libs.navigation.reimagined)
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
+    implementation("org.videolan.android:libvlc-all:4.0.0-eap20")
+
     testImplementation(libs.androidx.test.core.ktx)
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -269,7 +269,7 @@ dependencies {
     implementation(libs.navigation.reimagined)
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
-    implementation("org.videolan.android:libvlc-all:4.0.0-eap20")
+    implementation(libs.libvlc)
 
     testImplementation(libs.androidx.test.core.ktx)
     testImplementation(libs.junit)

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/NavDrawerFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/NavDrawerFragment.kt
@@ -82,6 +82,7 @@ import com.github.damontecres.stashapp.ui.components.ItemOnClicker
 import com.github.damontecres.stashapp.ui.components.LongClicker
 import com.github.damontecres.stashapp.ui.components.MarkerDurationDialog
 import com.github.damontecres.stashapp.ui.components.filter.CreateFilterScreen
+import com.github.damontecres.stashapp.ui.components.playback.VlcPlaybackPage
 import com.github.damontecres.stashapp.ui.components.server.ManageServers
 import com.github.damontecres.stashapp.ui.pages.ChooseThemePage
 import com.github.damontecres.stashapp.ui.pages.DialogParams
@@ -92,7 +93,6 @@ import com.github.damontecres.stashapp.ui.pages.ImagePage
 import com.github.damontecres.stashapp.ui.pages.MainPage
 import com.github.damontecres.stashapp.ui.pages.MarkerPage
 import com.github.damontecres.stashapp.ui.pages.PerformerPage
-import com.github.damontecres.stashapp.ui.pages.PlaybackPage
 import com.github.damontecres.stashapp.ui.pages.PlaylistPlaybackPage
 import com.github.damontecres.stashapp.ui.pages.SceneDetailsPage
 import com.github.damontecres.stashapp.ui.pages.SearchPage
@@ -398,14 +398,23 @@ fun FragmentContent(
                 }
 
                 is Destination.Playback -> {
-                    PlaybackPage(
+//                    PlaybackPage(
+//                        server = server,
+//                        sceneId = destination.sceneId,
+//                        startPosition = destination.position,
+//                        playbackMode = destination.mode,
+//                        uiConfig = composeUiConfig,
+//                        itemOnClick = itemOnClick,
+//                        modifier = Modifier,
+//                    )
+                    VlcPlaybackPage(
                         server = server,
                         sceneId = destination.sceneId,
                         startPosition = destination.position,
                         playbackMode = destination.mode,
                         uiConfig = composeUiConfig,
                         itemOnClick = itemOnClick,
-                        modifier = Modifier,
+                        modifier = Modifier.fillMaxSize(),
                     )
                 }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
@@ -68,6 +68,8 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
 
+private const val TAG = "PlaybackControls"
+
 sealed interface PlaybackAction {
     data object OCount : PlaybackAction
 

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
@@ -125,7 +125,7 @@ import java.util.Locale
 import kotlin.properties.Delegates
 import kotlin.time.Duration.Companion.milliseconds
 
-const val TAG = "PlaybackPageContent"
+private const val TAG = "PlaybackPageContent"
 
 class PlaybackViewModel : ViewModel() {
     private lateinit var server: StashServer

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistList.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistList.kt
@@ -41,6 +41,8 @@ import com.github.damontecres.stashapp.ui.tryRequestFocus
 import com.github.damontecres.stashapp.ui.util.ifElse
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 
+private const val TAG = "PlaylistList"
+
 @Composable
 fun PlaylistList(
     mediaItemCount: Int,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/VlcPlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/VlcPlaybackPage.kt
@@ -1,0 +1,429 @@
+package com.github.damontecres.stashapp.ui.components.playback
+
+import android.util.Log
+import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.net.toUri
+import androidx.preference.PreferenceManager
+import androidx.tv.material3.MaterialTheme
+import com.github.damontecres.stashapp.api.fragment.FullSceneData
+import com.github.damontecres.stashapp.data.Scene
+import com.github.damontecres.stashapp.playback.PlaybackMode
+import com.github.damontecres.stashapp.ui.ComposeUiConfig
+import com.github.damontecres.stashapp.ui.components.ItemOnClicker
+import com.github.damontecres.stashapp.ui.tryRequestFocus
+import com.github.damontecres.stashapp.util.LoggingCoroutineExceptionHandler
+import com.github.damontecres.stashapp.util.QueryEngine
+import com.github.damontecres.stashapp.util.StashServer
+import com.github.damontecres.stashapp.util.toLongMilliseconds
+import kotlinx.coroutines.launch
+import org.videolan.libvlc.LibVLC
+import org.videolan.libvlc.Media
+import org.videolan.libvlc.MediaPlayer
+import org.videolan.libvlc.util.VLCVideoLayout
+import kotlin.time.Duration.Companion.seconds
+
+private const val TAG = "VlcPlaybackPage"
+
+@Composable
+fun VlcPlaybackPage(
+    server: StashServer,
+    uiConfig: ComposeUiConfig,
+    sceneId: String,
+    startPosition: Long,
+    playbackMode: PlaybackMode,
+    itemOnClick: ItemOnClicker<Any>,
+    modifier: Modifier = Modifier,
+) {
+    var scene by remember { mutableStateOf<FullSceneData?>(null) }
+    var currentScene by remember { mutableStateOf<Scene?>(null) }
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    LaunchedEffect(server, sceneId) {
+        scope.launch(
+            LoggingCoroutineExceptionHandler(
+                server,
+                scope,
+                toastMessage = "Error fetching scene",
+            ),
+        ) {
+            val fullScene = QueryEngine(server).getScene(sceneId)
+            if (fullScene != null) {
+                scene = fullScene
+                currentScene = Scene.fromFullSceneData(fullScene)
+            } else {
+                Log.w("PlaybackPage", "Scene $sceneId not found")
+                Toast.makeText(context, "Scene $sceneId not found", Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+
+    val controllerViewState =
+        remember {
+            ControllerViewState(
+                prefs.getInt(
+                    "controllerShowTimeoutMs",
+                    3_000,
+                ),
+                true,
+            )
+        }.also {
+            LaunchedEffect(it) {
+                it.observe()
+            }
+        }
+
+    val libVlc = remember { LibVLC(context, listOf("-v")) }
+    val mediaPlayer = remember(libVlc) { MediaPlayer(libVlc) }
+
+    var isPlaying by remember { mutableStateOf(false) }
+
+    LaunchedEffect(mediaPlayer) {
+        mediaPlayer.setEventListener(
+            object : MediaPlayer.EventListener {
+                override fun onEvent(event: MediaPlayer.Event) {
+                    Log.v(TAG, "onEvent: 0x${event.type.toString(16)}")
+                    if (event.type == MediaPlayer.Event.Playing) {
+                        isPlaying = true
+                    } else if (event.type == MediaPlayer.Event.Paused) {
+                        isPlaying = false
+                    }
+                }
+            },
+        )
+    }
+
+    val focusRequester = remember { FocusRequester() }
+
+    var skipIndicatorDuration by remember { mutableLongStateOf(0L) }
+    LaunchedEffect(controllerViewState.controlsVisible) {
+        // If controller shows/hides, immediately cancel the skip indicator
+        skipIndicatorDuration = 0L
+    }
+    var skipPosition by remember { mutableLongStateOf(0L) }
+    val updateSkipIndicator = { delta: Long ->
+        if (skipIndicatorDuration > 0 && delta < 0 || skipIndicatorDuration < 0 && delta > 0) {
+            skipIndicatorDuration = 0
+        }
+        skipIndicatorDuration += delta
+        skipPosition = mediaPlayer.time
+    }
+    val playbackKeyHandler =
+        remember {
+            VlcPlaybackKeyHandler(
+                player = mediaPlayer,
+                controlsEnabled = true,
+                skipWithLeftRight = true,
+                nextWithUpDown = false,
+                controllerViewState = controllerViewState,
+                updateSkipIndicator = updateSkipIndicator,
+                seekBackIncrement = 10_000,
+                seekForwardIncrement = 30_000,
+            )
+        }
+
+    scene?.let {
+        val media = remember { Media(libVlc, currentScene!!.streamUrl!!.toUri()) }
+        LaunchedEffect(Unit) {
+            focusRequester.tryRequestFocus()
+        }
+        Box(
+            modifier =
+                modifier
+                    .background(Color.Black)
+                    .onKeyEvent(playbackKeyHandler::onKeyEvent)
+                    .focusRequester(focusRequester)
+                    .focusable(),
+        ) {
+            AndroidView(
+                factory = {
+                    VLCVideoLayout(it)
+                },
+                update = { vlcLayout ->
+                    mediaPlayer.attachViews(vlcLayout, null, true, false)
+                    mediaPlayer.media = media
+                    media.release()
+                    if (startPosition > 0) mediaPlayer.time = startPosition
+                    mediaPlayer.play()
+                },
+                modifier = Modifier.fillMaxSize(),
+            )
+
+            if (!controllerViewState.controlsVisible && skipIndicatorDuration != 0L) {
+                SkipIndicator(
+                    durationMs = skipIndicatorDuration,
+                    onFinish = {
+                        skipIndicatorDuration = 0L
+                    },
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 70.dp),
+                )
+                val showSkipProgress = true
+                if (showSkipProgress) {
+                    currentScene?.duration?.let {
+                        val percent =
+                            skipPosition.toFloat() / (it.toLongMilliseconds).toFloat()
+                        Box(
+                            modifier =
+                                Modifier
+                                    .align(Alignment.BottomStart)
+                                    .background(MaterialTheme.colorScheme.border)
+                                    .clip(RectangleShape)
+                                    .height(3.dp)
+                                    .fillMaxWidth(percent),
+                        ) {}
+                    }
+                }
+            }
+
+            currentScene?.let {
+                AnimatedVisibility(
+                    controllerViewState.controlsVisible,
+                    Modifier,
+                    slideInVertically { it },
+                    slideOutVertically { it },
+                ) {
+                    PlaybackOverlay(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .background(Color.Transparent),
+                        uiConfig = uiConfig,
+                        scene = it,
+                        tracks = listOf(),
+                        captions = listOf(),
+                        markers = listOf(),
+                        streamDecision = null,
+                        oCounter = it.oCounter ?: 0,
+                        playerControls = VlcPlayerControls(mediaPlayer, 10_000, 30_000),
+                        onPlaybackActionClick = {
+                            when (it) {
+                                PlaybackAction.CreateMarker -> {
+                                }
+
+                                PlaybackAction.OCount -> {
+                                }
+
+                                PlaybackAction.ShowDebug -> {
+                                }
+
+                                PlaybackAction.ShowVideoFilterDialog -> {}
+
+                                PlaybackAction.ShowPlaylist -> {
+                                }
+
+                                is PlaybackAction.ToggleCaptions -> {
+                                }
+
+                                is PlaybackAction.PlaybackSpeed -> {}
+                                is PlaybackAction.Scale -> {}
+                                is PlaybackAction.ToggleAudio -> {
+                                }
+
+                                PlaybackAction.ShowSceneDetails -> {
+                                }
+                            }
+                        },
+                        onSeekBarChange = {
+                        },
+                        controllerViewState = controllerViewState,
+                        showPlay = isPlaying,
+                        previousEnabled = false,
+                        nextEnabled = false,
+                        seekEnabled = mediaPlayer.isSeekable,
+                        seekPreviewEnabled = true,
+                        showDebugInfo = true,
+                        spriteImageLoaded = false,
+                        moreButtonOptions =
+                            MoreButtonOptions(
+                                buildMap {
+//                                    if (markersEnabled) {
+//                                        put("Create Marker", PlaybackAction.CreateMarker)
+//                                    }
+//                                    if (playlistPager != null && playlistPager.size > 1) {
+//                                        put("Show Playlist", PlaybackAction.ShowPlaylist)
+//                                    }
+//                                    if (useVideoFilters) {
+//                                        put("Set video filters", PlaybackAction.ShowVideoFilterDialog)
+//                                    }
+                                    put("Details", PlaybackAction.ShowSceneDetails)
+                                },
+                            ),
+                        subtitleIndex = null,
+                        audioIndex = null,
+                        audioOptions = listOf(),
+                        playbackSpeed = 1.0f,
+                        scale = ContentScale.Fit,
+                        playlistInfo = null,
+                    )
+                }
+            }
+        }
+    }
+    DisposableEffect(Unit) {
+        onDispose {
+            mediaPlayer.stop()
+            mediaPlayer.release()
+            libVlc.release()
+        }
+    }
+}
+
+class VlcPlaybackKeyHandler(
+    private val player: MediaPlayer,
+    private val controlsEnabled: Boolean,
+    private val skipWithLeftRight: Boolean,
+    private val nextWithUpDown: Boolean,
+    private val controllerViewState: ControllerViewState,
+    private val updateSkipIndicator: (Long) -> Unit,
+    private val seekBackIncrement: Long = 10.seconds.inWholeMilliseconds,
+    private val seekForwardIncrement: Long = 30.seconds.inWholeMilliseconds,
+) {
+    fun onKeyEvent(it: KeyEvent): Boolean {
+        var result = true
+        if (!controlsEnabled) {
+            result = false
+        } else if (it.type != KeyEventType.KeyUp) {
+            result = false
+        } else if (isDpad(it)) {
+            if (!controllerViewState.controlsVisible) {
+                if (skipWithLeftRight && it.key == Key.DirectionLeft) {
+                    updateSkipIndicator(-seekBackIncrement)
+                    player.time = player.time - seekBackIncrement
+                } else if (skipWithLeftRight && it.key == Key.DirectionRight) {
+                    player.time = player.time + seekForwardIncrement
+                    updateSkipIndicator(seekForwardIncrement)
+                } else if (nextWithUpDown && it.key == Key.DirectionUp) {
+//                    player.seekToPreviousMediaItem()
+                    // TODO
+                } else if (nextWithUpDown && it.key == Key.DirectionDown) {
+//                    player.seekToNextMediaItem()
+                    // TODO
+                } else {
+                    controllerViewState.showControls()
+                }
+            } else {
+                // When controller is visible, its buttons will handle pulsing
+            }
+        } else if (isMedia(it)) {
+            when (it.key) {
+                Key.MediaPlay -> {
+                    player.play()
+                }
+
+                Key.MediaPause -> {
+                    player.pause()
+                    controllerViewState.showControls()
+                }
+
+                Key.MediaPlayPause -> {
+                    if (player.isPlaying) player.pause() else player.play()
+                    if (!player.isPlaying) {
+                        controllerViewState.showControls()
+                    }
+                }
+
+                Key.MediaFastForward, Key.MediaSkipForward -> {
+                    player.time = player.time + seekForwardIncrement
+                    updateSkipIndicator(seekForwardIncrement)
+                }
+
+                Key.MediaRewind, Key.MediaSkipBackward -> {
+                    player.time = player.time - seekBackIncrement
+                    updateSkipIndicator(-seekBackIncrement)
+                }
+
+                // TODO
+//                Key.MediaNext -> if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_NEXT)) player.seekToNext()
+//                Key.MediaPrevious -> if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_PREVIOUS)) player.seekToPrevious()
+                else -> result = false
+            }
+        } else if (it.key == Key.Enter && !controllerViewState.controlsVisible) {
+            controllerViewState.showControls()
+        } else if (it.key == Key.Back && controllerViewState.controlsVisible) {
+            controllerViewState.hideControls()
+        } else {
+            controllerViewState.pulseControls()
+            result = false
+        }
+        return result
+    }
+}
+
+class VlcPlayerControls(
+    private val player: MediaPlayer,
+    private val seekBackIncrement: Long,
+    private val seekForwardIncrement: Long,
+) : PlayerControls {
+    override val duration: Long
+        get() = player.length
+    override val currentPosition: Long
+        get() = player.time
+    override val bufferedPosition: Long
+        get() = player.time
+
+    override fun seekTo(position: Long) {
+        player.time = position
+    }
+
+    override fun seekBack() {
+        player.time = player.time - seekBackIncrement
+    }
+
+    override fun seekForward() {
+        player.time = player.time + seekForwardIncrement
+    }
+
+    override fun seekToPrevious() {
+        TODO("Not yet implemented")
+    }
+
+    override fun seekToNext() {
+        TODO("Not yet implemented")
+    }
+
+    override fun hasNextMediaItem(): Boolean = false
+
+    override fun playOrPause() {
+        if (player.isPlaying) player.pause() else player.play()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ compose-bom = "2025.07.00"
 compose-runtime = "1.8.3"
 constraintlayout = "2.2.1"
 desugar_jdk_libs = "2.1.5"
+libvlc-all = "3.6.2"
 markwon-core = "4.6.2"
 core-ktx = "1.16.0"
 glide = "4.16.0"
@@ -86,6 +87,7 @@ coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version
 coil-network-cachecontrol = { module = "io.coil-kt.coil3:coil-network-cache-control", version.ref = "coil-compose" }
 coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil-compose" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
+libvlc = { module = "org.videolan.android:libvlc-all", version.ref = "libvlc-all" }
 markwon-core = { module = "io.noties.markwon:core", version.ref = "markwon-core" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 glide-okhttp3-integration = { module = "com.github.bumptech.glide:okhttp3-integration", version.ref = "glide" }


### PR DESCRIPTION
# **This PR is an experiment! It may not end up being used!**

## **This PR is a work-in-progress! Expect bugs and crashes!**

## Description
This PR switches the playback engine from media3 ExoPlayer to VLC via https://github.com/videolan/vlc-android.

I had previously considered using VLC, but since the VLC package doesn't include any UI elements and is quite larger, I went with ExoPlayer. However, the new UI implements pretty much all of the UI elements needed for playback, so switching the playback engine isn't as cumbersome now.

**Note: Lots of playback controls do not work!**

## Try it out?

This only works for the new UI!

See https://github.com/damontecres/StashAppAndroidTV/releases/tag/develop-v-vlc for instructions

## Pros:
* Direct play whatever VLC can, AKA everything
  * Including WMV, AVI, VC1, FLV, etc - though the device must be sufficiently powerful to do so

## Cons:
* APK download is >200mb larger, a 10x increase!
  * Might be able to reduce this by dropping `x86` & `x86_64` builds? Do any android TV devices even use these architectures?
* Installed app is ~45mb larger, a >50% increase
* Crashes - when VLC crashes, it crashes hard, sometimes rebooting the device
* libVLC doesn't support 16kb page size
  * Google play store [requires this for Android 15+](https://developer.android.com/guide/practices/page-sizes) but this app isn't distributed there
  * It looks like VLC is working on supporting this
* Documentation is not great