### PR TITLE
Fix crash in forced transcoding when building playlists

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/StreamUtils.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/StreamUtils.kt
@@ -273,7 +273,7 @@ fun checkIfAlwaysTranscode(
                     regex.find(stream)?.let { Pair(stream, it.groups[1]!!.value.toInt()) }
                 }.sortedByDescending { it.second }
         val streamKey = candidateStreams.firstOrNull { it.second <= maxRes }?.first
-        return streams[streamKey]
+        return streamKey
     } else {
         return null
     }


### PR DESCRIPTION
I've been experiencing frequent crashing after upgrading to 0.8.1. Turns out it was related to the recent forced transcoding changes in [`4ea91f16`](https://github.com/damontecres/StashAppAndroidTV/commit/4ea91f16b687215493bfd6016301574f3c92cdb2).

The rewrite of `checkIfAlwaysTranscode` changed [this line](https://github.com/damontecres/StashAppAndroidTV/commit/4ea91f16b687215493bfd6016301574f3c92cdb2#diff-a8330e6b2806eeffe85cb59f922836a975b2ec706beeda66669e1fab63541f88L250) to return `streams[streamKey]` (a URL) instead of `streamKey` (a map key like `"HLS Full HD (1080p)"`). That URL then gets passed as a `streamLabel` into `buildMediaItem`, which tries to use it as a key to look up the actual URL and fails.

The fix is just changing `return streams[streamKey]` to `return streamKey`.