### PR TITLE
Fix parsing dates for server v0.31+

### DIFF
--- a/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerInScenePresenter.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/presenters/PerformerInScenePresenter.kt
@@ -3,9 +3,7 @@ package com.github.damontecres.stashapp.presenters
 import android.os.Build
 import com.github.damontecres.stashapp.R
 import com.github.damontecres.stashapp.api.fragment.PerformerData
-import java.time.LocalDate
-import java.time.Period
-import java.time.format.DateTimeFormatter
+import com.github.damontecres.stashapp.util.yearsBetween
 
 /**
  * A [PerformerPresenter] which will use the age of a [PerformerData] at specified date for the content text
@@ -23,11 +21,7 @@ class PerformerInScenePresenter(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val ageInScene =
                 if (item.birthdate != null && date != null) {
-                    Period
-                        .between(
-                            LocalDate.parse(item.birthdate, DateTimeFormatter.ISO_LOCAL_DATE),
-                            LocalDate.parse(date, DateTimeFormatter.ISO_LOCAL_DATE),
-                        ).years
+                    yearsBetween(item.birthdate, date)
                 } else {
                     null
                 }

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/cards/PerformerCard.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/cards/PerformerCard.kt
@@ -27,9 +27,7 @@ import com.github.damontecres.stashapp.ui.components.LongClicker
 import com.github.damontecres.stashapp.ui.enableMarquee
 import com.github.damontecres.stashapp.util.ageInYears
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
-import java.time.LocalDate
-import java.time.Period
-import java.time.format.DateTimeFormatter
+import com.github.damontecres.stashapp.util.yearsBetween
 import java.util.EnumMap
 
 private const val TAG = "PerformerCard"
@@ -76,17 +74,13 @@ fun PerformerCard(
             ) {
                 val ctx = LocalContext.current
                 try {
-                    val ageInScene =
-                        Period
-                            .between(
-                                LocalDate.parse(item.birthdate, DateTimeFormatter.ISO_LOCAL_DATE),
-                                LocalDate.parse(ageOnDate, DateTimeFormatter.ISO_LOCAL_DATE),
-                            ).years
-                    ctx.getString(
-                        R.string.stashapp_media_info_performer_card_age_context,
-                        ageInScene.toString(),
-                        ctx.getString(R.string.stashapp_years_old),
-                    )
+                    yearsBetween(item.birthdate, ageOnDate)?.let {
+                        ctx.getString(
+                            R.string.stashapp_media_info_performer_card_age_context,
+                            it.toString(),
+                            ctx.getString(R.string.stashapp_years_old),
+                        )
+                    }
                 } catch (ex: Exception) {
                     Log.w(TAG, "Exception calculating age", ex)
                     item.birthdate

--- a/app/src/main/java/com/github/damontecres/stashapp/ui/components/main/MainPagePerformerDetails.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/ui/components/main/MainPagePerformerDetails.kt
@@ -30,9 +30,7 @@ import com.github.damontecres.stashapp.ui.components.Rating100
 import com.github.damontecres.stashapp.ui.components.TitleValueText
 import com.github.damontecres.stashapp.util.isNotNullOrBlank
 import com.github.damontecres.stashapp.util.listOfNotNullOrBlank
-import java.time.LocalDate
-import java.time.Period
-import java.time.format.DateTimeFormatter
+import com.github.damontecres.stashapp.util.yearsBetween
 import kotlin.math.floor
 import kotlin.math.round
 import kotlin.math.roundToInt
@@ -103,19 +101,7 @@ fun MainPagePerformerDetails(
             }
             val ageString =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && perf.birthdate.isNotNullOrBlank()) {
-                    val date =
-                        perf.death_date?.let {
-                            LocalDate.parse(
-                                perf.death_date,
-                                DateTimeFormatter.ISO_LOCAL_DATE,
-                            )
-                        } ?: LocalDate.now()
-                    val age =
-                        Period
-                            .between(
-                                LocalDate.parse(perf.birthdate, DateTimeFormatter.ISO_LOCAL_DATE),
-                                date,
-                            ).years
+                    val age = yearsBetween(perf.birthdate, perf.death_date)
                     age.toString() + " " + stringResource(R.string.stashapp_years_old)
                 } else {
                     null

--- a/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/stashapp/util/Constants.kt
@@ -78,7 +78,9 @@ import java.net.ConnectException
 import java.net.UnknownHostException
 import java.time.LocalDate
 import java.time.Period
+import java.time.YearMonth
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import java.util.Locale
 import javax.net.ssl.SSLHandshakeException
 import kotlin.contracts.ExperimentalContracts
@@ -555,25 +557,58 @@ val FullSceneData.asMinimalSceneData: MinimalSceneData
 val TagData.asSlimTagData: SlimTagData
     get() = SlimTagData(id, name)
 
+fun parseDate(
+    dateStr: String,
+    defaultToFirst: Boolean,
+): LocalDate? =
+    try {
+        LocalDate.parse(dateStr, DateTimeFormatter.ISO_LOCAL_DATE)
+    } catch (_: DateTimeParseException) {
+        val year = dateStr.toIntOrNull()
+        if (year != null) {
+            // Just a year
+            if (defaultToFirst) {
+                LocalDate.of(year, 1, 1)
+            } else {
+                LocalDate.of(year, 12, 31)
+            }
+        } else {
+            try {
+                // Maybe year-month
+                val split = dateStr.split("-")
+                val year = split.getOrNull(0)?.toIntOrNull()
+                val month = split.getOrNull(1)?.toIntOrNull()
+                if (year != null && month != null) {
+                    if (defaultToFirst) {
+                        LocalDate.of(year, month, 1)
+                    } else {
+                        YearMonth.of(year, month).atEndOfMonth()
+                    }
+                } else {
+                    null
+                }
+            } catch (_: DateTimeParseException) {
+                null
+            }
+        }
+    }
+
 val PerformerData.ageInYears: Int?
     @RequiresApi(Build.VERSION_CODES.O)
-    get() =
-        if (birthdate != null) {
-            Period
-                .between(
-                    LocalDate.parse(birthdate, DateTimeFormatter.ISO_LOCAL_DATE),
-                    if (death_date.isNotNullOrBlank()) {
-                        LocalDate.parse(
-                            death_date,
-                            DateTimeFormatter.ISO_LOCAL_DATE,
-                        )
-                    } else {
-                        LocalDate.now()
-                    },
-                ).years
-        } else {
-            null
-        }
+    get() = yearsBetween(birthdate, death_date)
+
+fun yearsBetween(
+    start: String?,
+    end: String?,
+): Int? {
+    val startDate = start?.let { parseDate(start, true) }
+    return if (startDate != null) {
+        val endDate = end?.let { parseDate(end, false) } ?: LocalDate.now()
+        Period.between(startDate, endDate).years
+    } else {
+        null
+    }
+}
 
 val GalleryData.name: String?
     get() =


### PR DESCRIPTION
Fixes #785 

Stash server `v0.31` allows dates to be just year or year-month instead of requiring year-month-day. Since this app assumed the year-month-day format when parsing it could crash on the newer server.

This PR updates the parsing code to handle the new format.