### PR TITLE
Fix showing more than 50 sub or containing groups

### DIFF
--- a/app/src/main/graphql/FindGroups.graphql
+++ b/app/src/main/graphql/FindGroups.graphql
@@ -44,7 +44,7 @@ query CountGroupRelationships($filter: FindFilterType, $group_filter: GroupFilte
 query FindGroupRelationships($filter: FindFilterType, $group_filter: GroupFilterType, $ids: [ID!]) {
   findGroups(filter: $filter, group_filter: $group_filter, ids: $ids) {
     groups {
-      id
+        ...GroupData
       sub_groups {
         ...GroupDescriptionData
       }

--- a/app/src/main/java/com/github/damontecres/stashapp/api/fragment/GroupRelationshipData.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/api/fragment/GroupRelationshipData.kt
@@ -12,10 +12,3 @@ data class GroupRelationshipData(
 ) : StashData {
     override val id: String = group.id
 }
-
-fun GroupDescriptionData.toRelationship(type: GroupRelationshipType): GroupRelationshipData =
-    GroupRelationshipData(
-        group.groupData,
-        type,
-        description,
-    )

--- a/app/src/main/java/com/github/damontecres/stashapp/suppliers/GroupRelationshipDataSupplier.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/suppliers/GroupRelationshipDataSupplier.kt
@@ -1,12 +1,17 @@
 package com.github.damontecres.stashapp.suppliers
 
+import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.api.Query
 import com.github.damontecres.stashapp.api.CountGroupRelationshipsQuery
 import com.github.damontecres.stashapp.api.FindGroupRelationshipsQuery
+import com.github.damontecres.stashapp.api.fragment.GroupData
+import com.github.damontecres.stashapp.api.fragment.GroupDescriptionData
 import com.github.damontecres.stashapp.api.fragment.GroupRelationshipData
 import com.github.damontecres.stashapp.api.fragment.GroupRelationshipType
-import com.github.damontecres.stashapp.api.fragment.toRelationship
+import com.github.damontecres.stashapp.api.type.CriterionModifier
 import com.github.damontecres.stashapp.api.type.FindFilterType
+import com.github.damontecres.stashapp.api.type.GroupFilterType
+import com.github.damontecres.stashapp.api.type.HierarchicalMultiCriterionInput
 import com.github.damontecres.stashapp.data.DataType
 
 class GroupRelationshipDataSupplier(
@@ -16,11 +21,43 @@ class GroupRelationshipDataSupplier(
     override val dataType: DataType get() = DataType.GROUP
 
     override fun createQuery(filter: FindFilterType?): Query<FindGroupRelationshipsQuery.Data> =
-        FindGroupRelationshipsQuery(
-            filter = filter,
-            group_filter = null,
-            ids = listOf(groupId),
-        )
+        when (type) {
+            GroupRelationshipType.CONTAINING -> {
+                FindGroupRelationshipsQuery(
+                    filter = filter,
+                    group_filter =
+                        GroupFilterType(
+                            sub_groups =
+                                Optional.present(
+                                    HierarchicalMultiCriterionInput(
+                                        value = Optional.present(listOf(groupId)),
+                                        modifier = CriterionModifier.INCLUDES,
+                                        depth = Optional.present(1),
+                                    ),
+                                ),
+                        ),
+                    ids = null,
+                )
+            }
+
+            GroupRelationshipType.SUB -> {
+                FindGroupRelationshipsQuery(
+                    filter = filter,
+                    group_filter =
+                        GroupFilterType(
+                            containing_groups =
+                                Optional.present(
+                                    HierarchicalMultiCriterionInput(
+                                        value = Optional.present(listOf(groupId)),
+                                        modifier = CriterionModifier.INCLUDES,
+                                        depth = Optional.present(1),
+                                    ),
+                                ),
+                        ),
+                    ids = null,
+                )
+            }
+        }
 
     override fun getDefaultFilter(): FindFilterType = DataType.GROUP.asDefaultFindFilterType
 
@@ -45,23 +82,31 @@ class GroupRelationshipDataSupplier(
 
     override fun parseQuery(data: FindGroupRelationshipsQuery.Data): List<GroupRelationshipData> =
         data.findGroups.groups
-            .map {
+            .mapNotNull { group ->
                 when (type) {
-                    GroupRelationshipType.SUB -> {
-                        it.sub_groups.map { subGroup ->
-                            subGroup.groupDescriptionData.toRelationship(
-                                type,
-                            )
-                        }
+                    GroupRelationshipType.CONTAINING -> {
+                        group.sub_groups
+                            .firstOrNull { it.groupDescriptionData.group.groupData.id == groupId }
+                            ?.groupDescriptionData
+                            ?.let { toRelationship(group.groupData, it) }
                     }
 
-                    GroupRelationshipType.CONTAINING -> {
-                        it.containing_groups.map { containingGroup ->
-                            containingGroup.groupDescriptionData.toRelationship(
-                                type,
-                            )
-                        }
+                    GroupRelationshipType.SUB -> {
+                        group.containing_groups
+                            .firstOrNull { it.groupDescriptionData.group.groupData.id == groupId }
+                            ?.groupDescriptionData
+                            ?.let { toRelationship(group.groupData, it) }
                     }
                 }
-            }.flatten()
+            }
+
+    private fun toRelationship(
+        group: GroupData,
+        groupDescriptionData: GroupDescriptionData,
+    ): GroupRelationshipData =
+        GroupRelationshipData(
+            group,
+            type,
+            groupDescriptionData.description,
+        )
 }


### PR DESCRIPTION
Fixes #781

Restructures the sub & containing group queries so that the paging is applied properly instead of reusing the first page (50) continuously.