### PR TITLE
Better handling for null timestamps

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,6 +149,8 @@ tasks.register("createGraphqlSchema") {
     doFirst {
         File("$projectDir/src/main/graphql/schema.graphqls").writeTextIfDifferent(
             "# Auto-generated do not edit\n\n" +
+                File("$projectDir/src/main/graphql/client_schema.graphqls").readText() +
+                "\n\n" +
                 fileTree("../stash-server/graphql/schema/")
                     .filter { it.extension == "graphql" }
                     .files

--- a/app/src/main/graphql/FindGalleries.graphql
+++ b/app/src/main/graphql/FindGalleries.graphql
@@ -45,8 +45,8 @@ fragment GalleryData on Gallery {
   rating100
   code
   photographer
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
   files {
     path
   }

--- a/app/src/main/graphql/FindGroups.graphql
+++ b/app/src/main/graphql/FindGroups.graphql
@@ -86,8 +86,8 @@ fragment GroupData on Group {
   scene_count
   front_image_path
   back_image_path
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
 }
 
 mutation CreateGroup($input: GroupCreateInput!) {

--- a/app/src/main/graphql/FindImages.graphql
+++ b/app/src/main/graphql/FindImages.graphql
@@ -41,8 +41,8 @@ fragment ImageData on Image {
   details
   photographer
   o_counter
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
   paths {
     thumbnail
     preview

--- a/app/src/main/graphql/FindPerformers.graphql
+++ b/app/src/main/graphql/FindPerformers.graphql
@@ -78,8 +78,8 @@ fragment PerformerData on Performer {
   gallery_count
   group_count
   o_counter
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
   tags {
     ...SlimTagData
     __typename

--- a/app/src/main/graphql/FindSceneMarkers.graphql
+++ b/app/src/main/graphql/FindSceneMarkers.graphql
@@ -44,8 +44,6 @@ fragment MinimalSceneData on Scene {
   date
   rating100
   o_counter
-  created_at
-  updated_at
   files {
     ...VideoFile
   }
@@ -59,8 +57,6 @@ fragment VideoSceneData on Scene {
   resume_time
   rating100
   o_counter
-  created_at
-  updated_at
   files {
     ...VideoFile
   }
@@ -84,8 +80,8 @@ fragment VideoSceneData on Scene {
 fragment MarkerData on SceneMarker {
   id
   title
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
   stream
   screenshot
   seconds
@@ -107,8 +103,8 @@ fragment MarkerData on SceneMarker {
 fragment FullMarkerData on SceneMarker {
   id
   title
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
   stream
   screenshot
   seconds
@@ -116,7 +112,6 @@ fragment FullMarkerData on SceneMarker {
   preview
   primary_tag {
     ...TagData
-    __typename
   }
   tags {
     ...TagData
@@ -124,5 +119,4 @@ fragment FullMarkerData on SceneMarker {
   scene {
     ...VideoSceneData
   }
-  __typename
 }

--- a/app/src/main/graphql/FindScenes.graphql
+++ b/app/src/main/graphql/FindScenes.graphql
@@ -46,8 +46,8 @@ fragment SlimSceneData on Scene {
   o_counter
   organized
   resume_time
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
   files {
     ...VideoFile
   }
@@ -104,8 +104,8 @@ fragment FullSceneData on Scene {
   resume_time
   play_duration
   play_count
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
   files {
     ...VideoFile
     __typename
@@ -135,8 +135,8 @@ fragment FullSceneData on Scene {
     title
     seconds
     end_seconds
-    created_at
-    updated_at
+    created_at @catch(to: NULL)
+    updated_at @catch(to: NULL)
     stream
     preview
     primary_tag {

--- a/app/src/main/graphql/FindStudios.graphql
+++ b/app/src/main/graphql/FindStudios.graphql
@@ -67,8 +67,8 @@ fragment StudioData on Studio {
   aliases
   favorite
   __typename
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
 }
 
 mutation UpdateStudio($input: StudioUpdateInput!){

--- a/app/src/main/graphql/Fragments.graphql
+++ b/app/src/main/graphql/Fragments.graphql
@@ -18,8 +18,8 @@ fragment TagData on Tag {
   gallery_count
   parent_count
   child_count
-  created_at
-  updated_at
+  created_at @catch(to: NULL)
+  updated_at @catch(to: NULL)
 }
 
 fragment StashJob on Job {

--- a/app/src/main/graphql/client_schema.graphqls
+++ b/app/src/main/graphql/client_schema.graphqls
@@ -1,0 +1,6 @@
+extend schema @link(
+  url: "https://specs.apollo.dev/nullability/v0.4",
+  import: ["@semanticNonNull", "@semanticNonNullField", "@catch", "CatchTo", "@catchByDefault"]
+)
+
+extend schema @catchByDefault(to: NULL)

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/ItemDetails.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/ItemDetails.kt
@@ -284,18 +284,8 @@ fun ItemDetailsFooter(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(20.dp, Alignment.Start),
     ) {
-        if (createdAt != null && createdAt.length >= 10) {
-            TitleValueText(
-                stringResource(R.string.stashapp_created_at),
-                createdAt.substring(0..<10),
-            )
-        }
-        if (updatedAt != null && updatedAt.length >= 10) {
-            TitleValueText(
-                stringResource(R.string.stashapp_updated_at),
-                updatedAt.substring(0..<10),
-            )
-        }
+        CreatedTimestamp(createdAt)
+        UpdatedTimestamp(updatedAt)
         TitleValueText(stringResource(R.string.id), id)
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/TitleValueText.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/TitleValueText.kt
@@ -16,6 +16,7 @@
 
 package com.github.damontecres.stashapp.ui.components
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -33,11 +34,13 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.ui.util.ifElse
 import com.github.damontecres.stashapp.ui.util.playOnClickSound
 
@@ -120,3 +123,30 @@ private fun MaybeClickColumn(
         Column(content = content, modifier = modifier)
     }
 }
+
+@Composable
+fun TimestampValueText(
+    @StringRes title: Int,
+    timestamp: Any?,
+    modifier: Modifier = Modifier,
+) {
+    val value =
+        if (timestamp != null && timestamp.toString().length >= 10) {
+            timestamp.toString().substring(0..<10)
+        } else {
+            stringResource(R.string.stashapp_unknown_date)
+        }
+    TitleValueText(stringResource(title), value, modifier)
+}
+
+@Composable
+fun CreatedTimestamp(
+    timestamp: Any?,
+    modifier: Modifier = Modifier,
+) = TimestampValueText(R.string.stashapp_created_at, timestamp, modifier)
+
+@Composable
+fun UpdatedTimestamp(
+    timestamp: Any?,
+    modifier: Modifier = Modifier,
+) = TimestampValueText(R.string.stashapp_updated_at, timestamp, modifier)

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageDetailsFooter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageDetailsFooter.kt
@@ -9,7 +9,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.fragment.ImageData
+import com.github.damontecres.stashapp.ui.components.CreatedTimestamp
 import com.github.damontecres.stashapp.ui.components.TitleValueText
+import com.github.damontecres.stashapp.ui.components.UpdatedTimestamp
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.views.formatBytes
 
@@ -24,22 +26,8 @@ fun ImageDetailsFooter(
                 .fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(20.dp),
     ) {
-        if (image.created_at.toString().length >= 10) {
-            item {
-                TitleValueText(
-                    stringResource(R.string.stashapp_created_at),
-                    image.created_at.toString().substring(0..<10),
-                )
-            }
-        }
-        if (image.updated_at.toString().length >= 10) {
-            item {
-                TitleValueText(
-                    stringResource(R.string.stashapp_updated_at),
-                    image.updated_at.toString().substring(0..<10),
-                )
-            }
-        }
+        item { CreatedTimestamp(image.created_at) }
+        item { UpdatedTimestamp(image.updated_at) }
         item {
             TitleValueText(stringResource(R.string.id), image.id)
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsFooter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsFooter.kt
@@ -11,7 +11,9 @@ import androidx.compose.ui.unit.dp
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.fragment.FullSceneData
 import com.github.damontecres.stashapp.playback.displayString
+import com.github.damontecres.stashapp.ui.components.CreatedTimestamp
 import com.github.damontecres.stashapp.ui.components.TitleValueText
+import com.github.damontecres.stashapp.ui.components.UpdatedTimestamp
 import com.github.damontecres.stashapp.util.bitRateString
 import com.github.damontecres.stashapp.views.formatBytes
 import java.util.Locale
@@ -27,22 +29,8 @@ fun SceneDetailsFooter(
                 .fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        if (scene.created_at.toString().length >= 10) {
-            item {
-                TitleValueText(
-                    stringResource(R.string.stashapp_created_at),
-                    scene.created_at.toString().substring(0..<10),
-                )
-            }
-        }
-        if (scene.updated_at.toString().length >= 10) {
-            item {
-                TitleValueText(
-                    stringResource(R.string.stashapp_updated_at),
-                    scene.updated_at.toString().substring(0..<10),
-                )
-            }
-        }
+        item { CreatedTimestamp(scene.created_at) }
+        item { UpdatedTimestamp(scene.updated_at) }
         item {
             TitleValueText(stringResource(R.string.stashapp_scene_id), scene.id)
         }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/MarkerPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/MarkerPage.kt
@@ -60,12 +60,14 @@ import com.github.damontecres.stashapp.playback.PlaybackMode
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.LocalGlobalContext
 import com.github.damontecres.stashapp.ui.compat.Button
+import com.github.damontecres.stashapp.ui.components.CreatedTimestamp
 import com.github.damontecres.stashapp.ui.components.DialogItem
 import com.github.damontecres.stashapp.ui.components.DialogPopup
 import com.github.damontecres.stashapp.ui.components.ItemOnClicker
 import com.github.damontecres.stashapp.ui.components.ItemsRow
 import com.github.damontecres.stashapp.ui.components.LongClicker
 import com.github.damontecres.stashapp.ui.components.TitleValueText
+import com.github.damontecres.stashapp.ui.components.UpdatedTimestamp
 import com.github.damontecres.stashapp.ui.tryRequestFocus
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
@@ -366,18 +368,8 @@ fun MarkerPageContent(
                 modifier = Modifier,
                 horizontalArrangement = Arrangement.spacedBy(20.dp),
             ) {
-                if (marker.created_at.toString().length >= 10) {
-                    TitleValueText(
-                        stringResource(R.string.stashapp_created_at),
-                        marker.created_at.toString().substring(0..<10),
-                    )
-                }
-                if (marker.updated_at.toString().length >= 10) {
-                    TitleValueText(
-                        stringResource(R.string.stashapp_updated_at),
-                        marker.updated_at.toString().substring(0..<10),
-                    )
-                }
+                CreatedTimestamp(marker.created_at)
+                UpdatedTimestamp(marker.updated_at)
                 TitleValueText(
                     stringResource(R.string.id),
                     marker.id,

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -522,8 +522,6 @@ val FullSceneData.asVideoSceneData: VideoSceneData
             resume_time,
             rating100,
             o_counter,
-            created_at,
-            updated_at,
             files.map { VideoSceneData.File("", it.videoFile) },
             VideoSceneData.Paths(
                 paths.caption,
@@ -545,8 +543,6 @@ val FullSceneData.asMinimalSceneData: MinimalSceneData
             date,
             rating100,
             o_counter,
-            created_at,
-            updated_at,
             files.map { MinimalSceneData.File("", it.videoFile) },
         )
 


### PR DESCRIPTION
Closes #653

Adds catch logic for null timestamp fields which are not supposed to be null. However, the error is generated server-side, so this new handling is really just cautionary.

Also, the UI logic for showing the timestamps is moved into its own composable since its reused in many places.