### PR TITLE
Fix playlist playback repeating after 50 videos

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
@@ -268,10 +268,10 @@ fun PlaylistPlaybackPage(
                                 pager?.let { pager ->
                                     if (count - currentIndex < PLAYLIST_THRESHOLD && pager.size > count) {
                                         val maxIndex =
-                                            (currentIndex + PLAYLIST_PREFETCH)
+                                            (count + PLAYLIST_PREFETCH)
                                                 .coerceAtMost(pager.size)
                                         val newMediaItems =
-                                            (currentIndex..<maxIndex).mapNotNull { index ->
+                                            (count..<maxIndex).mapNotNull { index ->
                                                 pager.getBlocking(index)?.let { item ->
                                                     convertToMediaItem(
                                                         context,


### PR DESCRIPTION
For #767, this PR fixes playlist playback looping back to previously played videos after the initial batch.

The issue was in the playlist prefetch logic in `PlaylistPlaybackPage`. When the player approached the end of the loaded items and triggered a prefetch, the code used `currentIndex` (the current playback position) as the starting point for fetching new items, instead of `count` (the current playlist size). This meant:

1. Items already in the playlist were being re-fetched from the pager and appended as duplicates
2. The upper bound `currentIndex + PLAYLIST_PREFETCH` didn't extend far enough past the existing playlist, so new items beyond the initial batch were never loaded

The fix changes both the range start and upper bound to use `count`, so new items are always fetched starting from where the playlist currently ends rather than from the current playback position.

I tested locally and this does solve my issue!