### PR TITLE
Disable caching for video playback

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/StashExoPlayer.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/StashExoPlayer.kt
@@ -14,6 +14,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.util.EventLogger
 import androidx.preference.PreferenceManager
+import com.github.damontecres.stashapp.StashExoPlayer.Companion.getInstance
 import com.github.damontecres.stashapp.util.Constants
 import com.github.damontecres.stashapp.util.SkipParams
 import com.github.damontecres.stashapp.util.StashClient
@@ -81,7 +82,7 @@ class StashExoPlayer private constructor() {
                 ) {
                     context.getString(R.string.playback_http_client_okhttp) -> {
                         OkHttpDataSource
-                            .Factory(server.okHttpClient)
+                            .Factory(server.streamingOkHttpClient)
                     }
 
                     context.getString(R.string.playback_http_client_default) -> {

--- a/app/src/main/java/com/github/damontecres/stashapp/util/StashServer.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/StashServer.kt
@@ -35,6 +35,7 @@ data class StashServer(
 
     val okHttpClient by lazy { StashClient.createOkHttpClient(this) }
     val apolloClient by lazy { StashClient.createApolloClient(this) }
+    val streamingOkHttpClient by lazy { okHttpClient.newBuilder().cache(null).build() }
 
     /**
      * Query the server for preferences


### PR DESCRIPTION
It's not necessary to cache any video content.

This might help a bit with #654, but probably not much since the cache isn't very large.