### PR TITLE
Show details with menu button

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
@@ -771,6 +771,7 @@ fun PlaybackPageContent(
                 updateSkipIndicator = updateSkipIndicator,
             )
         }
+    playbackKeyHandler.onMenuKey = { showSceneDetails = true }
     Box(
         modifier
             .background(Color.Black)
@@ -1111,6 +1112,8 @@ class PlaybackKeyHandler(
     private val controllerViewState: ControllerViewState,
     private val updateSkipIndicator: (Long) -> Unit,
 ) {
+    var onMenuKey: (() -> Unit)? = null
+
     fun onKeyEvent(it: KeyEvent): Boolean {
         var result = true
         if (!controlsEnabled) {
@@ -1185,6 +1188,9 @@ class PlaybackKeyHandler(
                 // Allow to propagate up
                 result = false
             }
+        } else if (it.key == Key.Menu) {
+            controllerViewState.hideControls()
+            onMenuKey?.invoke()
         } else {
             controllerViewState.pulseControls()
             result = false

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
@@ -69,7 +69,6 @@ fun PlaybackPage(
     OneTimeLaunchedEffect { viewModel.init(server, sceneId) }
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
-    val playbackViewModel: PlaybackPageViewModel = viewModel()
 
     val playbackMode =
         remember(playbackMode, uiConfig) {
@@ -135,20 +134,7 @@ fun PlaybackPage(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(Color.Transparent)
-                    .onPreviewKeyEvent { event ->
-                        if (event.type == KeyEventType.KeyDown) {
-                            when (event.nativeKeyEvent.keyCode) {
-                                KeyEvent.KEYCODE_MENU -> {
-                                    playbackViewModel.onDetailsClick()
-                                    true
-                                }
-                                else -> false
-                            }
-                        } else {
-                            false
-                        }
-                    },
+                    .background(Color.Transparent),
             controlsEnabled = true,
             startPosition = startPosition,
             onClickPlaylistItem = null,

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/pages/PlaybackPage.kt
@@ -69,6 +69,7 @@ fun PlaybackPage(
     OneTimeLaunchedEffect { viewModel.init(server, sceneId) }
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
+    val playbackViewModel: PlaybackPageViewModel = viewModel()
 
     val playbackMode =
         remember(playbackMode, uiConfig) {
@@ -134,7 +135,20 @@ fun PlaybackPage(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(Color.Transparent),
+                    .background(Color.Transparent)
+                    .onPreviewKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown) {
+                            when (event.nativeKeyEvent.keyCode) {
+                                KeyEvent.KEYCODE_MENU -> {
+                                    playbackViewModel.onDetailsClick()
+                                    true
+                                }
+                                else -> false
+                            }
+                        } else {
+                            false
+                        }
+                    },
             controlsEnabled = true,
             startPosition = startPosition,
             onClickPlaylistItem = null,


### PR DESCRIPTION
Resolves #776

The menu button (to the right of the Home in Firestick and similar handles) will open the details page, to quickly change the rating while watching a scene.