### PR TITLE
Add button to show scene description dialog

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/SceneDetailsOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/SceneDetailsOverlay.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -15,6 +18,7 @@ import com.github.damontecres.stashapp.api.fragment.FullSceneData
 import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.components.ItemOnClicker
+import com.github.damontecres.stashapp.ui.components.scene.SceneDescriptionDialog
 import com.github.damontecres.stashapp.ui.components.scene.SceneDetailsFooter
 import com.github.damontecres.stashapp.ui.components.scene.SceneDetailsHeaderInfo
 import com.github.damontecres.stashapp.ui.components.scene.sceneDetailsBody
@@ -34,6 +38,7 @@ fun SceneDetailsOverlay(
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
     val focusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
+    var showDetailsDialog by remember { mutableStateOf(false) }
     LazyColumn(
         state = listState,
         contentPadding = PaddingValues(top = 16.dp, start = 16.dp, end = 16.dp, bottom = 135.dp),
@@ -44,22 +49,13 @@ fun SceneDetailsOverlay(
                 scene = scene,
                 studio = scene.studio?.studioData,
                 rating100 = rating100,
-                oCount = scene.o_counter ?: 0,
                 uiConfig = uiConfig,
                 itemOnClick = itemOnClick,
-                playOnClick = { _, _ -> },
-                editOnClick = {},
-                moreOnClick = {},
-                oCounterOnClick = {},
-                oCounterOnLongClick = {},
+                detailsOnClick = { showDetailsDialog = true },
                 onRatingChange = onRatingChange,
-                focusRequester = focusRequester,
                 bringIntoViewRequester = bringIntoViewRequester,
                 removeLongClicker = { _, _ -> },
-                showEditButton = false,
-                alwaysStartFromBeginning = false,
                 modifier = Modifier.padding(bottom = 80.dp),
-                showRatingBar = true,
             )
         }
         sceneDetailsBody(
@@ -84,4 +80,9 @@ fun SceneDetailsOverlay(
             )
         }
     }
+    SceneDescriptionDialog(
+        show = showDetailsDialog,
+        scene = scene,
+        onDismissRequest = { showDetailsDialog = false },
+    )
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDescriptionDialog.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDescriptionDialog.kt
@@ -1,0 +1,76 @@
+package com.github.damontecres.stashapp.ui.components.scene
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.github.damontecres.stashapp.R
+import com.github.damontecres.stashapp.api.fragment.FullSceneData
+import com.github.damontecres.stashapp.ui.components.ScrollableDialog
+import com.github.damontecres.stashapp.util.joinNotNullOrBlank
+import com.github.damontecres.stashapp.util.titleOrFilename
+import com.github.damontecres.stashapp.views.formatBytes
+
+@Composable
+fun SceneDescriptionDialog(
+    show: Boolean,
+    scene: FullSceneData,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (show) {
+        ScrollableDialog(
+            onDismissRequest = onDismissRequest,
+            modifier = modifier,
+        ) {
+            scene.titleOrFilename?.let {
+                item {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+            scene.details?.let {
+                item {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth(),
+                    )
+                }
+            }
+            if (scene.files.isNotEmpty()) {
+                item {
+                    HorizontalDivider()
+                    Text(
+                        stringResource(R.string.stashapp_files) + ":",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground,
+                    )
+                }
+            }
+            items(scene.files.map { it.videoFile }) {
+                val size =
+                    it.size
+                        .toString()
+                        .toIntOrNull()
+                        ?.let(::formatBytes)
+                Text(
+                    text = listOf(it.path, size).joinNotNullOrBlank(" - "),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsHeader.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsHeader.kt
@@ -14,17 +14,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -54,7 +49,6 @@ import com.github.damontecres.stashapp.ui.components.DotSeparatedRow
 import com.github.damontecres.stashapp.ui.components.ItemOnClicker
 import com.github.damontecres.stashapp.ui.components.LongClicker
 import com.github.damontecres.stashapp.ui.components.Rating100
-import com.github.damontecres.stashapp.ui.components.ScrollableDialog
 import com.github.damontecres.stashapp.ui.components.TitleValueText
 import com.github.damontecres.stashapp.ui.components.ratingBarHeight
 import com.github.damontecres.stashapp.ui.util.ifElse
@@ -62,13 +56,11 @@ import com.github.damontecres.stashapp.ui.util.playOnClickSound
 import com.github.damontecres.stashapp.ui.util.playSoundOnFocus
 import com.github.damontecres.stashapp.util.StashCoroutineExceptionHandler
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
-import com.github.damontecres.stashapp.util.joinNotNullOrBlank
 import com.github.damontecres.stashapp.util.listOfNotNullOrBlank
 import com.github.damontecres.stashapp.util.resolutionName
 import com.github.damontecres.stashapp.util.resume_position
 import com.github.damontecres.stashapp.util.titleOrFilename
 import com.github.damontecres.stashapp.views.durationToString
-import com.github.damontecres.stashapp.views.formatBytes
 import kotlinx.coroutines.launch
 
 @Composable
@@ -82,6 +74,7 @@ fun SceneDetailsHeader(
     playOnClick: (position: Long, mode: PlaybackMode) -> Unit,
     editOnClick: () -> Unit,
     moreOnClick: () -> Unit,
+    detailsOnClick: () -> Unit,
     oCounterOnClick: () -> Unit,
     oCounterOnLongClick: () -> Unit,
     onRatingChange: (Int) -> Unit,
@@ -145,20 +138,12 @@ fun SceneDetailsHeader(
                 scene = scene,
                 studio = studio,
                 rating100 = rating100,
-                oCount = oCount,
                 uiConfig = uiConfig,
                 itemOnClick = itemOnClick,
-                playOnClick = playOnClick,
-                editOnClick = editOnClick,
-                moreOnClick = moreOnClick,
-                oCounterOnClick = oCounterOnClick,
-                oCounterOnLongClick = oCounterOnLongClick,
+                detailsOnClick = detailsOnClick,
                 onRatingChange = onRatingChange,
-                focusRequester = focusRequester,
                 bringIntoViewRequester = bringIntoViewRequester,
                 removeLongClicker = removeLongClicker,
-                showEditButton = showEditButton,
-                alwaysStartFromBeginning = alwaysStartFromBeginning,
                 modifier = Modifier.padding(start = 16.dp),
                 showRatingBar = showRatingBar,
             )
@@ -190,20 +175,12 @@ fun SceneDetailsHeaderInfo(
     scene: FullSceneData,
     studio: StudioData?,
     rating100: Int,
-    oCount: Int,
     uiConfig: ComposeUiConfig,
     itemOnClick: ItemOnClicker<Any>,
-    playOnClick: (position: Long, mode: PlaybackMode) -> Unit,
-    editOnClick: () -> Unit,
-    moreOnClick: () -> Unit,
-    oCounterOnClick: () -> Unit,
-    oCounterOnLongClick: () -> Unit,
+    detailsOnClick: () -> Unit,
     onRatingChange: (Int) -> Unit,
-    focusRequester: FocusRequester,
     bringIntoViewRequester: BringIntoViewRequester,
     removeLongClicker: LongClicker<Any>,
-    showEditButton: Boolean,
-    alwaysStartFromBeginning: Boolean,
     modifier: Modifier = Modifier,
     showRatingBar: Boolean = true,
 ) {
@@ -215,7 +192,7 @@ fun SceneDetailsHeaderInfo(
         // Title
         Text(
             text = scene.titleOrFilename ?: "",
-            color = Color.LightGray,
+            color = MaterialTheme.colorScheme.onSurface,
             style =
                 MaterialTheme.typography.displayMedium.copy(
                     shadow =
@@ -267,7 +244,6 @@ fun SceneDetailsHeaderInfo(
                     } else {
                         Color.Unspecified
                     }
-                var showDetailsDialog by remember { mutableStateOf(false) }
                 Box(
                     modifier =
                         Modifier
@@ -283,7 +259,7 @@ fun SceneDetailsHeaderInfo(
                                 indication = LocalIndication.current,
                             ) {
                                 if (uiConfig.playSoundOnFocus) playOnClickSound(context)
-                                showDetailsDialog = true
+                                detailsOnClick.invoke()
                             },
                 ) {
                     Text(
@@ -294,45 +270,6 @@ fun SceneDetailsHeaderInfo(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.padding(8.dp),
                     )
-                }
-                if (showDetailsDialog) {
-                    ScrollableDialog(
-                        onDismissRequest = { showDetailsDialog = false },
-                        modifier = Modifier,
-                    ) {
-                        item {
-                            Text(
-                                text = scene.details,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth(),
-                            )
-                        }
-                        if (scene.files.isNotEmpty()) {
-                            item {
-                                HorizontalDivider()
-                                Text(
-                                    stringResource(R.string.stashapp_files) + ":",
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    color = MaterialTheme.colorScheme.onBackground,
-                                )
-                            }
-                        }
-                        items(scene.files.map { it.videoFile }) {
-                            val size =
-                                it.size
-                                    .toString()
-                                    .toIntOrNull()
-                                    ?.let(::formatBytes)
-                            Text(
-                                text = listOf(it.path, size).joinNotNullOrBlank(" - "),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onBackground,
-                            )
-                        }
-                    }
                 }
             }
             // Key-Values


### PR DESCRIPTION
Adds an additional button under more to show the scene details/description dialog. This is useful when the scene has no description (so its not clickable) but you want to see the other info that dialog has such as file info.

Also adds the full scene title to the dialog since it could be truncated.

Also if there are no markers in the scene, remove the option to play markers.