### PR TITLE
Apply overscan padding to compose NavDrawer

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/ui/nav/NavDrawer.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/nav/NavDrawer.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -94,6 +95,8 @@ fun NavDrawer(
     NavigationDrawer(
         modifier =
             modifier
+                .background(MaterialTheme.colorScheme.background)
+                .padding(horizontal = 24.dp, vertical = 16.dp)
                 .focusRequester(drawerFocusRequester),
         drawerState = drawerState,
         drawerContent = {


### PR DESCRIPTION
I noticed that the nav icons are being cut off on my older TV. This is caused by a phenomenon called overscan, which is very common on older TVs (like older Samsung and Sony models). Overscan refers to the TV stretching the picture by 2-5% beyond the physical edges of the display to hide edge artifacts. Because the main Compose interface (`NavigationDrawer`) was rendering its layout directly against the edge of the device screen without an inset, the UI elements closest to the boundaries (like the navigation icons on the far left) are getting physically cut off by the television bezel.

The fix was simple enough. I added a protective "safe drawing margin" around the core Android TV interface for the app.
  
 - I modified the NavDrawer.kt root Compose modifier.
 - I set a 24.dp horizontal padding and a 16.dp vertical padding around the NavigationDrawer.
 - To prevent the padding from showing a transparent void to the activity root, I explicitly bound the
     MaterialTheme.colorScheme.background before the padding applies so that it seamlessly connects visually to the edges.
 - Video playback remains unaffected and will continue to take up the full physical screen edge-to-edge, as it
     conditionally bypasses this wrapper component.