### PR TITLE
Display group scene index on cards

### DIFF
--- a/app/src/main/graphql/FindScenes.graphql
+++ b/app/src/main/graphql/FindScenes.graphql
@@ -72,6 +72,7 @@ fragment SlimSceneData on Scene {
     image_path
   }
   groups {
+    scene_index
     group {
       id
       name

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/Cards.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/Cards.kt
@@ -495,6 +495,7 @@ fun StashCard(
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
     modifier: Modifier = Modifier,
+    cardContext: CardContext = CardContext.None,
 ) {
     when (item) {
         is SlimSceneData? ->
@@ -505,6 +506,7 @@ fun StashCard(
                 longClicker,
                 getFilterAndPosition,
                 modifier,
+                cardContext = cardContext as? CardContext.SceneCardContext,
             )
 
         is FullSceneData? ->
@@ -515,6 +517,7 @@ fun StashCard(
                 longClicker,
                 getFilterAndPosition,
                 modifier,
+                cardContext = cardContext as? CardContext.SceneCardContext,
             )
 
         is PerformerData? ->
@@ -565,6 +568,7 @@ fun StashCard(
                 longClicker,
                 getFilterAndPosition,
                 modifier,
+                cardContext = cardContext as? CardContext.GroupCardContext,
             )
 
         is GroupRelationshipData? -> {
@@ -634,4 +638,21 @@ fun StashCard(
 
         else -> throw UnsupportedOperationException("Item with class ${item?.javaClass} not supported.")
     }
+}
+
+/**
+ * Context about where this card is being shown to alter its display
+ */
+interface CardContext {
+    data object None : CardContext
+
+    data class SceneCardContext(
+        // If listing scenes of a group, this is the group id
+        val sceneInGroupId: String,
+    ) : CardContext
+
+    data class GroupCardContext(
+        // If listing groups that a scene is in, this is the scene's index
+        val indexInGroup: Int?,
+    ) : CardContext
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/GroupCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/GroupCard.kt
@@ -1,5 +1,7 @@
 package com.github.damontecres.stashapp.ui.cards
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -7,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Text
@@ -30,6 +33,7 @@ fun GroupCard(
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
     modifier: Modifier = Modifier,
     subtitle: String? = null,
+    cardContext: CardContext.GroupCardContext? = null,
 ) {
     val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
     item?.let {
@@ -57,7 +61,16 @@ fun GroupCard(
         videoUrl = null,
         title = AnnotatedString(title),
         subtitle = {
-            Text(details)
+            Column {
+                Text(details)
+                cardContext?.indexInGroup?.let { index ->
+                    Text(
+                        text = "#$index in group",
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
         },
         description = { focused ->
             item?.let {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/SceneCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/SceneCard.kt
@@ -2,6 +2,7 @@ package com.github.damontecres.stashapp.ui.cards
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -13,8 +14,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -41,6 +44,7 @@ fun SceneCard(
     longClicker: LongClicker<Any>,
     getFilterAndPosition: ((item: Any) -> FilterAndPosition)?,
     modifier: Modifier = Modifier,
+    cardContext: CardContext.SceneCardContext? = null,
 ) {
     val dataTypeMap = EnumMap<DataType, Int>(DataType::class.java)
     item?.let {
@@ -67,7 +71,22 @@ fun SceneCard(
         defaultImageDrawableRes = R.drawable.default_scene,
         videoUrl = item?.paths?.preview,
         title = AnnotatedString(item?.titleOrFilename ?: ""),
-        subtitle = { Text(item?.date ?: "") },
+        subtitle = {
+            Column {
+                Text(item?.date ?: "")
+                cardContext?.let {
+                    val index =
+                        item?.groups?.firstOrNull { cardContext.sceneInGroupId == it.group.id }?.scene_index
+                    if (index != null) {
+                        Text(
+                            text = stringResource(R.string.stashapp_scene) + " #$index",
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        },
         description = {
             IconRowText(
                 dataTypeMap,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/StashGrid.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/StashGrid.kt
@@ -66,6 +66,7 @@ import com.github.damontecres.stashapp.ui.AppColors
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.FontAwesome
 import com.github.damontecres.stashapp.ui.LocalGlobalContext
+import com.github.damontecres.stashapp.ui.cards.CardContext
 import com.github.damontecres.stashapp.ui.cards.StashCard
 import com.github.damontecres.stashapp.ui.compat.Button
 import com.github.damontecres.stashapp.ui.compat.isNotTvDevice
@@ -119,6 +120,7 @@ fun StashGridControls(
     onSubToggleCheck: ((Boolean) -> Unit)? = null,
     subToggleChecked: Boolean = false,
     subToggleEnabled: Boolean = true,
+    cardContext: ((index: Int, item: StashData) -> CardContext)? = null,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -301,6 +303,7 @@ fun StashGridControls(
                 positionCallback?.invoke(columns, position)
             },
             gridFocusRequester = gridFocusRequester,
+            cardContext = cardContext,
             modifier =
                 Modifier
                     .fillMaxSize()
@@ -339,6 +342,7 @@ fun StashGrid(
     modifier: Modifier = Modifier,
     initialPosition: Int = 0,
     positionCallback: ((columns: Int, position: Int) -> Unit)? = null,
+    cardContext: ((index: Int, item: StashData) -> CardContext)? = null,
 ) {
     val orientation = LocalConfiguration.current.orientation
     val navigationManager = LocalGlobalContext.current.navigationManager
@@ -640,6 +644,9 @@ fun StashGrid(
                                 index,
                             )
                         },
+                        cardContext =
+                            item?.let { cardContext?.invoke(index, item) }
+                                ?: CardContext.None,
                     )
                 }
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/TabPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/TabPage.kt
@@ -36,6 +36,7 @@ import androidx.tv.material3.TabRow
 import androidx.tv.material3.Text
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.StashApplication
+import com.github.damontecres.stashapp.api.fragment.StashData
 import com.github.damontecres.stashapp.data.DataType
 import com.github.damontecres.stashapp.data.StashFindFilter
 import com.github.damontecres.stashapp.navigation.Destination
@@ -44,6 +45,7 @@ import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.FilterViewModel
 import com.github.damontecres.stashapp.ui.LocalGlobalContext
+import com.github.damontecres.stashapp.ui.cards.CardContext
 import com.github.damontecres.stashapp.ui.compat.isTvDevice
 import com.github.damontecres.stashapp.ui.filterArgsSaver
 import com.github.damontecres.stashapp.ui.tryRequestFocus
@@ -258,6 +260,7 @@ fun StashGridTab(
     onSubToggleCheck: ((Boolean) -> Unit)? = null,
     subToggleChecked: Boolean = false,
     subToggleEnabled: Boolean = true,
+    cardContext: ((index: Int, item: StashData) -> CardContext)? = null,
 ) {
     val navigationManager = LocalGlobalContext.current.navigationManager
     LaunchedEffect(server, initialFilter) {
@@ -290,6 +293,7 @@ fun StashGridTab(
             subToggleChecked = subToggleChecked,
             subToggleEnabled = subToggleEnabled,
             requestFocus = false,
+            cardContext = cardContext,
         )
     }
 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsBody.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/scene/SceneDetailsBody.kt
@@ -2,6 +2,7 @@ package com.github.damontecres.stashapp.ui.components.scene
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.github.damontecres.stashapp.R
@@ -13,6 +14,8 @@ import com.github.damontecres.stashapp.api.fragment.PerformerData
 import com.github.damontecres.stashapp.api.fragment.SlimSceneData
 import com.github.damontecres.stashapp.api.fragment.TagData
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
+import com.github.damontecres.stashapp.ui.cards.CardContext
+import com.github.damontecres.stashapp.ui.cards.GroupCard
 import com.github.damontecres.stashapp.ui.cards.PerformerCard
 import com.github.damontecres.stashapp.ui.components.FocusPair
 import com.github.damontecres.stashapp.ui.components.ItemOnClicker
@@ -70,6 +73,24 @@ fun LazyListScope.sceneDetailsBody(
                 modifier =
                     androidx.compose.ui.Modifier
                         .padding(start = startPadding, bottom = bottomPadding),
+                itemContent = { uiConfig, item, itemOnClick, longClicker, getFilterAndPosition, cardModifier ->
+                    val index =
+                        remember { scene.groups.firstOrNull { it.group.groupData.id == item.id }?.scene_index }
+                    GroupCard(
+                        uiConfig = uiConfig,
+                        item = item,
+                        onClick = {
+                            itemOnClick.onClick(
+                                item,
+                                getFilterAndPosition?.invoke(item),
+                            )
+                        },
+                        longClicker = longClicker,
+                        getFilterAndPosition = getFilterAndPosition,
+                        modifier = cardModifier,
+                        cardContext = CardContext.GroupCardContext(index),
+                    )
+                },
             )
         }
     }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/GroupPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/GroupPage.kt
@@ -50,6 +50,7 @@ import com.github.damontecres.stashapp.suppliers.DataSupplierOverride
 import com.github.damontecres.stashapp.suppliers.FilterArgs
 import com.github.damontecres.stashapp.ui.ComposeUiConfig
 import com.github.damontecres.stashapp.ui.LocalGlobalContext
+import com.github.damontecres.stashapp.ui.cards.CardContext
 import com.github.damontecres.stashapp.ui.components.ItemDetailsFooter
 import com.github.damontecres.stashapp.ui.components.ItemOnClicker
 import com.github.damontecres.stashapp.ui.components.ItemsRow
@@ -170,6 +171,8 @@ fun GroupPage(
                 ),
             )
         }
+        val cardContext =
+            remember(group.id) { CardContext.SceneCardContext(sceneInGroupId = group.id) }
         val scenesTab =
             remember(scenesFilter, scenesSubTags) {
                 TabProvider(
@@ -189,6 +192,7 @@ fun GroupPage(
                         subToggleChecked = scenesSubTags,
                         composeUiConfig = uiConfig,
                         onFilterChange = { scenesFilter = it },
+                        cardContext = { _, _ -> cardContext },
                     )
                 }
             }

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -503,6 +503,7 @@ val FullSceneData.asSlimeSceneData: SlimSceneData
             groups =
                 this.groups.map {
                     SlimSceneData.Group(
+                        it.scene_index,
                         SlimSceneData.Group1(
                             it.group.groupData.id,
                             it.group.groupData.name,


### PR DESCRIPTION
When viewing a group's scenes, the scene cards will show the index within the group.

And on scene details, if it's part of any groups, the group cards will show the scene's index in that group.