### PR TITLE
export StashDreamService for Android screensaver binding

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,7 @@
 
         <service
             android:name=".util.StashDreamService"
-            android:exported="false"
+            android:exported="true"
             android:label="@string/app_name"
             android:permission="android.permission.BIND_DREAM_SERVICE">
             <intent-filter>


### PR DESCRIPTION
A fix for the Dream Service, which needs to be exported. 

https://developer.android.com/reference/android/service/dreams/DreamService