### PR TITLE
Move device type lookup to composition local

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/data/SortOption.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/data/SortOption.kt
@@ -194,13 +194,14 @@ sealed interface SortOption {
     }
 
     companion object {
-        private val MAPPING =
+        private val MAPPING by lazy {
             SortOption::class
                 .nestedClasses
                 .filter { klass -> klass.isSubclassOf(SortOption::class) }
                 .mapNotNull { klass -> klass.objectInstance }
                 .filterIsInstance<SortOption>()
                 .associateBy { it.key }
+        }
 
         fun getByKey(key: String): SortOption =
             if (key.startsWith("random")) {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/Extensions.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/Extensions.kt
@@ -40,6 +40,7 @@ import com.github.damontecres.stashapp.api.type.ImageFilterType
 import com.github.damontecres.stashapp.api.type.IntCriterionInput
 import com.github.damontecres.stashapp.navigation.NavigationManager
 import com.github.damontecres.stashapp.suppliers.FilterArgs
+import com.github.damontecres.stashapp.ui.compat.detectTvDevice
 import com.github.damontecres.stashapp.util.StashServer
 import com.github.damontecres.stashapp.util.getFilterArgs
 import com.github.damontecres.stashapp.util.name
@@ -67,6 +68,13 @@ object PlayerContext {
 
 val LocalPlayerContext =
     compositionLocalOf<PlayerContext> { PlayerContext }
+
+enum class DeviceType {
+    TV,
+    TOUCH,
+}
+
+val LocalDeviceType = compositionLocalOf { if (detectTvDevice) DeviceType.TV else DeviceType.TOUCH }
 
 fun Modifier.enableMarquee(focused: Boolean) =
     if (focused) {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/Themes.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/Themes.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -15,7 +16,6 @@ import androidx.preference.PreferenceManager
 import androidx.tv.material3.ColorScheme
 import androidx.tv.material3.MaterialTheme
 import com.github.damontecres.stashapp.R
-import com.github.damontecres.stashapp.ui.compat.isTvDevice
 import com.github.damontecres.stashapp.ui.theme.inversePrimaryDark
 import com.github.damontecres.stashapp.ui.theme.inversePrimaryLight
 import kotlinx.serialization.json.Json
@@ -115,7 +115,7 @@ fun AppTheme(
     colorScheme: AppColorScheme = getTheme(LocalContext.current, forceDark, isSystemInDarkTheme()),
     content: @Composable () -> Unit,
 ) {
-    if (isTvDevice) {
+    if (LocalDeviceType.current == DeviceType.TV) {
         MaterialTheme(
             colorScheme = colorScheme.tvColorScheme,
             content = content,
@@ -133,14 +133,6 @@ fun AppTheme(
 @Composable
 fun DefaultTheme(content: @Composable () -> Unit) {
     MaterialTheme(colorScheme = defaultColorSchemeSet.dark.tvColorScheme, content = content)
-}
-
-@Composable
-fun DefaultMaterial3Theme(content: @Composable () -> Unit) {
-    androidx.compose.material3.MaterialTheme(
-        colorScheme = defaultColorSchemeSet.dark.colorScheme,
-        content = content,
-    )
 }
 
 @Composable
@@ -172,6 +164,30 @@ fun Material3AppTheme(content: @Composable () -> Unit) {
         colorScheme = colorScheme.colorScheme,
         content = content,
     )
+}
+
+/**
+ * A theme useful for @Preview composables which provides [LocalDeviceType] for the specified device type
+ */
+@Composable
+fun PreviewTheme(
+    deviceType: DeviceType = DeviceType.TV,
+    useDark: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    CompositionLocalProvider(LocalDeviceType provides deviceType) {
+        val colorScheme = if (useDark) defaultColorSchemeSet.dark else defaultColorSchemeSet.light
+        if (deviceType == DeviceType.TV) {
+            MaterialTheme(colorScheme = colorScheme.tvColorScheme, content = content)
+        } else {
+            MaterialTheme(colorScheme = colorScheme.tvColorScheme) {
+                androidx.compose.material3.MaterialTheme(
+                    colorScheme = colorScheme.colorScheme,
+                    content = content,
+                )
+            }
+        }
+    }
 }
 
 sealed class AppColors private constructor() {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/compat/Button.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/compat/Button.kt
@@ -16,6 +16,8 @@ import androidx.tv.material3.ButtonScale
 import androidx.tv.material3.ButtonShape
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
+import com.github.damontecres.stashapp.ui.DeviceType
+import com.github.damontecres.stashapp.ui.LocalDeviceType
 
 val DefaultButtonColors: androidx.compose.material3.ButtonColors
     @Composable
@@ -42,7 +44,7 @@ fun Button(
     interactionSource: MutableInteractionSource? = null,
     content: @Composable RowScope.() -> Unit,
 ) {
-    if (isTvDevice) {
+    if (LocalDeviceType.current == DeviceType.TV) {
         Button(
             onClick = onClick,
             modifier = modifier,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/compat/Card.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/compat/Card.kt
@@ -15,6 +15,8 @@ import androidx.tv.material3.CardScale
 import androidx.tv.material3.CardShape
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
+import com.github.damontecres.stashapp.ui.DeviceType
+import com.github.damontecres.stashapp.ui.LocalDeviceType
 
 @Composable
 fun Card(
@@ -29,7 +31,7 @@ fun Card(
     interactionSource: MutableInteractionSource? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    if (isTvDevice) {
+    if (LocalDeviceType.current == DeviceType.TV) {
         androidx.tv.material3.Card(
             onClick = onClick,
             modifier = modifier,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/compat/ListItem.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/compat/ListItem.kt
@@ -18,6 +18,8 @@ import androidx.tv.material3.ListItemGlow
 import androidx.tv.material3.ListItemScale
 import androidx.tv.material3.ListItemShape
 import androidx.tv.material3.LocalContentColor
+import com.github.damontecres.stashapp.ui.DeviceType
+import com.github.damontecres.stashapp.ui.LocalDeviceType
 
 @Composable
 fun ListItem(
@@ -39,7 +41,7 @@ fun ListItem(
     glow: ListItemGlow = ListItemDefaults.glow(),
     interactionSource: MutableInteractionSource? = null,
 ) {
-    if (isTvDevice) {
+    if (LocalDeviceType.current == DeviceType.TV) {
         androidx.tv.material3.ListItem(
             selected = selected,
             onClick = onClick,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/compat/TvUtils.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/compat/TvUtils.kt
@@ -5,10 +5,19 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.util.Log
+import androidx.compose.runtime.Composable
 import com.github.damontecres.stashapp.StashApplication
+import com.github.damontecres.stashapp.ui.DeviceType
+import com.github.damontecres.stashapp.ui.LocalDeviceType
+
+val isTvDevice: Boolean
+    @Composable get() = LocalDeviceType.current == DeviceType.TV
+
+val isNotTvDevice: Boolean
+    @Composable get() = !isTvDevice
 
 // TODO make this a preference?
-val isTvDevice by lazy {
+val detectTvDevice by lazy {
     val context = StashApplication.getApplication()
     val pm = context.packageManager
     val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
@@ -21,5 +30,3 @@ val isTvDevice by lazy {
     Log.i("isTvDevice", "isTvDevice=$isTvDevice")
     isTvDevice
 }
-
-val isNotTvDevice = !isTvDevice

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/EditTextBox.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/EditTextBox.kt
@@ -36,8 +36,8 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
-import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.Material3AppTheme
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Button
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -191,7 +191,7 @@ fun SearchEditTextBox(
 @Preview
 @Composable
 private fun EditTextBoxPreview() {
-    AppTheme(true) {
+    PreviewTheme {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier =

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/Rating.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/Rating.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -59,8 +60,8 @@ import androidx.tv.material3.Text
 import androidx.tv.material3.surfaceColorAtElevation
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.ui.AppColors
-import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Button
 import com.github.damontecres.stashapp.ui.compat.isTvDevice
 import com.github.damontecres.stashapp.ui.tryRequestFocus
@@ -89,7 +90,8 @@ enum class StarRatingPrecision {
 val FilledStarColor = Color(0xFFFFC700)
 val EmptyStarColor = Color(0x2AFFC700)
 
-val ratingBarHeight = if (isTvDevice) 32.dp else 48.dp
+val ratingBarHeight: Dp
+    @Composable get() = if (isTvDevice) 32.dp else 48.dp
 
 @Composable
 fun Rating100(
@@ -413,7 +415,7 @@ fun DecimalRating(
 @Preview
 @Composable
 private fun StarRatingPreview() {
-    AppTheme {
+    PreviewTheme {
         val bgColor = AppColors.TransparentBlack75
         Column(modifier = Modifier.background(Color.DarkGray)) {
             var rating by remember { mutableIntStateOf(50) }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/SliderBar.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/SliderBar.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
-import com.github.damontecres.stashapp.ui.DefaultTheme
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.util.handleDPadKeyEvents
 
 @Composable
@@ -114,7 +114,7 @@ fun SliderBar(
 @Preview
 @Composable
 private fun SliderBarPreview() {
-    DefaultTheme {
+    PreviewTheme {
         Column {
             SliderBar(
                 value = 40,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/SwitchWithLabel.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/SwitchWithLabel.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Switch
 import androidx.tv.material3.Text
-import com.github.damontecres.stashapp.ui.AppTheme
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Button
 
 @Composable
@@ -84,7 +84,7 @@ fun SwitchWithLabel(
 @Preview
 @Composable
 private fun SwitchWithLabelPreview() {
-    AppTheme(forceDark = true) {
+    PreviewTheme {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Button(onClick = {}) { Text(text = "Create Filter") }
             SwitchWithLabel(

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageControlsOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageControlsOverlay.kt
@@ -32,8 +32,8 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
-import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.FontAwesome
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Button
 import com.github.damontecres.stashapp.ui.components.OCounterButton
 import com.github.damontecres.stashapp.ui.tryRequestFocus
@@ -212,7 +212,7 @@ fun ImageControlButton(
 @Preview(widthDp = 800)
 @Composable
 private fun ImageControlsOverlayPreview() {
-    AppTheme {
+    PreviewTheme {
         ImageControlsOverlay(
             isImageClip = false,
             oCount = 10,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageFilterSliders.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/image/ImageFilterSliders.kt
@@ -31,7 +31,8 @@ import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.data.VideoFilter
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
-import com.github.damontecres.stashapp.ui.DefaultTheme
+import com.github.damontecres.stashapp.ui.DeviceType
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Button
 import com.github.damontecres.stashapp.ui.compat.isTvDevice
 import com.github.damontecres.stashapp.ui.components.SliderBar
@@ -280,7 +281,7 @@ fun ImageFilterDialog(
 @Preview
 @Composable
 private fun ImageFilterSlidersPreview() {
-    DefaultTheme {
+    PreviewTheme(DeviceType.TV) {
         ImageFilterSliders(
             filter = VideoFilter(),
             showVideoOptions = true,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/main/MainPageImageDetails.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/main/MainPageImageDetails.kt
@@ -28,8 +28,8 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.fragment.ImageData
-import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.components.DotSeparatedRow
 import com.github.damontecres.stashapp.ui.components.Rating100
 import com.github.damontecres.stashapp.ui.components.TitleValueText
@@ -165,7 +165,7 @@ fun MainPageImageDetails(
 @Preview(device = "spec:parent=tv_1080p", backgroundColor = 0xFF383535)
 @Composable
 private fun MainPageImageDetailsPreview() {
-    AppTheme {
+    PreviewTheme {
         MainPageImageDetails(
             image = imagePreview,
             uiConfig = uiConfigPreview,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/main/MainPageSceneDetails.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/main/MainPageSceneDetails.kt
@@ -28,8 +28,8 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
-import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.components.DotSeparatedRow
 import com.github.damontecres.stashapp.ui.components.Rating100
 import com.github.damontecres.stashapp.ui.components.TitleValueText
@@ -167,7 +167,7 @@ fun MainPageSceneDetails(
 @Preview(device = "spec:parent=tv_1080p", backgroundColor = 0xFF383535)
 @Composable
 private fun MainPageSceneDetailsPreview() {
-    AppTheme {
+    PreviewTheme {
         MainPageSceneDetails(
             scene = slimScenePreview,
             uiConfig = uiConfigPreview,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
@@ -64,7 +64,7 @@ import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.data.Scene
 import com.github.damontecres.stashapp.playback.TrackSupport
 import com.github.damontecres.stashapp.ui.AppColors
-import com.github.damontecres.stashapp.ui.AppTheme
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Button
 import com.github.damontecres.stashapp.ui.compat.ListItem
 import com.github.damontecres.stashapp.ui.compat.isTvDevice
@@ -667,7 +667,7 @@ private fun BottomDialog(
 @Preview
 @Composable
 private fun PlaybackButtonsPreview() {
-    AppTheme {
+    PreviewTheme {
         PlaybackButtons(
             player = FakePlayerControls,
             initialFocusRequester = FocusRequester(),
@@ -682,7 +682,7 @@ private fun PlaybackButtonsPreview() {
 @Preview
 @Composable
 private fun RightPlaybackButtonsPreview() {
-    AppTheme {
+    PreviewTheme {
         RightPlaybackButtons(
             captions = listOf(),
             onControllerInteraction = {},

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
@@ -69,8 +69,8 @@ import com.github.damontecres.stashapp.playback.TrackSupportReason
 import com.github.damontecres.stashapp.playback.TrackType
 import com.github.damontecres.stashapp.playback.TranscodeDecision
 import com.github.damontecres.stashapp.ui.AppColors
-import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.cards.RootCard
 import com.github.damontecres.stashapp.ui.compat.isNotTvDevice
 import com.github.damontecres.stashapp.ui.components.StarRatingPrecision
@@ -564,7 +564,7 @@ fun BasicMarkerCard(
 @Preview(device = "spec:parent=tv_1080p", backgroundColor = 0xFF383535)
 @Composable
 private fun PlaybackOverlayPreview() {
-    AppTheme {
+    PreviewTheme {
         val controllerViewState = ControllerViewState(3000, true)
         controllerViewState.showControls(Int.MAX_VALUE)
         PlaybackOverlay(

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
@@ -454,10 +454,12 @@ fun PlaybackPageContent(
 
     val isMarkerPlaylist = playlistPager?.filter?.dataType == DataType.MARKER
 
+    val isTvDevice = isTvDevice
+
     LaunchedEffect(Unit) {
         viewModel.init(server, markersEnabled, uiConfig.persistVideoFilters, useVideoFilters)
         viewModel.changeScene(playlist[currentPlaylistIndex].localConfiguration!!.tag as PlaylistFragment.MediaItemTag)
-        if (isNotTvDevice) {
+        if (!isTvDevice) {
             viewModel.videoFilter.startThrottling(DRAG_THROTTLE_DELAY)
         }
         maybeMuteAudio(context, false, player)
@@ -668,6 +670,7 @@ fun PlaybackPageContent(
     val playbackKeyHandler =
         remember {
             PlaybackKeyHandler(
+                isTvDevice = isTvDevice,
                 player = player,
                 controlsEnabled = controlsEnabled,
                 skipWithLeftRight = skipWithLeftRight,
@@ -1002,6 +1005,7 @@ fun Player.setupFinishedBehavior(
 }
 
 class PlaybackKeyHandler(
+    private val isTvDevice: Boolean,
     private val player: Player,
     private val controlsEnabled: Boolean,
     private val skipWithLeftRight: Boolean,
@@ -1070,7 +1074,7 @@ class PlaybackKeyHandler(
         } else if (it.key == Key.Back && controllerViewState.controlsVisible) {
             // TODO change this to a BackHandler?
             controllerViewState.hideControls()
-            if (isNotTvDevice) {
+            if (!isTvDevice) {
                 // Allow to propagate up
                 result = false
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistList.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaylistList.kt
@@ -34,7 +34,7 @@ import androidx.tv.material3.Text
 import coil3.compose.AsyncImage
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.data.PlaylistItem
-import com.github.damontecres.stashapp.ui.AppTheme
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Card
 import com.github.damontecres.stashapp.ui.enableMarquee
 import com.github.damontecres.stashapp.ui.tryRequestFocus
@@ -186,7 +186,7 @@ fun PlaylistItemCompose(
 @Preview(widthDp = 600)
 @Composable
 private fun PlaylistItemPreview() {
-    AppTheme {
+    PreviewTheme {
         PlaylistList(
             mediaItemCount = 10,
             mediaItemCountOffset = 0,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/SkipIndicator.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/SkipIndicator.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.sp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
-import com.github.damontecres.stashapp.ui.AppTheme
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.util.ifElse
 import kotlin.math.abs
 
@@ -71,7 +71,7 @@ fun SkipIndicator(
 @Preview
 @Composable
 private fun SkipIndicatorPreview() {
-    AppTheme {
+    PreviewTheme {
         SkipIndicator(-3000L, {}, Modifier)
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/ScenePlayButton.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/ScenePlayButton.kt
@@ -30,7 +30,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.playback.PlaybackMode
-import com.github.damontecres.stashapp.ui.AppTheme
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Button
 import com.github.damontecres.stashapp.ui.components.EditButton
 import com.github.damontecres.stashapp.ui.components.OCounterButton
@@ -177,7 +177,7 @@ fun PlayButton(
 @Preview(widthDp = 800)
 @Composable
 private fun PlayButtonsPreview() {
-    AppTheme {
+    PreviewTheme {
         PlayButtons(
             resumePosition = 1000L,
             oCount = 10,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/server/AddServerContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/server/AddServerContent.kt
@@ -45,7 +45,7 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
-import com.github.damontecres.stashapp.ui.AppTheme
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Button
 import com.github.damontecres.stashapp.ui.components.CircularProgress
 import com.github.damontecres.stashapp.ui.components.EditTextBox
@@ -457,7 +457,7 @@ fun AllowSelfSignedCertsDialog(
 @Preview
 @Composable
 private fun AddServerPreview() {
-    AppTheme {
+    PreviewTheme {
         AllowSelfSignedCertsDialog(
             {},
             {},

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/server/ConfigurePin.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/server/ConfigurePin.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
-import com.github.damontecres.stashapp.ui.AppTheme
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.compat.Button
 import com.github.damontecres.stashapp.ui.components.EditTextBox
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
@@ -147,7 +147,7 @@ fun ConfigurePin(
 @Preview
 @Composable
 private fun ConfigurePinPreview() {
-    AppTheme {
+    PreviewTheme {
         ConfigurePin(
             {},
             {},

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/server/InitialSetup.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/server/InitialSetup.kt
@@ -36,6 +36,7 @@ fun InitialSetup(
 
     var server by remember { mutableStateOf<StashServer?>(null) }
     var showPinDialog by remember { mutableStateOf(false) }
+    val isNotTvDevice = isNotTvDevice
 
     fun submit(pin: String?) {
         server?.let {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/ChooseThemePage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/ChooseThemePage.kt
@@ -48,8 +48,8 @@ import com.github.damontecres.stashapp.navigation.Destination
 import com.github.damontecres.stashapp.navigation.NavigationListener
 import com.github.damontecres.stashapp.navigation.NavigationManager
 import com.github.damontecres.stashapp.presenters.ScenePresenter
-import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.cards.IconRowText
 import com.github.damontecres.stashapp.ui.cards.ImageOverlay
 import com.github.damontecres.stashapp.ui.cards.RootCard
@@ -340,7 +340,7 @@ fun deleteJson(
 @Preview
 @Composable
 private fun ChooseThemePagePreview() {
-    AppTheme {
+    PreviewTheme {
         ChooseThemePage(
             server = StashServer("0.0.0.0", null),
             navigationManager =

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/ImagePage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/ImagePage.kt
@@ -111,6 +111,7 @@ fun ImagePage(
     viewModel: ImageDetailsViewModel = viewModel(),
 ) {
     val context = LocalContext.current
+    val isNotTvDevice = isNotTvDevice
     LaunchedEffect(server, filter) {
         val slideshowDelay =
             PreferenceManager.getDefaultSharedPreferences(context).getInt(

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PerformerPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PerformerPage.kt
@@ -62,10 +62,10 @@ import com.github.damontecres.stashapp.navigation.Destination
 import com.github.damontecres.stashapp.navigation.NavigationListener
 import com.github.damontecres.stashapp.navigation.NavigationManager
 import com.github.damontecres.stashapp.suppliers.FilterArgs
-import com.github.damontecres.stashapp.ui.AppTheme
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.GlobalContext
 import com.github.damontecres.stashapp.ui.LocalGlobalContext
+import com.github.damontecres.stashapp.ui.PreviewTheme
 import com.github.damontecres.stashapp.ui.components.BasicItemInfo
 import com.github.damontecres.stashapp.ui.components.DialogItem
 import com.github.damontecres.stashapp.ui.components.DialogPopup
@@ -685,34 +685,33 @@ private fun PerformerDetailsPreview() {
     val longClicker =
         LongClicker<Any> { item, filterAndPosition ->
         }
+    PreviewTheme {
+        CompositionLocalProvider(
+            LocalGlobalContext provides
+                GlobalContext(
+                    StashServer("http://0.0.0.0", null),
+                    object : NavigationManager {
+                        override var previousDestination: Destination?
+                            get() = null
+                            set(value) {}
 
-    CompositionLocalProvider(
-        LocalGlobalContext provides
-            GlobalContext(
-                StashServer("http://0.0.0.0", null),
-                object : NavigationManager {
-                    override var previousDestination: Destination?
-                        get() = null
-                        set(value) {}
+                        override fun navigate(destination: Destination) {
+                        }
 
-                    override fun navigate(destination: Destination) {
-                    }
+                        override fun goBack() {
+                        }
 
-                    override fun goBack() {
-                    }
+                        override fun goToMain() {
+                        }
 
-                    override fun goToMain() {
-                    }
+                        override fun clearPinFragment() {
+                        }
 
-                    override fun clearPinFragment() {
-                    }
-
-                    override fun addListener(listener: NavigationListener) {
-                    }
-                },
-            ),
-    ) {
-        AppTheme {
+                        override fun addListener(listener: NavigationListener) {
+                        }
+                    },
+                ),
+        ) {
             PerformerDetails(
                 perf = performer,
                 tags = listOf(tagPreview, tagPreview.copy(id = "723")),


### PR DESCRIPTION
Fixes previews by moving the `isTvDevice` detection to be provided by a composition local instead of being used directly so that previews can set it without relying on Android framework code.

No user facing changes