### PR TITLE
Catch exceptions when migrating settings

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/prefs/ComposablePreference.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/prefs/ComposablePreference.kt
@@ -104,8 +104,9 @@ fun <T> ComposablePreference(
 
                 StashPreference.MigratePreferences -> {
                     scope.launch(StashCoroutineExceptionHandler(autoToast = true)) {
-                        AppUpgradeHandler.migratePreferences(context)
-                        Toast.makeText(context, "Settings migrated", Toast.LENGTH_LONG).show()
+                        if (AppUpgradeHandler.migratePreferences(context)) {
+                            Toast.makeText(context, "Settings migrated", Toast.LENGTH_LONG).show()
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/prefs/PreferencesContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/prefs/PreferencesContent.kt
@@ -129,7 +129,7 @@ val uiPreferences =
                 StashPreference.ShowProgressSkipping,
                 StashPreference.MovementSound,
                 StashPreference.UpDownNextPrevious,
-                StashPreference.Captions,
+                StashPreference.CaptionsOnByDefault,
                 StashPreference.ThemeStylePref,
                 StashPreference.ChooseTheme,
             ),

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/prefs/StashPreference.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/prefs/StashPreference.kt
@@ -421,7 +421,7 @@ sealed interface StashPreference<T> {
             StashChoicePreference<ThemeStyle>(
                 title = R.string.theme_style_preference_title,
                 prefKey = R.string.pref_key_ui_theme_dark_appearance,
-                defaultValue = ThemeStyle.SYSTEM,
+                defaultValue = ThemeStyle.DARK,
                 displayValues = R.array.ui_theme_dark_appearance_choices,
                 indexToValue = {
                     ThemeStyle.forNumber(it)
@@ -501,7 +501,7 @@ sealed interface StashPreference<T> {
                 summaryOff = R.string.transcode_options_disabled,
             )
 
-        val Captions =
+        val CaptionsOnByDefault =
             StashSwitchPreference(
                 title = R.string.captions_default,
                 prefKey = R.string.pref_key_captions_on_by_default,

--- a/app/src/main/java/com/github/damontecres/stashapp/util/StashPreferencesSerializer.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/StashPreferencesSerializer.kt
@@ -14,7 +14,6 @@ import com.github.damontecres.stashapp.proto.SearchPreferences
 import com.github.damontecres.stashapp.proto.StashPreferences
 import com.github.damontecres.stashapp.proto.StreamChoice
 import com.github.damontecres.stashapp.proto.TabPreferences
-import com.github.damontecres.stashapp.proto.ThemeStyle
 import com.github.damontecres.stashapp.proto.UpdatePreferences
 import com.github.damontecres.stashapp.ui.components.prefs.StashPreference
 import com.google.protobuf.InvalidProtocolBufferException
@@ -31,26 +30,30 @@ object StashPreferencesSerializer : Serializer<StashPreferences> {
                     InterfacePreferences
                         .newBuilder()
                         .apply {
-                            useComposeUi = true
-                            cardSize = 5
-                            playVideoPreviews = true
-                            rememberSelectedTab = true
-                            cardPreviewDelayMs = 1000
-                            slideShowIntervalMs = 5000
-                            slideShowImageClipPauseMs = 250
-                            showGridJumpButtons = true
+                            useComposeUi = StashPreference.UseNewUI.defaultValue
+                            cardSize = StashPreference.CardSize.defaultValue
+                            playVideoPreviews = StashPreference.PlayVideoPreviews.defaultValue
+                            rememberSelectedTab = StashPreference.RememberTab.defaultValue
+                            cardPreviewDelayMs =
+                                StashPreference.VideoPreviewDelay.defaultValue.toLong()
+                            slideShowIntervalMs =
+                                StashPreference.SlideshowDuration.defaultValue.seconds.inWholeMilliseconds
+                            slideShowImageClipPauseMs =
+                                StashPreference.SlideshowImageClipDelay.defaultValue.toLong()
+                            showGridJumpButtons = StashPreference.GridJumpButtons.defaultValue
                             theme = "default"
-                            themeStyle = ThemeStyle.DARK
-                            showProgressWhenSkipping = true
-                            playMovementSounds = true
-                            captionsByDefault = true
-                            scrollNextViewAll = true
-                            scrollTopOnBack = true
-                            showPositionFooter = true
-                            showRatingOnCards = true
-                            videoPreviewAudio = false
-                            pageWithRemoteButtons = true
-                            dpadSkipIndicator = true
+                            themeStyle = StashPreference.ThemeStylePref.defaultValue
+                            showProgressWhenSkipping =
+                                StashPreference.ShowProgressSkipping.defaultValue
+                            playMovementSounds = StashPreference.MovementSound.defaultValue
+                            captionsByDefault = StashPreference.CaptionsOnByDefault.defaultValue
+                            scrollNextViewAll = StashPreference.ScrollViewAll.defaultValue
+                            scrollTopOnBack = StashPreference.ScrollTopOnBack.defaultValue
+                            showPositionFooter = StashPreference.ShowGridFooter.defaultValue
+                            showRatingOnCards = StashPreference.ShowCardRating.defaultValue
+                            videoPreviewAudio = StashPreference.PlayCardAudio.defaultValue
+                            pageWithRemoteButtons = StashPreference.PageRemoteButtons.defaultValue
+                            dpadSkipIndicator = StashPreference.DPadSkipIndicator.defaultValue
                             tabPreferences =
                                 TabPreferences
                                     .newBuilder()
@@ -66,12 +69,14 @@ object StashPreferencesSerializer : Serializer<StashPreferences> {
                     PlaybackPreferences
                         .newBuilder()
                         .apply {
-                            skipForwardMs = 30.seconds.inWholeMilliseconds
-                            skipBackwardMs = 10.seconds.inWholeMilliseconds
-                            dpadSkipping = true
-                            controllerTimeoutMs = 3500
-                            savePlayHistory = true
-                            saveVideoFilters = true
+                            skipForwardMs =
+                                StashPreference.SkipForward.defaultValue.seconds.inWholeMilliseconds
+                            skipBackwardMs =
+                                StashPreference.SkipBack.defaultValue.seconds.inWholeMilliseconds
+                            dpadSkipping = StashPreference.DPadSkipping.defaultValue
+                            controllerTimeoutMs = StashPreference.ControllerTimeout.defaultValue
+                            savePlayHistory = StashPreference.SavePlayHistory.defaultValue
+                            saveVideoFilters = StashPreference.VideoFilter.defaultValue
                             seekBarSteps = 16
 
                             addAllDirectPlayVideo(StashPreference.DirectPlayVideo.defaultValue)
@@ -82,31 +87,34 @@ object StashPreferencesSerializer : Serializer<StashPreferences> {
                     UpdatePreferences
                         .newBuilder()
                         .apply {
-                            checkForUpdates = true
-                            updateUrl = "https://api.github.com/repos/damontecres/StashAppAndroidTV/releases/latest"
+                            checkForUpdates = StashPreference.AutoCheckForUpdates.defaultValue
+                            updateUrl = StashPreference.UpdateUrl.defaultValue
                         }.build()
                 advancedPreferences =
                     AdvancedPreferences
                         .newBuilder()
                         .apply {
-                            logErrorsToServer = true
-                            networkTimeoutMs = 15.seconds.inWholeMilliseconds
-                            imageThreadCount = Runtime.getRuntime().availableProcessors()
+                            logErrorsToServer = StashPreference.LogErrorsToServer.defaultValue
+                            networkTimeoutMs =
+                                StashPreference.NetworkTimeout.defaultValue.seconds.inWholeMilliseconds
+                            imageThreadCount = StashPreference.ImageThreads.defaultValue
                         }.build()
                 cachePreferences =
                     CachePreferences
                         .newBuilder()
                         .apply {
-                            imageDiskCacheSize = 100 * 1024 * 1024 // 100 MB
-                            networkCacheSize = 10 * 1024 * 1024 // 10 MB
-                            cacheExpirationTime = 6 // TODO
+                            imageDiskCacheSize =
+                                StashPreference.ImageDiskCache.defaultValue * 1024L * 1024L
+                            networkCacheSize =
+                                StashPreference.NetworkCache.defaultValue * 1024L * 1024L
+                            cacheExpirationTime = StashPreference.CacheInvalidation.defaultValue
                         }.build()
                 searchPreferences =
                     SearchPreferences
                         .newBuilder()
                         .apply {
-                            maxResults = 25
-                            searchDelayMs = 1000
+                            maxResults = StashPreference.SearchResults.defaultValue
+                            searchDelayMs = StashPreference.SearchDelay.defaultValue.toLong()
                         }.build()
             }.build()
 


### PR DESCRIPTION
Catch exceptions during settings migrations so one error doesn't block the whole process.

Also the default settings creation now uses the preference objects for default values.