### PR TITLE
Fix setting rating to 1 star

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/Cards.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/Cards.kt
@@ -118,7 +118,7 @@ fun ImageOverlay(
     val showRatings = LocalGlobalContext.current.preferences.interfacePreferences.showRatingOnCards
 
     Box(modifier = modifier.fillMaxSize()) {
-        if (showRatings && rating100 != null && rating100 >= 0) {
+        if (showRatings && rating100 != null && rating100 > 0) {
             val ratingText = getRatingAsDecimalString(rating100, ratingsAsStars)
             val text = context.getString(R.string.stashapp_rating) + ": $ratingText"
             val ratingColors = context.resources.obtainTypedArray(R.array.rating_colors)

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/Rating.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/Rating.kt
@@ -248,7 +248,9 @@ fun StarRating(
                                                 if (playSoundOnFocus) playOnClickSound(context)
                                                 val newRating100 =
                                                     when (precision) {
-                                                        StarRatingPrecision.FULL -> i * 20
+                                                        StarRatingPrecision.FULL ->
+                                                            if (i == 1 && rating100 > 0 && rating100 <= 20) 0 else i * 20
+
                                                         StarRatingPrecision.HALF -> {
                                                             if (rating100 > i * 20) {
                                                                 i * 20
@@ -256,7 +258,11 @@ fun StarRating(
                                                                 i * 20 - 10
                                                             } else if (rating100 == i * 20 - 10) {
                                                                 (i - 1) * 20
-                                                            } else if (i == 1 && rating100 < 20) {
+                                                            } else if (i == 1 && rating100 == 0) {
+                                                                20
+                                                            } else if (i == 1 && rating100 > 10) {
+                                                                10
+                                                            } else if (i == 1 && rating100 <= 10) {
                                                                 0
                                                             } else {
                                                                 (i) * 20


### PR DESCRIPTION
Fixes being unable to set the rating to 1 (or half) star

Also the rating is no longer shown on cards if it is zero (or null/unset)