### PR TITLE
Fix playback activity tracking during playlists

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/TrackActivityPlaybackListener.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/TrackActivityPlaybackListener.kt
@@ -26,7 +26,7 @@ import kotlin.time.Duration.Companion.seconds
 class TrackActivityPlaybackListener(
     private val server: StashServer,
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
-    private val scene: Scene,
+    val scene: Scene,
     private val getCurrentPosition: () -> Long,
 ) : Player.Listener {
     private val mutationEngine = MutationEngine(server)
@@ -74,12 +74,13 @@ class TrackActivityPlaybackListener(
     }
 
     fun release() {
+        Log.v(TAG, "release for scene=${scene.id}")
         task.cancel()
         TIMER.purge()
     }
 
     fun release(position: Long) {
-        Log.v(TAG, "release: position=$position")
+        Log.v(TAG, "release: scene=${scene.id}, position=$position")
         release()
         if (position >= 0) {
             saveSceneActivity(position, currentDurationMilliseconds.getAndSet(0))


### PR DESCRIPTION
A user reported this on discord. If activity tracking is enabled, when playing a playlist of scenes, as you moved to the next scene, the activity tracker would report activity for the previous scenes when it should have stopped.

The actual issue was that `trackActivityListener` was not stored in a `mutableStateOf`, so re-compositions destroyed the reference. Then when going to teh next scene, the code to cancel tracking for the previous scene thought there was no `trackActivityListener` since the reference was lost.

This PR moves the `trackActivityListener` into the view model which more accurately follows the lifecycle of the entire playlist and movement between scenes.