### PR TITLE
Add the ability to repeat a single video in a playlist

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/playback/PlaybackFragment.kt
@@ -517,6 +517,23 @@ abstract class PlaybackFragment(
                             val fragment = this@PlaybackFragment as PlaylistFragment<*, *, *>
                             fragment.showPlaylist()
                         }
+
+                        val repeatLabel =
+                            if (player?.repeatMode == Player.REPEAT_MODE_ONE) {
+                                "Stop Repeating Video"
+                            } else {
+                                "Repeat Current Video"
+                            }
+                        add(repeatLabel)
+                        callbacks[size - 1] = {
+                            player?.let { p ->
+                                if (p.repeatMode == Player.REPEAT_MODE_ONE) {
+                                    p.repeatMode = Player.REPEAT_MODE_OFF
+                                } else {
+                                    p.repeatMode = Player.REPEAT_MODE_ONE
+                                }
+                            }
+                        }
                     }
 
                     if (optionsButtonOptions.dataType == DataType.SCENE &&

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackControls.kt
@@ -106,6 +106,8 @@ sealed interface PlaybackAction {
     data class Scale(
         val scale: ContentScale,
     ) : PlaybackAction
+
+    data object ToggleRepeatOne : PlaybackAction
 }
 
 @OptIn(UnstableApi::class)
@@ -132,6 +134,8 @@ fun PlaybackControls(
     scale: ContentScale,
     seekBarIntervals: Int,
     modifier: Modifier = Modifier,
+    isPlaylist: Boolean = false,
+    repeatOneEnabled: Boolean = false,
     initialFocusRequester: FocusRequester = remember { FocusRequester() },
     seekBarInteractionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
@@ -197,6 +201,9 @@ fun PlaybackControls(
                 previousEnabled = previousEnabled,
                 nextEnabled = nextEnabled,
                 modifier = Modifier,
+                isPlaylist = isPlaylist,
+                repeatOneEnabled = repeatOneEnabled,
+                onToggleRepeatOne = { onPlaybackActionClick(PlaybackAction.ToggleRepeatOne) },
             )
             RightPlaybackButtons(
                 modifier = Modifier,
@@ -504,6 +511,9 @@ fun PlaybackButtons(
     previousEnabled: Boolean,
     nextEnabled: Boolean,
     modifier: Modifier = Modifier,
+    isPlaylist: Boolean = false,
+    repeatOneEnabled: Boolean = false,
+    onToggleRepeatOne: () -> Unit = {},
 ) {
     Row(
         modifier = modifier.focusGroup(),
@@ -552,6 +562,16 @@ fun PlaybackButtons(
             enabled = nextEnabled,
             onControllerInteraction = onControllerInteraction,
         )
+        if (isPlaylist) {
+            PlaybackButton(
+                iconRes = if (repeatOneEnabled) R.drawable.baseline_repeat_one_24 else R.drawable.baseline_repeat_24,
+                onClick = {
+                    onControllerInteraction.invoke()
+                    onToggleRepeatOne()
+                },
+                onControllerInteraction = onControllerInteraction,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackOverlay.kt
@@ -168,6 +168,7 @@ fun PlaybackOverlay(
     audioDecoder: String?,
     spriteData: List<SpriteData>,
     modifier: Modifier = Modifier,
+    repeatOneEnabled: Boolean = false,
     seekPreviewPlaceholder: Painter? = null,
     seekBarInteractionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
@@ -335,6 +336,8 @@ fun PlaybackOverlay(
                     scale = scale,
                     seekBarIntervals = uiConfig.preferences.playbackPreferences.seekBarSteps,
                     sfwMode = uiConfig.sfwMode,
+                    isPlaylist = playlistInfo != null,
+                    repeatOneEnabled = repeatOneEnabled,
                 )
             }
             if (markers.isNotEmpty()) {

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/playback/PlaybackPageContent.kt
@@ -505,6 +505,7 @@ fun PlaybackPageContent(
     var showPlaylist by remember { mutableStateOf(false) }
     var contentScale by remember { mutableStateOf(ContentScale.Fit) }
     var playbackSpeed by remember { mutableFloatStateOf(1.0f) }
+    var repeatOneEnabled by remember { mutableStateOf(false) }
     LaunchedEffect(playbackSpeed) { player.setPlaybackSpeed(playbackSpeed) }
 
     val presentationState = rememberPresentationState(player)
@@ -944,6 +945,12 @@ fun PlaybackPageContent(
                             PlaybackAction.ShowSceneDetails -> {
                                 showSceneDetails = true
                             }
+
+                            PlaybackAction.ToggleRepeatOne -> {
+                                repeatOneEnabled = !repeatOneEnabled
+                                player.repeatMode =
+                                    if (repeatOneEnabled) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
+                            }
                         }
                     },
                     onSeekBarChange = seekBarState::onValueChange,
@@ -985,6 +992,7 @@ fun PlaybackPageContent(
                     videoDecoder = videoDecoder,
                     audioDecoder = audioDecoder,
                     spriteData = spriteImageLoaded,
+                    repeatOneEnabled = repeatOneEnabled,
                 )
             }
         }

--- a/app/src/main/res/drawable/baseline_repeat_24.xml
+++ b/app/src/main/res/drawable/baseline_repeat_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M7,7h10v3l4,-4 -4,-4v3L5,5v6h2L7,7zM17,17L7,17v-3l-4,4 4,4v-3h12v-6h-2v4z"/>
+</vector>

--- a/app/src/main/res/drawable/baseline_repeat_one_24.xml
+++ b/app/src/main/res/drawable/baseline_repeat_one_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M7,7h10v3l4,-4 -4,-4v3L5,5v6h2L7,7zM17,17L7,17v-3l-4,4 4,4v-3h12v-6h-2v4zM13,15L13,9h-1l-2,1v1h1.5v4z"/>
+</vector>


### PR DESCRIPTION
For #766, this PR adds a "repeat current video" toggle to the player controls when playing a playlist.

### Notes
 - When playing a single video, no repeat button is shown as the repeat behavior is controlled by the existing setting in preferences.
 - When playing a playlist, a repeat button appears in the player controls. Tapping it loops the current video indefinitely, and tapping again resumes normal playlist progression.

### Demo

Apologies that the demo is very clunky. My CCwGTV is already slow, and the debug version of the app runs even slower, and then I'm trying to capture video over adb. 😆

https://github.com/user-attachments/assets/6c7af818-fa33-42dd-a491-5f718977fd5b